### PR TITLE
Fix isinstance-second-argument-not-valid-type for union types with None

### DIFF
--- a/doc/whatsnew/fragments/8424.false_positive
+++ b/doc/whatsnew/fragments/8424.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for isinstance-second-argument-not-valid-type when union types contains None.
+
+Closes #8424

--- a/tests/functional/i/isinstance_second_argument_py310.py
+++ b/tests/functional/i/isinstance_second_argument_py310.py
@@ -1,13 +1,17 @@
-'''Tests for invalid isinstance with compound types'''
+"""Tests for invalid isinstance with compound types"""
 
 # True negatives
 isinstance(0, int | str)
 isinstance(0, int | int | int)
 isinstance(0, int | str | list | float)
 isinstance(0, (int | str) | (list | float))
+isinstance(0, int | None)
+isinstance(0, None | int)
 
 IntOrStr = int | str
 isinstance(0, IntOrStr)
+IntOrNone = int | None
+isinstance(0, IntOrNone)
 ListOrDict = list | dict
 isinstance(0, (float | ListOrDict) | IntOrStr)
 

--- a/tests/functional/i/isinstance_second_argument_py310.txt
+++ b/tests/functional/i/isinstance_second_argument_py310.txt
@@ -1,3 +1,3 @@
-isinstance-second-argument-not-valid-type:15:0:15:22::Second argument of isinstance is not a type:INFERENCE
-isinstance-second-argument-not-valid-type:16:0:16:28::Second argument of isinstance is not a type:INFERENCE
-isinstance-second-argument-not-valid-type:18:0:18:24::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:19:0:19:22::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:20:0:20:28::Second argument of isinstance is not a type:INFERENCE
+isinstance-second-argument-not-valid-type:22:0:22:24::Second argument of isinstance is not a type:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Fix false positive for `isinstance-second-argument-not-valid-type` when union type includes `None`, for example:

```py
isinstance(0, int | None)
```

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8424
