### PR TITLE
Bump pylint to 2.17.3, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -130,10 +130,10 @@ contributors:
 - Eli Fine <ejfine@gmail.com> (eli88fine): Fixed false positive duplicate code warning for lines with symbols only
 - Andrew Haigh <nelfin@gmail.com> (nelfin)
 - Émile Crater <emile@crater.logilab.fr>
+- Yilei "Dolee" Yang <yileiyang@google.com>
 - Pavel Roskin <proski@gnu.org>
 - David Gilman <davidgilman1@gmail.com>
 - へーさん <hira9603859504@gmail.com>
-- Yilei "Dolee" Yang <yileiyang@google.com>
 - Thomas Hisch <t.hisch@gmail.com>
 - Marianna Polatoglou <mpolatoglou@bloomberg.net>: minor contribution for wildcard import check
 - Manuel Vázquez Acosta <mva.led@gmail.com>
@@ -206,6 +206,7 @@ contributors:
 - chohner <mail@chohner.com>
 - Tiago Honorato <61059243+tiagohonorato@users.noreply.github.com>
 - Steven M. Vascellaro <svascellaro@gmail.com>
+- Rogdham <contact@rogdham.net>
 - Robin Tweedie <70587124+robin-wayve@users.noreply.github.com>
 - Roberto Leinardi <leinardi@gmail.com>: PyCharm plugin maintainer
 - Ricardo Gemignani <ricardo.gemignani@gmail.com>
@@ -254,7 +255,6 @@ contributors:
 - Scott Worley <scottworley@scottworley.com>
 - Saugat Pachhai <suagatchhetri@outlook.com>
 - Rémi Cardona <remi.cardona@polyconseil.fr>
-- Rogdham <contact@rogdham.net>
 - Raphael Gaschignard <raphael@makeleaps.com>
 - Ram Rachum <ram@rachum.com> (cool-RR)
 - Radostin Stoyanov <rst0git@users.noreply.github.com>

--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -29,6 +29,64 @@ so we find problems before the actual release.
 
 .. towncrier release notes start
 
+What's new in Pylint 2.17.3?
+----------------------------
+Release date: 2023-04-23
+
+
+False Positives Fixed
+---------------------
+
+- Fix `unused-argument` false positive when `__new__` does not use all the
+  arguments of `__init__`.
+
+  Closes #3670 (`#3670 <https://github.com/PyCQA/pylint/issues/3670>`_)
+
+- Fix ``unused-import`` false positive for usage of ``six.with_metaclass``.
+
+  Closes #7506 (`#7506 <https://github.com/PyCQA/pylint/issues/7506>`_)
+
+- `logging-not-lazy` is not longer emitted for explicitly concatenated string
+  arguments.
+
+  Closes #8410 (`#8410 <https://github.com/PyCQA/pylint/issues/8410>`_)
+
+- Fix false positive for isinstance-second-argument-not-valid-type when union
+  types contains None.
+
+  Closes #8424 (`#8424 <https://github.com/PyCQA/pylint/issues/8424>`_)
+
+- Fixed `unused-import` so that it observes the `dummy-variables-rgx` option.
+
+  Closes #8500 (`#8500 <https://github.com/PyCQA/pylint/issues/8500>`_)
+
+- `Union` typed variables without assignment are no longer treated as
+  `TypeAlias`.
+
+  Closes #8540 (`#8540 <https://github.com/PyCQA/pylint/issues/8540>`_)
+
+- Fix false positive for ``positional-only-arguments-expected`` when a function
+  contains both a positional-only parameter that has a default value, and
+  ``**kwargs``.
+
+  Closes #8555 (`#8555 <https://github.com/PyCQA/pylint/issues/8555>`_)
+
+- Fix false positive for ``keyword-arg-before-vararg`` when a positional-only
+  parameter with a default value precedes ``*args``.
+
+  Closes #8570 (`#8570 <https://github.com/PyCQA/pylint/issues/8570>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Improve output of ``consider-using-generator`` message for ``min()` calls
+  with ``default`` keyword.
+
+  Closes #8563 (`#8563 <https://github.com/PyCQA/pylint/issues/8563>`_)
+
+
 What's new in Pylint 2.17.2?
 ----------------------------
 Release date: 2023-04-03

--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -31,7 +31,7 @@ so we find problems before the actual release.
 
 What's new in Pylint 2.17.3?
 ----------------------------
-Release date: 2023-04-23
+Release date: 2023-04-24
 
 
 False Positives Fixed

--- a/doc/whatsnew/fragments/3670.false_positive
+++ b/doc/whatsnew/fragments/3670.false_positive
@@ -1,3 +1,0 @@
-Fix `unused-argument` false positive when `__new__` does not use all the arguments of `__init__`.
-
-Closes #3670

--- a/doc/whatsnew/fragments/7506.false_positive
+++ b/doc/whatsnew/fragments/7506.false_positive
@@ -1,3 +1,0 @@
-Fix ``unused-import`` false positive for usage of ``six.with_metaclass``.
-
-Closes #7506

--- a/doc/whatsnew/fragments/8410.false_positive
+++ b/doc/whatsnew/fragments/8410.false_positive
@@ -1,3 +1,0 @@
-`logging-not-lazy` is not longer emitted for explicitly concatenated string arguments.
-
-Closes #8410

--- a/doc/whatsnew/fragments/8424.false_positive
+++ b/doc/whatsnew/fragments/8424.false_positive
@@ -1,3 +1,0 @@
-Fix false positive for isinstance-second-argument-not-valid-type when union types contains None.
-
-Closes #8424

--- a/doc/whatsnew/fragments/8500.false_positive
+++ b/doc/whatsnew/fragments/8500.false_positive
@@ -1,3 +1,0 @@
-Fixed `unused-import` so that it observes the `dummy-variables-rgx` option.
-
-Closes #8500

--- a/doc/whatsnew/fragments/8540.false_positive
+++ b/doc/whatsnew/fragments/8540.false_positive
@@ -1,4 +1,0 @@
-`Union` typed variables without assignment are no longer treated as
-`TypeAlias`.
-
-Closes #8540

--- a/doc/whatsnew/fragments/8555.false_positive
+++ b/doc/whatsnew/fragments/8555.false_positive
@@ -1,3 +1,0 @@
-Fix false positive for ``positional-only-arguments-expected`` when a function contains both a positional-only parameter that has a default value, and ``**kwargs``.
-
-Closes #8555

--- a/doc/whatsnew/fragments/8563.bugfix
+++ b/doc/whatsnew/fragments/8563.bugfix
@@ -1,3 +1,0 @@
-Improve output of ``consider-using-generator`` message for ``min()` calls with ``default`` keyword.
-
-Closes #8563

--- a/doc/whatsnew/fragments/8570.false_positive
+++ b/doc/whatsnew/fragments/8570.false_positive
@@ -1,3 +1,0 @@
-Fix false positive for ``keyword-arg-before-vararg`` when a positional-only parameter with a default value precedes ``*args``.
-
-Closes #8570

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "2.17.2"
+__version__ = "2.17.3"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/PyCQA/pylint"
 
 [version]
-current = "2.17.2"
+current = "2.17.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "2.17.2"
+version = "2.17.3"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/2/2.17/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 2.17.3?
----------------------------
Release date: 2023-04-24


False Positives Fixed
---------------------

- Fix `unused-argument` false positive when `__new__` does not use all the
  arguments of `__init__`.

  Closes #3670 

- Fix ``unused-import`` false positive for usage of ``six.with_metaclass``.

  Closes #7506 

- `logging-not-lazy` is not longer emitted for explicitly concatenated string
  arguments.

  Closes #8410 

- Fix false positive for isinstance-second-argument-not-valid-type when union
  types contains None.

  Closes #8424 

- Fixed `unused-import` so that it observes the `dummy-variables-rgx` option.

  Closes #8500 

- `Union` typed variables without assignment are no longer treated as
  `TypeAlias`.

  Closes #8540 

- Fix false positive for ``positional-only-arguments-expected`` when a function
  contains both a positional-only parameter that has a default value, and
  ``**kwargs``.

  Closes #8555 

- Fix false positive for ``keyword-arg-before-vararg`` when a positional-only
  parameter with a default value precedes ``*args``.

  Closes #8570



Other Bug Fixes
---------------

- Improve output of ``consider-using-generator`` message for ``min()` calls
  with ``default`` keyword.

  Closes #8563