### PR TITLE
Improve output of `consider-using-generator` message for `min()` calls with `default` keyword

### DIFF
--- a/doc/whatsnew/fragments/8563.bugfix
+++ b/doc/whatsnew/fragments/8563.bugfix
@@ -1,0 +1,3 @@
+Improve output of ``consider-using-generator`` message for ``min()` calls with ``default`` keyword.
+
+Closes #8563

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1070,11 +1070,15 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             and isinstance(node.func, nodes.Name)
             and node.func.name in checked_call
         ):
-            # functions in checked_calls take exactly one argument
+            # functions in checked_calls take exactly one positional argument
             # check whether the argument is list comprehension
             if len(node.args) == 1 and isinstance(node.args[0], nodes.ListComp):
                 # remove square brackets '[]'
                 inside_comp = node.args[0].as_string()[1:-1]
+                if node.keywords:
+                    inside_comp = f"({inside_comp})"
+                    inside_comp += ", "
+                    inside_comp += ", ".join(kw.as_string() for kw in node.keywords)
                 call_name = node.func.name
                 if call_name in {"any", "all"}:
                     self.add_message(

--- a/tests/functional/c/consider/consider_using_generator.py
+++ b/tests/functional/c/consider/consider_using_generator.py
@@ -18,3 +18,8 @@ tuple(0 for y in list(range(10)))
 sum(x*x for x in range(10))
 min(x*x for x in range(10))
 max(x*x for x in range(10))
+
+# Keyword arguments
+# https://github.com/pylint-dev/pylint/issues/8563
+min([x*x for x in range(10)], default=42)  # [consider-using-generator]
+min((x*x for x in range(10)), default=42)

--- a/tests/functional/c/consider/consider_using_generator.txt
+++ b/tests/functional/c/consider/consider_using_generator.txt
@@ -3,3 +3,4 @@ consider-using-generator:11:0:11:35::Consider using a generator instead 'tuple(0
 consider-using-generator:12:0:12:29::Consider using a generator instead 'sum(x * x for x in range(10))':UNDEFINED
 consider-using-generator:13:0:13:29::Consider using a generator instead 'min(x * x for x in range(10))':UNDEFINED
 consider-using-generator:14:0:14:29::Consider using a generator instead 'max(x * x for x in range(10))':UNDEFINED
+consider-using-generator:24:0:24:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #8563