### PR TITLE
Disable Info linters in definition instead of Run class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,13 @@ repos:
             doc/data/messages/m/missing-final-newline/bad.py|
           )$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.260"
+    rev: "v0.0.261"
     hooks:
       - id: ruff
         args: ["--fix"]
         exclude: &fixtures tests(/\w*)*/functional/|tests/input|doc/data/messages|tests(/\w*)*data/
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.260"
+    rev: "v0.0.261"
     hooks:
       - id: ruff
         name: ruff-doc
@@ -91,7 +91,7 @@ repos:
         files: ^(doc/(.*/)*.*\.rst)
         additional_dependencies: [Sphinx==5.0.1]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.2.0
     hooks:
       - id: mypy
         name: mypy

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -29,6 +29,7 @@ class ByIdManagedMessagesChecker(BaseRawFileChecker):
             "%s",
             "use-symbolic-message-instead",
             "Used when a message is enabled or disabled by id.",
+            {"default_enabled": False}
         )
     }
     options = ()

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -138,26 +138,26 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "raw-checker-failed",
         "Used to inform that a built-in module has not been checked "
         "using the raw checkers.",
-        {"scope": WarningScope.LINE},
+        {"scope": WarningScope.LINE, "default_enabled": False,},
     ),
     "I0010": (
         "Unable to consider inline option %r",
         "bad-inline-option",
         "Used when an inline option is either badly formatted or can't "
         "be used inside modules.",
-        {"scope": WarningScope.LINE},
+        {"scope": WarningScope.LINE, "default_enabled": False,},
     ),
     "I0011": (
         "Locally disabling %s (%s)",
         "locally-disabled",
         "Used when an inline option disables a message or a messages category.",
-        {"scope": WarningScope.LINE},
+        {"scope": WarningScope.LINE, "default_enabled": False,},
     ),
     "I0013": (
         "Ignoring entire file",
         "file-ignored",
         "Used to inform that the file will not be checked",
-        {"scope": WarningScope.LINE},
+        {"scope": WarningScope.LINE, "default_enabled": False,},
     ),
     "I0020": (
         "Suppressed %s (from line %d)",
@@ -166,14 +166,14 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "by a disable= comment in the file. This message is not "
         "generated for messages that are ignored due to configuration "
         "settings.",
-        {"scope": WarningScope.LINE},
+        {"scope": WarningScope.LINE, "default_enabled": False,},
     ),
     "I0021": (
         "Useless suppression of %s",
         "useless-suppression",
         "Reported when a message is explicitly disabled for a line or "
         "a block of code, but never triggered.",
-        {"scope": WarningScope.LINE},
+        {"scope": WarningScope.LINE, "default_enabled": False,},
     ),
     "I0022": (
         'Pragma "%s" is deprecated, use "%s" instead',
@@ -184,6 +184,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         {
             "old_names": [("I0014", "deprecated-disable-all")],
             "scope": WarningScope.LINE,
+            "default_enabled": False,
         },
     ),
     "E0001": (

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -154,9 +154,6 @@ group are mutually exclusive.",
         # load command line plugins
         linter.load_plugin_modules(self._plugins)
 
-        linter.disable("I")
-        linter.enable("c-extension-no-member")
-
         # Register the options needed for 'pylint-config'
         # By not registering them by default they don't show up in the normal usage message
         if self._is_pylint_config:

--- a/pylint/testutils/testing_pylintrc
+++ b/pylint/testutils/testing_pylintrc
@@ -7,3 +7,7 @@ disable=
     suppressed-message,
     locally-disabled,
     useless-suppression,
+
+enable=
+    deprecated-pragma,
+    use-symbolic-message-instead,


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
|     | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

This PR refactors code in a way that it removes explicit disable of Info Messages during creation of `Run` class but instead define it in message definition. This fixes issue when Message documentation is not showing Caution Bar that message is disabled by default.
