### PR TITLE
Fix typelias `invalid-name` false positives for Union variables without assignment.

### DIFF
--- a/doc/whatsnew/fragments/8540.false_positive
+++ b/doc/whatsnew/fragments/8540.false_positive
@@ -1,0 +1,4 @@
+`Union` typed variables without assignment are no longer treated as
+`TypeAlias`.
+
+Closes #8540

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -602,10 +602,7 @@ class NameChecker(_BasicChecker):
                 # Union is a special case because it can be used as a type alias
                 # or as a type annotation. We only want to check the former.
                 assert node is not None
-                return not (
-                    isinstance(node.parent, nodes.AnnAssign)
-                    and node.parent.value is not None
-                )
+                return not isinstance(node.parent, nodes.AnnAssign)
         elif isinstance(inferred, nodes.FunctionDef):
             if inferred.qname() == "typing.TypeAlias":
                 return True

--- a/tests/functional/t/typealias_naming_style_default.py
+++ b/tests/functional/t/typealias_naming_style_default.py
@@ -26,5 +26,8 @@ _1BadName = Union[int, str]  # [invalid-name]
 ANOTHERBADNAME = Union[int, str]  # [invalid-name]
 
 # Regression tests
-# This is not a TypeAlias, and thus shouldn't flag the message
+# They are not TypeAlias, and thus shouldn't flag the message
 x: Union[str, int] = 42
+y: Union[str, int]
+# But the following, using a good TypeAlias name, is:
+GoodTypeAliasToUnion: TypeAlias = Union[str, int]

--- a/tests/functional/t/typealias_naming_style_rgx.py
+++ b/tests/functional/t/typealias_naming_style_rgx.py
@@ -3,8 +3,8 @@ from typing import TypeAlias, Union
 
 # Valid
 TypeAliasShouldBeLikeThis: TypeAlias = int
-_TypeAliasShouldBeLikeThis: Union[str, int]
+_TypeAliasShouldBeLikeThis = Union[str, int]
 
 # Invalid
 TypeAliasShouldntBeLikeThis: TypeAlias = int  # [invalid-name]
-_TypeAliasShouldntBeLikeThis: Union[str, int]  # [invalid-name]
+_TypeAliasShouldntBeLikeThis = Union[str, int]  # [invalid-name]


### PR DESCRIPTION
Those variables shouldn't be treated as TypeAlias.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Closes #8540
