### PR TITLE
Fix check unused arguments false positive bug

### DIFF
--- a/doc/whatsnew/fragments/3670.false_positive
+++ b/doc/whatsnew/fragments/3670.false_positive
@@ -1,0 +1,3 @@
+Fix `unused-argument` false positive when `__new__` does not use all the arguments of `__init__`.
+
+Closes #3670

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2593,6 +2593,16 @@ class VariablesChecker(BaseChecker):
         argnames = node.argnames()
         # Care about functions with unknown argument (builtins)
         if name in argnames:
+            if node.name == "__new__":
+                is_init_def = False
+                # Look for the `__init__` method in all the methods of the same class.
+                for n in node.parent.get_children():
+                    is_init_def = hasattr(n, "name") and (n.name == "__init__")
+                    if is_init_def:
+                        break
+                # Ignore unused arguments check for `__new__` if `__init__` is defined.
+                if is_init_def:
+                    return
             self._check_unused_arguments(name, node, stmt, argnames, nonlocal_names)
         else:
             if stmt.parent and isinstance(

--- a/tests/functional/u/unused/unused_argument.py
+++ b/tests/functional/u/unused/unused_argument.py
@@ -107,3 +107,24 @@ class Descendant(Ancestor):
     def set_thing(self, thing, *, other=None):
         """Subclass does not raise unused-argument"""
         self.thing = thing
+
+
+# Test that Class with both `__init__` and `__new__` don't check
+# on `__new__` for unused arguments
+
+# pylint: disable=invalid-name
+
+class TestClassWithInitAndNew:
+    def __init__(self, argA, argB):
+        self.argA = argA
+        self.argB = argB
+
+    def __new__(cls, argA, argB):
+        return object.__new__(cls)
+
+# Test that `__new__` method is checked for unused arguments
+# when `__init__` is not in the Class
+
+class TestClassWithOnlyNew:
+    def __new__(cls, argA, argB): # [unused-argument, unused-argument]
+        return object.__new__(cls)

--- a/tests/functional/u/unused/unused_argument.txt
+++ b/tests/functional/u/unused/unused_argument.txt
@@ -7,3 +7,5 @@ unused-argument:73:0:None:None:AAAA.selected:Unused argument 'args':INFERENCE
 unused-argument:73:0:None:None:AAAA.selected:Unused argument 'kwargs':INFERENCE
 unused-argument:92:23:92:26:BBBB.__init__:Unused argument 'arg':INFERENCE
 unused-argument:103:34:103:39:Ancestor.set_thing:Unused argument 'other':INFERENCE
+unused-argument:129:21:129:25:TestClassWithOnlyNew.__new__:Unused argument 'argA':INFERENCE
+unused-argument:129:27:129:31:TestClassWithOnlyNew.__new__:Unused argument 'argB':INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Problem: the special method `__new__` must match the arguments of the `__init__` method even if `__new__` method does not use them. This generate `unused-argument` for the `__new__` method.

Fix: the unused arguments check should not be done on the `__new__` method if the `__init__` method is defined in the same class.

Closes https://github.com/pylint-dev/pylint/issues/3670