### PR TITLE
Fix `FunctionDef` isinstance checks

### DIFF
--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -733,7 +733,9 @@ def _no_context_variadic(
         else:
             inferred_statement = inferred.statement(future=True)
 
-        if not length and isinstance(inferred_statement, nodes.Lambda):
+        if not length and isinstance(
+            inferred_statement, (nodes.Lambda, nodes.FunctionDef)
+        ):
             is_in_starred_context = _has_parent_of_type(node, variadic_type, statement)
             used_as_starred_argument = any(
                 variadic.value == name or variadic.value.parent_of(name)

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -360,7 +360,6 @@ def is_defined_before(var_node: nodes.Name) -> bool:
             defnode_scope, (*COMP_NODE_TYPES, nodes.Lambda, nodes.FunctionDef)
         ):
             # Avoid the case where var_node_scope is a nested function
-            # FunctionDef is a Lambda until https://github.com/pylint-dev/astroid/issues/291
             if isinstance(defnode_scope, nodes.FunctionDef):
                 var_node_scope = var_node.scope()
                 if var_node_scope is not defnode_scope and isinstance(

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -356,7 +356,9 @@ def is_defined_before(var_node: nodes.Name) -> bool:
         if defnode is None:
             continue
         defnode_scope = defnode.scope()
-        if isinstance(defnode_scope, (*COMP_NODE_TYPES, nodes.Lambda)):
+        if isinstance(
+            defnode_scope, (*COMP_NODE_TYPES, nodes.Lambda, nodes.FunctionDef)
+        ):
             # Avoid the case where var_node_scope is a nested function
             # FunctionDef is a Lambda until https://github.com/pylint-dev/astroid/issues/291
             if isinstance(defnode_scope, nodes.FunctionDef):

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2500,7 +2500,7 @@ class VariablesChecker(BaseChecker):
         # FunctionDef subclasses Lambda due to a curious ontology. Check both.
         # See https://github.com/pylint-dev/astroid/issues/291
         # TODO: Revisit when astroid 3.0 includes the change
-        if isinstance(scope, nodes.Lambda) and any(
+        if isinstance(scope, (nodes.Lambda, nodes.FunctionDef)) and any(
             asmt.scope().parent_of(scope) for asmt in astmts
         ):
             return

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2497,9 +2497,6 @@ class VariablesChecker(BaseChecker):
         # the usage is safe because the function will not be defined either if
         # the variable is not defined.
         scope = node.scope()
-        # FunctionDef subclasses Lambda due to a curious ontology. Check both.
-        # See https://github.com/pylint-dev/astroid/issues/291
-        # TODO: Revisit when astroid 3.0 includes the change
         if isinstance(scope, (nodes.Lambda, nodes.FunctionDef)) and any(
             asmt.scope().parent_of(scope) for asmt in astmts
         ):


### PR DESCRIPTION
## Description
Fallout from https://github.com/pylint-dev/astroid/pull/2115 - required for the next astroid update.
Fix `isinstance` checks now that `nodes.FunctionDef` doesn't inherit from `nodes.Lambda`.

Changes are compatible with the current astroid version, so don't need to wait to fix these.