### PR TITLE
Release branch 2.17.2

### DIFF
--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -29,6 +29,42 @@ so we find problems before the actual release.
 
 .. towncrier release notes start
 
+What's new in Pylint 2.17.2?
+----------------------------
+Release date: 2023-04-03
+
+
+False Positives Fixed
+---------------------
+
+- ``invalid-name`` now allows for integers in ``typealias`` names:
+  - now valid: ``Good2Name``, ``GoodName2``.
+  - still invalid: ``_1BadName``.
+
+  Closes #8485 (`#8485 <https://github.com/PyCQA/pylint/issues/8485>`_)
+
+- No longer consider ``Union`` as type annotation as type alias for naming
+  checks.
+
+  Closes #8487 (`#8487 <https://github.com/PyCQA/pylint/issues/8487>`_)
+
+- ``unnecessary-lambda`` no longer warns on lambdas which use its parameters in
+  their body (other than the final arguments), e.g.
+  ``lambda foo: (bar if foo else baz)(foo)``.
+
+  Closes #8496 (`#8496 <https://github.com/PyCQA/pylint/issues/8496>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fix a crash in pyreverse when "/" characters are used in the output filename
+  e.g pyreverse -o png -p name/ path/to/project.
+
+  Closes #8504 (`#8504 <https://github.com/PyCQA/pylint/issues/8504>`_)
+
+
 What's new in Pylint 2.17.1?
 ----------------------------
 Release date: 2023-03-22

--- a/doc/whatsnew/fragments/8485.false_positive
+++ b/doc/whatsnew/fragments/8485.false_positive
@@ -1,5 +1,0 @@
-``invalid-name`` now allows for integers in ``typealias`` names:
-- now valid: ``Good2Name``, ``GoodName2``.
-- still invalid: ``_1BadName``.
-
-Closes #8485

--- a/doc/whatsnew/fragments/8487.false_positive
+++ b/doc/whatsnew/fragments/8487.false_positive
@@ -1,3 +1,0 @@
-No longer consider ``Union`` as type annotation as type alias for naming checks.
-
-Closes #8487

--- a/doc/whatsnew/fragments/8496.false_positive
+++ b/doc/whatsnew/fragments/8496.false_positive
@@ -1,5 +1,0 @@
-``unnecessary-lambda`` no longer warns on lambdas which use its parameters in
-their body (other than the final arguments), e.g.
-``lambda foo: (bar if foo else baz)(foo)``.
-
-Closes #8496

--- a/doc/whatsnew/fragments/8504.bugfix
+++ b/doc/whatsnew/fragments/8504.bugfix
@@ -1,3 +1,0 @@
-Fix a crash in pyreverse when "/" characters are used in the output filename e.g pyreverse -o png -p name/ path/to/project.
-
-Closes #8504

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "2.17.1"
+__version__ = "2.17.2"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/PyCQA/pylint"
 
 [version]
-current = "2.17.1"
+current = "2.17.2"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "2.17.1"
+version = "2.17.2"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/2/2.17/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION

False Positives Fixed
---------------------

- ``invalid-name`` now allows for integers in ``typealias`` names:
  - now valid: ``Good2Name``, ``GoodName2``.
  - still invalid: ``_1BadName``.

  Closes #8485 (`#8485 <https://github.com/PyCQA/pylint/issues/8485>`_)

- No longer consider ``Union`` as type annotation as type alias for naming
  checks.

  Closes #8487 (`#8487 <https://github.com/PyCQA/pylint/issues/8487>`_)

- ``unnecessary-lambda`` no longer warns on lambdas which use its parameters in
  their body (other than the final arguments), e.g.
  ``lambda foo: (bar if foo else baz)(foo)``.

  Closes #8496 (`#8496 <https://github.com/PyCQA/pylint/issues/8496>`_)



Other Bug Fixes
---------------

- Fix a crash in pyreverse when "/" characters are used in the output filename
  e.g pyreverse -o png -p name/ path/to/project.

  Closes #8504 (`#8504 <https://github.com/PyCQA/pylint/issues/8504>`_)
