### PR TITLE
Declare function mutators with inline comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ build-stamp
 .pytest_cache/
 .mypy_cache/
 .benchmarks/
-venv

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build-stamp
 .pytest_cache/
 .mypy_cache/
 .benchmarks/
+venv

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -382,9 +382,10 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "a custom __getitem__ method.",
     ),
     "E1145": (
-        "",
-        "decorator-preserves-signature",
-        "Ignore invalid argument errors on calls to this function",
+        "Decorator does not preserve function signature",
+        "signature-mutator",
+        "Emitted when a decorator does not preserve the signature "
+        "of the functions is takes as inputs.",
     ),
     "W1113": (
         "Keyword argument before variable positional arguments list "

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -240,6 +240,17 @@ def other_mutation_decorator(fun):
     return wrapper
 
 
+def yet_another_mutation_decorator(fun):  # pylint: disable=decorator-preserves-signature
+    """Yet another decorator that changes a function's signature"""
+    def wrapper(*args, do_something=True, **kwargs):
+        if do_something:
+            return fun(*args, **kwargs)
+
+        return None
+
+    return wrapper
+
+
 @mutation_decorator
 def mutated_function(arg):
     return arg
@@ -250,11 +261,17 @@ def mutated(arg):
     return arg
 
 
+@yet_another_mutation_decorator
+def another_mutated_function(arg):
+    return arg
+
+
 mutated_function(do_something=False)
 mutated_function()
 
 mutated(do_something=True)
 
+another_mutated_function(do_something=False)
 
 def func(one, two, three):
     return one + two + three

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -240,7 +240,7 @@ def other_mutation_decorator(fun):
     return wrapper
 
 
-def yet_another_mutation_decorator(fun):  # pylint: disable=decorator-preserves-signature
+def yet_another_mutation_decorator(fun):  # pylint: disable=signature-mutator
     """Yet another decorator that changes a function's signature"""
     def wrapper(*args, do_something=True, **kwargs):
         if do_something:


### PR DESCRIPTION
_Preface: There may be a better way to do this, but this is my first contribution and I'm unfamiliar with the code base. I'm mostly hoping this can be a starting point for discussion on how this should actually be achieved. I'll update docs if/when this approach is given the go-ahead._

This addresses [this comment](https://github.com/PyCQA/pylint/pull/2926#issuecomment-747463194) requesting a way to mark decorators that mutate function signatures via a comment. This is vital for package authors since, if they create a mutative decorator, all their users would have to manually populate their `function_mutators` config.

I was able to allow mutative decorators to be marked with inline comments by creating an "error" called `decorator-preserves-signature` which, when disabled via a comment on a decorator definition, will disable function argument checks on calls to functions that have that decorator. I used an error to do this in order to consume the inline comment state via the `linter.file_state._supression_mapping`.

So for example, all functions decorated with the following decorator would not have their arguments checked

```python
def mutative_decorator(fun):  # pylint: disable=signature-mutator
    """Yet another decorator that changes a function's signature"""
    def wrapper(*args, do_something=None, **kwargs):
        if do_something:
            return fun(*args, **kwargs)

        return None

    return wrapper

@mutative_decorator
def my_func(): pass

my_func(do_something='a-thing')  # OK
```

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Write a good description on what the PR does.
- [ ] Create a news fragment with `towncrier create <IssueNumber>.<type>` which will be
  included in the changelog. `<type>` can be one of: breaking, user_action, feature,
  new_check, removed_check, extension, false_positive, false_negative, bugfix, other, internal.
  If necessary you can write details or offer examples on how the new change is supposed to work.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|   maybe    | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|       | :hammer: Refactoring   |
|       | :scroll: Docs          |

## Description

Refs https://github.com/PyCQA/pylint/pull/2926#issuecomment-747463194
Maybe closes this issue https://github.com/PyCQA/pylint/issues/5784