### PR TITLE
Cache `class_is_abstract()`

### DIFF
--- a/doc/whatsnew/fragments/1954.performance
+++ b/doc/whatsnew/fragments/1954.performance
@@ -1,0 +1,3 @@
+Cache `class_is_abstract()`.
+
+Refs #1954

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1130,6 +1130,7 @@ def node_ignores_exception(
     return any(get_contextlib_suppressors(node, exception))
 
 
+@lru_cache(maxsize=1024)
 def class_is_abstract(node: nodes.ClassDef) -> bool:
     """Return true if the given class node should be considered as an abstract
     class.
@@ -2191,6 +2192,7 @@ def overridden_method(
 def clear_lru_caches() -> None:
     """Clear caches holding references to AST nodes."""
     caches_holding_node_references: list[_lru_cache_wrapper[Any]] = [
+        class_is_abstract,
         in_for_else_branch,
         infer_all,
         is_overload_stub,

--- a/script/check_newsfragments.py
+++ b/script/check_newsfragments.py
@@ -34,6 +34,7 @@ VALID_FILE_TYPE = frozenset(
         "bugfix",
         "other",
         "internal",
+        "performance",
     ]
 )
 ISSUES_KEYWORDS = "|".join(VALID_ISSUES_KEYWORDS)

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -65,3 +65,8 @@ showcontent = true
 directory = "internal"
 name = "Internal Changes"
 showcontent = true
+
+[[tool.towncrier.type]]
+directory = "performance"
+name = "Performance Improvements"
+showcontent = true


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
For one project in the pylint primer (music21), provides 15% speedup _linting the entire project_. (171.6s -> 145.6s on an M1 mac running python3.11.)

I think we should batch the performance improvements in 3.0 and describe them all with a set of benchmarks at the end, so adding a skip news label.
