### PR TITLE
Fix `used-before-assignment` TYPE_CHECKING false negatives

### DIFF
--- a/doc/whatsnew/fragments/8198.bugfix
+++ b/doc/whatsnew/fragments/8198.bugfix
@@ -1,0 +1,4 @@
+Fix ``used-before-assignment`` false negative when TYPE_CHECKING imports
+are used in multiple scopes.
+
+Closes #8198

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1257,6 +1257,7 @@ class VariablesChecker(BaseChecker):
             tuple[nodes.ExceptHandler, nodes.AssignName]
         ] = []
         """This is a queue, last in first out."""
+        self._evaluated_type_checking_scopes: dict[str, list[nodes.NodeNG]] = {}
         self._postponed_evaluation_enabled = False
 
     @utils.only_required_for_messages(
@@ -1717,30 +1718,16 @@ class VariablesChecker(BaseChecker):
         if found_nodes is None:
             return (VariableVisitConsumerAction.CONTINUE, None)
         if not found_nodes:
-            if (
-                not (
-                    self._postponed_evaluation_enabled
-                    and utils.is_node_in_type_annotation_context(node)
-                )
-                and not self._is_builtin(node.name)
-                and not self._is_variable_annotation_in_function(node)
-            ):
-                confidence = (
-                    CONTROL_FLOW
-                    if node.name in current_consumer.consumed_uncertain
-                    else HIGH
-                )
-                self.add_message(
-                    "used-before-assignment",
-                    args=node.name,
-                    node=node,
-                    confidence=confidence,
-                )
+            self._report_unfound_name_definition(node, current_consumer)
             # Mark for consumption any nodes added to consumed_uncertain by
             # get_next_to_consume() because they might not have executed.
+            nodes_to_consume = current_consumer.consumed_uncertain[node.name]
+            nodes_to_consume = self._filter_type_checking_import_from_consumption(
+                node, nodes_to_consume
+            )
             return (
                 VariableVisitConsumerAction.RETURN,
-                current_consumer.consumed_uncertain[node.name],
+                nodes_to_consume,
             )
 
         self._check_late_binding_closure(node)
@@ -1905,6 +1892,61 @@ class VariablesChecker(BaseChecker):
                     return (VariableVisitConsumerAction.RETURN, found_nodes)
 
         return (VariableVisitConsumerAction.RETURN, found_nodes)
+
+    def _report_unfound_name_definition(
+        self, node: nodes.NodeNG, current_consumer: NamesConsumer
+    ) -> None:
+        """Reports used-before-assignment when all name definition nodes
+        gets filtered out by NamesConsumer.
+        """
+        if (
+            self._postponed_evaluation_enabled
+            and utils.is_node_in_type_annotation_context(node)
+        ):
+            return
+        if self._is_builtin(node.name):
+            return
+        if self._is_variable_annotation_in_function(node):
+            return
+        if (
+            node.name in self._evaluated_type_checking_scopes
+            and node.scope() in self._evaluated_type_checking_scopes[node.name]
+        ):
+            return
+
+        confidence = (
+            CONTROL_FLOW if node.name in current_consumer.consumed_uncertain else HIGH
+        )
+        self.add_message(
+            "used-before-assignment",
+            args=node.name,
+            node=node,
+            confidence=confidence,
+        )
+
+    def _filter_type_checking_import_from_consumption(
+        self, node: nodes.NodeNG, nodes_to_consume: list[nodes.NodeNG]
+    ) -> list[nodes.NodeNG]:
+        """Do not consume type checking import node as used-before-assignment
+        may invoke in different scopes.
+        """
+        type_checking_import = next(
+            (
+                n
+                for n in nodes_to_consume
+                if isinstance(n, (nodes.Import, nodes.ImportFrom))
+                and in_type_checking_block(n)
+            ),
+            None,
+        )
+        # If used-before-assignment reported for usage of type checking import
+        # keep track of its scope
+        if type_checking_import and not self._is_variable_annotation_in_function(node):
+            self._evaluated_type_checking_scopes.setdefault(node.name, []).append(
+                node.scope()
+            )
+        nodes_to_consume = [n for n in nodes_to_consume if n != type_checking_import]
+        return nodes_to_consume
 
     @utils.only_required_for_messages("no-name-in-module")
     def visit_import(self, node: nodes.Import) -> None:

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1897,7 +1897,7 @@ class VariablesChecker(BaseChecker):
         self, node: nodes.NodeNG, current_consumer: NamesConsumer
     ) -> None:
         """Reports used-before-assignment when all name definition nodes
-        gets filtered out by NamesConsumer.
+        get filtered out by NamesConsumer.
         """
         if (
             self._postponed_evaluation_enabled
@@ -1927,7 +1927,7 @@ class VariablesChecker(BaseChecker):
     def _filter_type_checking_import_from_consumption(
         self, node: nodes.NodeNG, nodes_to_consume: list[nodes.NodeNG]
     ) -> list[nodes.NodeNG]:
-        """Do not consume type checking import node as used-before-assignment
+        """Do not consume type-checking import node as used-before-assignment
         may invoke in different scopes.
         """
         type_checking_import = next(

--- a/tests/functional/u/used/used_before_assignment_scoping.py
+++ b/tests/functional/u/used/used_before_assignment_scoping.py
@@ -1,0 +1,18 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+def func_two():
+    second = datetime.now()  # [used-before-assignment]
+    return second
+
+
+def func():
+    first: datetime
+    first = datetime.now()  # [used-before-assignment]
+    second = datetime.now()
+    return first, second

--- a/tests/functional/u/used/used_before_assignment_scoping.txt
+++ b/tests/functional/u/used/used_before_assignment_scoping.txt
@@ -1,0 +1,2 @@
+used-before-assignment:10:13:10:21:func_two:Using variable 'datetime' before assignment:CONTROL_FLOW
+used-before-assignment:16:12:16:20:func:Using variable 'datetime' before assignment:CONTROL_FLOW


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

This PR addresses false negative cases for `used-before-assignment`, when imports are made within `TYPE_CHECKING` guard clauses.

The root cause of these false negatives is the consumption of `Import`, `ImportFrom` nodes within `TYPE_CHECKING` clauses. Upon consumption, subsequent usages are not evaluated by the checker.

My approach is to not consume these nodes and keep track of usage scopes, so that errors can be emitted in multiple scopes.

Feel free to discuss alternative solutions! 🙂 

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8198 
