### PR TITLE
Cope with changes to `Starred`, `AssignAttr`, and `Arguments` constructors

### DIFF
--- a/pylint/checkers/nested_min_max.py
+++ b/pylint/checkers/nested_min_max.py
@@ -10,6 +10,7 @@ import copy
 from typing import TYPE_CHECKING
 
 from astroid import nodes, objects
+from astroid.const import Context
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages, safe_infer
@@ -96,7 +97,14 @@ class NestedMinMaxChecker(BaseChecker):
                 if isinstance(
                     inferred, (nodes.List, nodes.Tuple, nodes.Set, *DICT_TYPES)
                 ):
-                    splat_node = nodes.Starred(lineno=inferred.lineno)
+                    splat_node = nodes.Starred(
+                        ctx=Context.Load,
+                        lineno=inferred.lineno,
+                        col_offset=0,
+                        parent=nodes.NodeNG(),
+                        end_lineno=0,
+                        end_col_offset=0,
+                    )
                     splat_node.value = arg
                     fixed_node.args = (
                         fixed_node.args[:idx]

--- a/tests/checkers/unittest_stdlib.py
+++ b/tests/checkers/unittest_stdlib.py
@@ -48,7 +48,14 @@ class TestStdlibChecker(CheckerTestCase):
             inner_node: nodes.Name,
             context: InferenceContext | None = None,  # pylint: disable=unused-argument
         ) -> Iterator[nodes.AssignAttr]:
-            new_node = nodes.AssignAttr(attrname="alpha", parent=inner_node)
+            new_node = nodes.AssignAttr(
+                attrname="alpha",
+                parent=inner_node,
+                lineno=0,
+                col_offset=0,
+                end_lineno=0,
+                end_col_offset=0,
+            )
             yield new_node
 
         manager = astroid.MANAGER

--- a/tests/pyreverse/test_printer.py
+++ b/tests/pyreverse/test_printer.py
@@ -41,7 +41,7 @@ def test_unsupported_layout(layout: Layout, printer_class: type[Printer]) -> Non
 
 def test_method_arguments_none() -> None:
     func = nodes.FunctionDef()
-    args = nodes.Arguments()
+    args = nodes.Arguments(vararg=None, kwarg=None, parent=func)
     args.args = None
     func.postinit(args, body=None)
     parsed_args = Printer._get_method_arguments(func)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Refs pylint-dev/astroid@c59a4a4bdcc7b3593ea93aba1b72a2b516852bb6

Shows a real-world example of inventing nodes without parents.