### PR TITLE
Minor refactor on type annotation

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1292,7 +1292,9 @@ class VariablesChecker(BaseChecker):
             tuple[nodes.ExceptHandler, nodes.AssignName]
         ] = []
         """This is a queue, last in first out."""
-        self._evaluated_type_checking_scopes: dict[str, list[nodes.LocalsDictNodeNG]] = {}
+        self._evaluated_type_checking_scopes: dict[
+            str, list[nodes.LocalsDictNodeNG]
+        ] = {}
         self._postponed_evaluation_enabled = False
 
     @utils.only_required_for_messages(

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1292,7 +1292,7 @@ class VariablesChecker(BaseChecker):
             tuple[nodes.ExceptHandler, nodes.AssignName]
         ] = []
         """This is a queue, last in first out."""
-        self._evaluated_type_checking_scopes: dict[str, list[nodes.NodeNG]] = {}
+        self._evaluated_type_checking_scopes: dict[str, list[nodes.LocalsDictNodeNG]] = {}
         self._postponed_evaluation_enabled = False
 
     @utils.only_required_for_messages(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

A small change on #8431 to update the container (of [scope nodes](https://pylint.readthedocs.io/projects/astroid/en/latest/api/base_nodes.html#astroid.nodes.NodeNG.scope)) type to `LocalsDictNodeNG` which is more specific compared to the base class `NodeNG`. 

Nothing functional is changed, apologies for any inconvenience caused!

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

