### PR TITLE
[pyreverse] Bugfix: strip "/" at the end of the file 

### DIFF
--- a/doc/whatsnew/fragments/8504.bugfix
+++ b/doc/whatsnew/fragments/8504.bugfix
@@ -1,3 +1,3 @@
-Fix a crash in pyreverse when "/" characters are used in the output filename e.g pyreverse -o png -p name/ path/to/project
+Fix a crash in pyreverse when "/" characters are used in the output filename e.g pyreverse -o png -p name/ path/to/project.
 
 Closes #8504

--- a/doc/whatsnew/fragments/8504.bugfix
+++ b/doc/whatsnew/fragments/8504.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in pyreverse when "/" characters are used in the output filename e.g pyreverse -o png -p name/ path/to/project
+
+Closes #8504

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -41,7 +41,7 @@ class DiagramWriter:
     def write(self, diadefs: Iterable[ClassDiagram | PackageDiagram]) -> None:
         """Write files for <project> according to <diadefs>."""
         for diagram in diadefs:
-            basename = diagram.title.strip().replace(" ", "_")
+            basename = diagram.title.strip().rstrip("/").replace(" ", "_")
             file_name = f"{basename}.{self.config.output_format}"
             if os.path.exists(self.config.output_directory):
                 file_name = os.path.join(self.config.output_directory, file_name)

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -41,7 +41,7 @@ class DiagramWriter:
     def write(self, diadefs: Iterable[ClassDiagram | PackageDiagram]) -> None:
         """Write files for <project> according to <diadefs>."""
         for diagram in diadefs:
-            basename = diagram.title.strip().rstrip("/").replace(" ", "_")
+            basename = diagram.title.strip().replace("/", "_").replace(" ", "_")
             file_name = f"{basename}.{self.config.output_format}"
             if os.path.exists(self.config.output_directory):
                 file_name = os.path.join(self.config.output_directory, file_name)

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -208,7 +208,8 @@ def test_color_for_stdlib_module(default_config: PyreverseConfig) -> None:
     obj.node.qname.return_value = "collections"
     assert writer.get_shape_color(obj) == "grey"
 
-# test to check the names of the generated files are corrected when using an incorrect character like "/" in the package name
+# test to check the names of the generated files are corrected
+#  when using an incorrect character like "/" in the package name
 def test_package_name_with_slash(default_config: PyreverseConfig) -> None:
     writer = DiagramWriter(default_config)
     obj = Mock()

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -207,3 +207,17 @@ def test_color_for_stdlib_module(default_config: PyreverseConfig) -> None:
     obj.node = Mock()
     obj.node.qname.return_value = "collections"
     assert writer.get_shape_color(obj) == "grey"
+
+# test to check the names of the generated files are corrected when using an incorrect character like "/" in the package name
+def test_package_name_with_slash(default_config: PyreverseConfig) -> None:
+    writer = DiagramWriter(default_config)
+    obj = Mock()
+
+    obj.objects = []
+    obj.get_relationships.return_value = []
+    obj.title = "test/package/name/with/slash/"
+    writer.write([obj])
+
+    assert os.path.exists("test_package_name_with_slash_.dot")
+    # remove the generated file
+    os.remove("test_package_name_with_slash_.dot")

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -209,9 +209,10 @@ def test_color_for_stdlib_module(default_config: PyreverseConfig) -> None:
     assert writer.get_shape_color(obj) == "grey"
 
 
-# test to check the names of the generated files are corrected
-#  when using an incorrect character like "/" in the package name
 def test_package_name_with_slash(default_config: PyreverseConfig) -> None:
+    """Test to check the names of the generated files are corrected
+    when using an incorrect character like "/" in the package name.
+    """
     writer = DiagramWriter(default_config)
     obj = Mock()
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

When calling pyreverse with an output filename like that ends with a "/" character like

```
pyreverse -o png -p packagename/ path_to_project/
``` 

the program crashes. 

Added bugfix to strip those characters at the end of the output filename

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8504
