### PR TITLE
Bump astroid to 3.0.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.0.0a1,<=3.1.0-dev0",
+    "astroid>=3.0.0a2,<=3.1.0-dev0",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.0.0a1  # Pinned to a specific version for tests
+astroid==3.0.0a2  # Pinned to a specific version for tests
 typing-extensions~=4.5
 py~=1.11.0
 pytest~=7.3


### PR DESCRIPTION
Did another release. Maybe a bit early but the less breaking changes we batch, the easier these bump PRs are.

https://github.com/pylint-dev/astroid/milestone/77?closed=1
https://github.com/pylint-dev/astroid/releases/tag/v3.0.0a2