### PR TITLE
use property-decorators for no-member

### DIFF
--- a/doc/data/messages/i/invalid-name/details.rst
+++ b/doc/data/messages/i/invalid-name/details.rst
@@ -186,7 +186,7 @@ Name Hints
 
 
 Property Decorators
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 If your code triggers a false positive instance of ``invalid-name`` when a property class or function
 decorator is used, you can register the property decorator as in the following example in sample.py::

--- a/doc/data/messages/i/invalid-name/details.rst
+++ b/doc/data/messages/i/invalid-name/details.rst
@@ -40,7 +40,7 @@ Pylint provides set of predefined naming styles. Those predefined
 naming styles may be used to adjust Pylint configuration to coding
 style used in linted project.
 
-Following predefined naming styles are available:
+The following predefined naming styles are available:
 
 * ``snake_case``
 * ``camelCase``
@@ -48,7 +48,7 @@ Following predefined naming styles are available:
 * ``UPPER_CASE``
 * ``any`` - fake style which does not enforce any limitations
 
-Following options are exposed:
+The following options are exposed:
 
 .. option:: --module-naming-style=<style>
 
@@ -71,6 +71,8 @@ Following options are exposed:
 .. option:: --class-const-naming-style=<style>
 
 .. option:: --inlinevar-naming-style=<style>
+
+.. option:: --property-classes=<property1:property2:...,...>
 
 Predefined Naming Patterns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -181,3 +183,23 @@ Name Hints
    Include a hint (regular expression used) for the correct name format with every ``invalid-name`` warning.
 
 .. _PEP8: https://peps.python.org/pep-0008
+
+
+Property Decorators
+~~~~~~~~~~
+
+If your code triggers a false positive instance of ``invalid-name`` when a property class or function
+decorator is used, you can register the property decorator as in the following example in sample.py::
+
+   def custom_property(f):
+      return property(f)
+
+   class FooClass:
+      @custom_property
+      def QUX(self):
+          pass
+
+
+Then run with::
+
+   pylint --property-classes='sample.custom_property' sample.py

--- a/doc/data/messages/n/no-member/details.rst
+++ b/doc/data/messages/n/no-member/details.rst
@@ -2,9 +2,10 @@ If you are getting the dreaded ``no-member`` error, there is a possibility that
 either:
 
 - pylint found a bug in your code
-- You're launching pylint without the dependencies installed in its environment
+- you're launching pylint without the dependencies installed in its environment
 - pylint would need to lint a C extension module and is refraining to do so
 - pylint does not understand dynamically generated code
+- your code uses a property decorator that pylint does not understand
 
 Linting C extension modules is not supported out of the box, especially since
 pylint has no way to get an AST object out of the extension module.
@@ -35,3 +36,22 @@ with the ``generated-members`` option. For example if ``cv2.LINE_AA`` and
 ``sphinx.generated_member`` create false positives for ``no-member``, you can do::
 
    $ pylint --generated-member=cv2.LINE_AA,sphinx.generated_member
+
+
+If your code uses property class/function decorators, you can specify these properties
+with the ``property-classes`` option as in the following example::
+
+    class custom_property:
+        def __init__(self):
+            self.value = 5
+
+    class my_class:
+        @custom_property
+        def my_property(self):
+            pass
+
+    print(my_class().my_property.value)
+
+Then run with::
+
+   pylint --property-classes='sample.custom_property' sample.py

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -167,6 +167,13 @@ Standard Checkers
 **Default:**  ``True``
 
 
+--property-classes
+""""""""""""""""""
+*List of decorators that produce properties, such as abc.abstractproperty. Add to this list to register other decorators that produce valid properties. *
+
+**Default:**  ``('abc.abstractproperty',)``
+
+
 --py-version
 """"""""""""
 *Minimum Python version to use for version dependent checks. Will default to the version used to run pylint.*
@@ -270,6 +277,8 @@ Standard Checkers
    # output-format =
 
    persistent = true
+
+   property-classes = ["abc.abstractproperty"]
 
    py-version = [3, 10]
 
@@ -490,13 +499,6 @@ Standard Checkers
 **Default:**  ``re.compile('^_')``
 
 
---property-classes
-""""""""""""""""""
-*List of decorators that produce properties, such as abc.abstractproperty. Add to this list to register other decorators that produce valid properties. These decorators are taken in consideration only for invalid-name.*
-
-**Default:**  ``('abc.abstractproperty',)``
-
-
 --typevar-rgx
 """""""""""""
 *Regular expression matching correct type variable names. If left empty, type variable names will be checked with the set naming style.*
@@ -584,8 +586,6 @@ Standard Checkers
    name-group = []
 
    no-docstring-rgx = "^_"
-
-   property-classes = ["abc.abstractproperty"]
 
    # typevar-rgx =
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -171,7 +171,7 @@ Standard Checkers
 """"""""""""""""""
 *List of decorators that produce properties, such as abc.abstractproperty. Add to this list to register other decorators that produce valid properties.*
 
-**Default:**  ``('abc.abstractproperty',)``
+**Default:**  ``()``
 
 
 --py-version
@@ -278,7 +278,7 @@ Standard Checkers
 
    persistent = true
 
-   property-classes = ["abc.abstractproperty"]
+   property-classes = []
 
    py-version = [3, 10]
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -169,7 +169,7 @@ Standard Checkers
 
 --property-classes
 """"""""""""""""""
-*List of decorators that produce properties, such as abc.abstractproperty. Add to this list to register other decorators that produce valid properties. *
+*List of decorators that produce properties, such as abc.abstractproperty. Add to this list to register other decorators that produce valid properties.*
 
 **Default:**  ``('abc.abstractproperty',)``
 

--- a/doc/whatsnew/2/2.16/index.rst
+++ b/doc/whatsnew/2/2.16/index.rst
@@ -56,7 +56,6 @@ Changes requiring user actions
 
 - The ``accept-no-raise-doc`` option related to ``missing-raises-doc`` will now
   be correctly taken into account all the time.
-
   Pylint will no longer raise missing-raises-doc (W9006) when no exceptions are
   documented and accept-no-raise-doc is true (issue #7208).
   If you were expecting missing-raises-doc errors to be raised in that case,

--- a/doc/whatsnew/fragments/1127.false_positive
+++ b/doc/whatsnew/fragments/1127.false_positive
@@ -1,5 +1,0 @@
-Fix ``no-name`` false positive in cases when property decorators are used.
-
- ``--property-classes=`` can now be passed in to configure property functions or classes.
-
-Closes #1127

--- a/doc/whatsnew/fragments/1127.false_positive
+++ b/doc/whatsnew/fragments/1127.false_positive
@@ -1,0 +1,5 @@
+Fix ``no-name`` false positive in cases when property decorators are used.
+
+ ``--property-classes=`` can now be passed in to configure property functions or classes.
+
+Closes #1127

--- a/doc/whatsnew/fragments/1127.feature
+++ b/doc/whatsnew/fragments/1127.feature
@@ -1,0 +1,4 @@
+``--property-classes=`` can now be passed in to configure property functions or classes
+ for the ``no-name`` checker.
+
+Closes #1127

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -345,7 +345,6 @@ class NameChecker(_BasicChecker):
                 if utils.has_known_bases(node.parent.frame(future=True))
                 else interfaces.INFERENCE_FAILURE
             )
-        breakpoint()
         self._check_name(
             _determine_function_name_type(node, config=self.linter.config),
             node.name,

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -345,7 +345,7 @@ class NameChecker(_BasicChecker):
                 if utils.has_known_bases(node.parent.frame(future=True))
                 else interfaces.INFERENCE_FAILURE
             )
-
+        breakpoint()
         self._check_name(
             _determine_function_name_type(node, config=self.linter.config),
             node.name,

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -43,7 +43,6 @@ DEFAULT_PATTERNS = {
     )
 }
 
-BUILTIN_PROPERTY = "builtins.property"
 TYPE_VAR_QNAME = frozenset(
     (
         "typing.TypeVar",
@@ -57,22 +56,6 @@ class TypeVarVariance(Enum):
     covariant = auto()
     contravariant = auto()
     double_variant = auto()
-
-
-def _get_properties(config: argparse.Namespace) -> tuple[set[str], set[str]]:
-    """Returns a tuple of property classes and names.
-
-    Property classes are fully qualified, such as 'abc.abstractproperty' and
-    property names are the actual names, such as 'abstract_property'.
-    """
-    property_classes = {BUILTIN_PROPERTY}
-    property_names: set[str] = set()  # Not returning 'property', it has its own check.
-    if config is not None:
-        property_classes.update(config.property_classes)
-        property_names.update(
-            prop.rsplit(".", 1)[-1] for prop in config.property_classes
-        )
-    return property_classes, property_names
 
 
 def _redefines_import(node: nodes.AssignName) -> bool:
@@ -107,7 +90,7 @@ def _determine_function_name_type(
 
     :returns: One of ('function', 'method', 'attr')
     """
-    property_classes, property_names = _get_properties(config)
+    property_classes, property_names = utils.get_properties(config)
     if not node.is_method():
         return "function"
 
@@ -252,18 +235,6 @@ class NameChecker(_BasicChecker):
                 "type": "yn",
                 "metavar": "<y or n>",
                 "help": "Include a hint for the correct naming format with invalid-name.",
-            },
-        ),
-        (
-            "property-classes",
-            {
-                "default": ("abc.abstractproperty",),
-                "type": "csv",
-                "metavar": "<decorator names>",
-                "help": "List of decorators that produce properties, such as "
-                "abc.abstractproperty. Add to this list to register "
-                "other decorators that produce valid properties. "
-                "These decorators are taken in consideration only for invalid-name.",
             },
         ),
     )

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -345,6 +345,7 @@ class NameChecker(_BasicChecker):
                 if utils.has_known_bases(node.parent.frame(future=True))
                 else interfaces.INFERENCE_FAILURE
             )
+
         self._check_name(
             _determine_function_name_type(node, config=self.linter.config),
             node.name,

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2193,6 +2193,7 @@ def is_class_attr(name: str, klass: nodes.ClassDef) -> bool:
     except astroid.NotFoundError:
         return False
 
+
 def is_defined(name: str, node: nodes.NodeNG) -> bool:
     """Searches for a tree node that defines the given variable name."""
     is_defined_so_far = False

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import argparse
 import builtins
 import fnmatch
 import itertools
@@ -237,6 +238,8 @@ SINGLETON_VALUES = {True, False, None}
 TERMINATING_FUNCS_QNAMES = frozenset(
     {"_sitebuiltins.Quitter", "sys.exit", "posix._exit", "nt._exit"}
 )
+
+BUILTIN_PROPERTY = "builtins.property"
 
 
 class NoSuchArgumentError(Exception):
@@ -2294,3 +2297,19 @@ def not_condition_as_string(
         )
         msg = f"{lhs} {get_inverse_comparator(ops)} {rhs}"
     return msg
+
+
+def get_properties(config: argparse.Namespace) -> tuple[set[str], set[str]]:
+    """Returns a tuple of property classes and names.
+
+    Property classes are fully qualified, such as 'abc.abstractproperty' and
+    property names are the actual names, such as 'abstract_property'.
+    """
+    property_classes = {BUILTIN_PROPERTY}
+    property_names: set[str] = set()  # Not returning 'property', it has its own check.
+    if config is not None:
+        property_classes.update(config.property_classes)
+        property_names.update(
+            prop.rsplit(".", 1)[-1] for prop in config.property_classes
+        )
+    return property_classes, property_names

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2193,7 +2193,6 @@ def is_class_attr(name: str, klass: nodes.ClassDef) -> bool:
     except astroid.NotFoundError:
         return False
 
-
 def is_defined(name: str, node: nodes.NodeNG) -> bool:
     """Searches for a tree node that defines the given variable name."""
     is_defined_so_far = False
@@ -2303,11 +2302,9 @@ def get_properties(config: argparse.Namespace) -> tuple[set[str], set[str]]:
     Property classes are fully qualified, such as 'abc.abstractproperty' and
     property names are the actual names, such as 'abstract_property'.
     """
-    property_classes = {"builtins.property"}
+    property_classes = {"builtins.property", "abc.abstractproperty"}
     property_names: set[str] = set()  # Not returning 'property', it has its own check.
-    if config is not None:
-        property_classes.update(config.property_classes)
-        property_names.update(
-            prop.rsplit(".", 1)[-1] for prop in config.property_classes
-        )
+    property_classes.update(config.property_classes)
+    property_names.update(prop.rsplit(".", 1)[-1] for prop in config.property_classes)
+
     return property_classes, property_names

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -239,8 +239,6 @@ TERMINATING_FUNCS_QNAMES = frozenset(
     {"_sitebuiltins.Quitter", "sys.exit", "posix._exit", "nt._exit"}
 )
 
-BUILTIN_PROPERTY = "builtins.property"
-
 
 class NoSuchArgumentError(Exception):
     pass
@@ -2305,7 +2303,7 @@ def get_properties(config: argparse.Namespace) -> tuple[set[str], set[str]]:
     Property classes are fully qualified, such as 'abc.abstractproperty' and
     property names are the actual names, such as 'abstract_property'.
     """
-    property_classes = {BUILTIN_PROPERTY}
+    property_classes = {"builtins.property"}
     property_names: set[str] = set()  # Not returning 'property', it has its own check.
     if config is not None:
         property_classes.update(config.property_classes)

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -412,6 +412,17 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "Useful if running pylint in a server-like mode.",
             },
         ),
+        (
+            "property-classes",
+            {
+                "default": ("abc.abstractproperty",),
+                "type": "csv",
+                "metavar": "<decorator names>",
+                "help": "List of decorators that produce properties, such as "
+                "abc.abstractproperty. Add to this list to register "
+                "other decorators that produce valid properties. ",
+            },
+        ),
     )
 
 

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -415,7 +415,7 @@ def _make_linter_options(linter: PyLinter) -> Options:
         (
             "property-classes",
             {
-                "default": ("abc.abstractproperty",),
+                "default": (),
                 "type": "csv",
                 "metavar": "<decorator names>",
                 "help": "List of decorators that produce properties, such as "

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -420,7 +420,7 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "metavar": "<decorator names>",
                 "help": "List of decorators that produce properties, such as "
                 "abc.abstractproperty. Add to this list to register "
-                "other decorators that produce valid properties. ",
+                "other decorators that produce valid properties.",
             },
         ),
     )

--- a/tests/functional/n/no/no_member_property_decorator.py
+++ b/tests/functional/n/no/no_member_property_decorator.py
@@ -19,17 +19,17 @@ class my_class:
 print(my_class().my_property.value)
 
 
-def with_value(Cls):
-    Cls_setUp = Cls.setUp
+def with_value(klass):
+    klass_setup = klass.setup
 
-    def _setUp(self):
+    def _setup(self):
         self.value = 5
-        self.addCleanup(delattr, self, 'value')
-        Cls_setUp(self)
+        self.addcleanup(delattr, self, 'value')
+        klass_setup(self)
 
-    Cls.setUp = _setUp
+    klass.setup = _setup
 
-    return Cls
+    return klass
 
 @with_value
 class TestValue(TestCase):

--- a/tests/functional/n/no/no_member_property_decorator.py
+++ b/tests/functional/n/no/no_member_property_decorator.py
@@ -1,0 +1,38 @@
+"""Tests for no-member on decorated properties.
+
+https://github.com/PyCQA/pylint/issues/1127
+"""
+# pylint: disable=missing-function-docstring, too-few-public-methods, invalid-name
+# pylint: disable=deprecated-module, missing-class-docstring
+
+from unittest import TestCase
+
+class prop:
+    def __init__(self):
+        self.value = 5
+
+class my_class:
+    @prop
+    def my_property(self):
+        pass
+
+print(my_class().my_property.value)
+
+
+def with_value(Cls):
+    Cls_setUp = Cls.setUp
+
+    def _setUp(self):
+        self.value = 5
+        self.addCleanup(delattr, self, 'value')
+        Cls_setUp(self)
+
+    Cls.setUp = _setUp
+
+    return Cls
+
+@with_value
+class TestValue(TestCase):
+    def test_value(self):
+        value = self.value
+        self.assertEqual(value, 5)

--- a/tests/functional/n/no/no_member_property_decorator.rc
+++ b/tests/functional/n/no/no_member_property_decorator.rc
@@ -1,0 +1,3 @@
+[BASIC]
+property-classes=functional.n.no.no_member_property_decorator.prop,
+                 functional.n.no.no_member_property_decorator.with_value,


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

`--property-classes=...` can now be configured to fix `no-member` FP.

Closes #1127
