### PR TITLE
Fix false negative for `no-value-for-parameter`

### DIFF
--- a/doc/whatsnew/fragments/8559.false_negative
+++ b/doc/whatsnew/fragments/8559.false_negative
@@ -1,0 +1,3 @@
+Fix false negative for ``no-value-for-parameter`` when a function, whose signature contains both a positional-only parameter ``name`` and also ``*kwargs``, is called with a keyword-argument for ``name``.
+
+Closes #8559

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1569,6 +1569,11 @@ accessed. Python regular expressions are accepted.",
                             node=node,
                             args=(keyword, callable_name),
                         )
+                elif (
+                    keyword in [arg.name for arg in called.args.posonlyargs]
+                    and called.args.kwarg
+                ):
+                    pass
                 else:
                     parameters[i] = (parameters[i][0], True)
             elif keyword in kwparams:

--- a/tests/functional/a/arguments_positional_only.py
+++ b/tests/functional/a/arguments_positional_only.py
@@ -1,0 +1,15 @@
+"""Test `no-value-for-parameter` in the context of positional-only parameters"""
+
+# pylint: disable=missing-docstring, unused-argument
+
+
+def name1(param1, /, **kwargs): ...
+def name2(param1, /, param2, **kwargs): ...
+def name3(param1=True, /, **kwargs): ...
+def name4(param1, **kwargs): ...
+
+name1(param1=43)  # [no-value-for-parameter]
+name1(43)
+name2(1, param2=False)
+name3()
+name4(param1=43)

--- a/tests/functional/a/arguments_positional_only.rc
+++ b/tests/functional/a/arguments_positional_only.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.8

--- a/tests/functional/a/arguments_positional_only.txt
+++ b/tests/functional/a/arguments_positional_only.txt
@@ -1,0 +1,1 @@
+no-value-for-parameter:11:0:11:16::No value for argument 'param1' in function call:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fix false negative for ``no-value-for-parameter`` when a function, whose signature contains both a positional-only parameter ``name`` and also ``*kwargs``, is called with a keyword-argument for ``name``.
```python
# pylint: disable=missing-function-docstring, missing-module-docstring
def required_positional_with_var_kwargs(a, /, **_kwargs):
    return a

required_positional_with_var_kwargs(a=43)
```

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8559
