### PR TITLE
Fix false positive for ``positional-only-arguments-expected``

### DIFF
--- a/doc/whatsnew/fragments/8555.false_positive
+++ b/doc/whatsnew/fragments/8555.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for ``positional-only-arguments-expected`` when a function contains both a positional-only parameter that has a default value, and ``**kwargs``.
+
+Closes #8555

--- a/pylint/checkers/method_args.py
+++ b/pylint/checkers/method_args.py
@@ -111,6 +111,8 @@ class MethodArgsChecker(BaseChecker):
             and inferred_func.args.posonlyargs
         ):
             return
+        if inferred_func.args.kwarg:
+            return
         pos_args = [a.name for a in inferred_func.args.posonlyargs]
         kws = [k.arg for k in node.keywords if k.arg in pos_args]
         if not kws:

--- a/tests/functional/p/positional_only_arguments_expected.py
+++ b/tests/functional/p/positional_only_arguments_expected.py
@@ -16,3 +16,21 @@ cake.nihon(1, 2, i=3)  # [positional-only-arguments-expected]
 cake.nihon(1, r=2, i=3)  # [positional-only-arguments-expected]
 cake.nihon(a=1, r=2, i=3)  # [positional-only-arguments-expected]
 cake.nihon(1, r=2, i=3, cheese=True)  # [positional-only-arguments-expected]
+
+
+def function_with_kwargs(apple, banana="Yellow banana", /, **kwargs):
+    """
+    Calling this function with the `banana` keyword should not emit
+    `positional-only-arguments-expected` since it is added to `**kwargs`.
+
+    >>> function_with_kwargs("Red apple", banana="Green banana")
+    >>> "Red apple"
+    >>> "Yellow banana"
+    >>> {"banana": "Green banana"}
+    """
+    print(apple)
+    print(banana)
+    print(kwargs)
+
+
+function_with_kwargs("Red apple", banana="Green banana")


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->
Fix false positive for ``positional-only-arguments-expected`` when a
function contains both a positional-only parameter that has a default value, and ``**kwargs``.


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8555
