### PR TITLE
Add applicability notes for `compare-to-empty-string/zero` (#8592)

### DIFF
--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -96,9 +96,20 @@ Compare-To-Empty-String checker
 This checker is provided by ``pylint.extensions.emptystring``.
 Verbatim name of the checker is ``compare-to-empty-string``.
 
+Compare-To-Empty-String checker Documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can use this plugin for finding patterns such as ``a == ''`` and ``a != ''`` in your code base.
+It is usually possible to replace ``a == ''`` with a Pythonic expression of ``not a``
+and replace ``a != ''`` with ``a``, if the variable ``a`` is strictly a ``str``.
+
+Note that this replacement is not always safe to perform when the expression
+being compared to an empty string is not an ``str``, or a union of ``str`` with other types.
+For example, ``False != ''`` is ``True``, while the expression ``False`` is falsey.
+
 Compare-To-Empty-String checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:compare-to-empty-string (C1901): *"%s" can be simplified to "%s" as an empty string is falsey*
+:compare-to-empty-string (C1901): *"%s" can be simplified to "%s", if "%s" is strictly a string, as an empty string is falsey*
   Used when Pylint detects comparison to an empty string constant.
 
 
@@ -110,9 +121,20 @@ Compare-To-Zero checker
 This checker is provided by ``pylint.extensions.comparetozero``.
 Verbatim name of the checker is ``compare-to-zero``.
 
+Compare-To-Zero checker Documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can use this plugin for finding patterns such as ``a == 0`` and ``a != 0`` in your code base.
+It is usually possible to replace ``a == 0`` with a Pythonic expression of ``not a``
+and replace ``a != 0`` with ``a``, if the variable ``a`` is strictly an ``int``.
+
+Note that this replacement is not always safe to perform when the expression
+being compared to zero is not an ``int``, or a union of ``int`` with other types.
+For example, ``'' != 0`` is ``True``, while the expression ``''`` is falsey.
+
 Compare-To-Zero checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:compare-to-zero (C2001): *"%s" can be simplified to "%s" as 0 is falsey*
+:compare-to-zero (C2001): *"%s" can be simplified to "%s", if "%s" is strictly an int, as 0 is falsey*
   Used when Pylint detects comparison to a 0 constant.
 
 

--- a/pylint/extensions/comparetozero.py
+++ b/pylint/extensions/comparetozero.py
@@ -40,7 +40,7 @@ class CompareToZeroChecker(checkers.BaseChecker):
     name = "compare-to-zero"
     msgs = {
         "C2001": (
-            '"%s" can be simplified to "%s" as 0 is falsey',
+            '"%s" can be simplified to "%s", if "%s" is strictly an int, as 0 is falsey',
             "compare-to-zero",
             "Used when Pylint detects comparison to a 0 constant.",
         )
@@ -85,7 +85,7 @@ class CompareToZeroChecker(checkers.BaseChecker):
                 )
                 self.add_message(
                     "compare-to-zero",
-                    args=(original, suggestion),
+                    args=(original, suggestion, op.as_string()),
                     node=node,
                     confidence=HIGH,
                 )

--- a/pylint/extensions/emptystring.py
+++ b/pylint/extensions/emptystring.py
@@ -23,7 +23,7 @@ class CompareToEmptyStringChecker(checkers.BaseChecker):
     name = "compare-to-empty-string"
     msgs = {
         "C1901": (
-            '"%s" can be simplified to "%s" as an empty string is falsey',
+            '"%s" can be simplified to "%s", if "%s" is strictly a string, as an empty string is falsey',
             "compare-to-empty-string",
             "Used when Pylint detects comparison to an empty string constant.",
         )
@@ -68,7 +68,7 @@ class CompareToEmptyStringChecker(checkers.BaseChecker):
                 suggestion = f"not {node_name}" if op_2 in {"==", "is"} else node_name
                 self.add_message(
                     "compare-to-empty-string",
-                    args=(node.as_string(), suggestion),
+                    args=(node.as_string(), suggestion, node_name),
                     node=node,
                     confidence=HIGH,
                 )

--- a/tests/functional/ext/comparetozero/compare_to_zero.txt
+++ b/tests/functional/ext/comparetozero/compare_to_zero.txt
@@ -1,6 +1,6 @@
-compare-to-zero:6:3:6:9::"""X is 0"" can be simplified to ""not X"" as 0 is falsey":HIGH
-compare-to-zero:12:3:12:13::"""Y is not 0"" can be simplified to ""Y"" as 0 is falsey":HIGH
-compare-to-zero:18:3:18:9::"""X == 0"" can be simplified to ""not X"" as 0 is falsey":HIGH
-compare-to-zero:24:3:24:9::"""0 == Y"" can be simplified to ""not Y"" as 0 is falsey":HIGH
-compare-to-zero:27:3:27:9::"""Y != 0"" can be simplified to ""Y"" as 0 is falsey":HIGH
-compare-to-zero:30:3:30:9::"""0 != X"" can be simplified to ""X"" as 0 is falsey":HIGH
+compare-to-zero:6:3:6:9::"""X is 0"" can be simplified to ""not X"", if ""X"" is strictly an int, as 0 is falsey":HIGH
+compare-to-zero:12:3:12:13::"""Y is not 0"" can be simplified to ""Y"", if ""Y"" is strictly an int, as 0 is falsey":HIGH
+compare-to-zero:18:3:18:9::"""X == 0"" can be simplified to ""not X"", if ""X"" is strictly an int, as 0 is falsey":HIGH
+compare-to-zero:24:3:24:9::"""0 == Y"" can be simplified to ""not Y"", if ""Y"" is strictly an int, as 0 is falsey":HIGH
+compare-to-zero:27:3:27:9::"""Y != 0"" can be simplified to ""Y"", if ""Y"" is strictly an int, as 0 is falsey":HIGH
+compare-to-zero:30:3:30:9::"""0 != X"" can be simplified to ""X"", if ""X"" is strictly an int, as 0 is falsey":HIGH

--- a/tests/functional/ext/emptystring/empty_string_comparison.txt
+++ b/tests/functional/ext/emptystring/empty_string_comparison.txt
@@ -1,6 +1,6 @@
-compare-to-empty-string:6:3:6:10::"""X is ''"" can be simplified to ""not X"" as an empty string is falsey":HIGH
-compare-to-empty-string:9:3:9:14::"""Y is not ''"" can be simplified to ""Y"" as an empty string is falsey":HIGH
-compare-to-empty-string:12:3:12:10::"""X == ''"" can be simplified to ""not X"" as an empty string is falsey":HIGH
-compare-to-empty-string:15:3:15:10::"""Y != ''"" can be simplified to ""Y"" as an empty string is falsey":HIGH
-compare-to-empty-string:18:3:18:10::"""'' == Y"" can be simplified to ""not Y"" as an empty string is falsey":HIGH
-compare-to-empty-string:21:3:21:10::"""'' != X"" can be simplified to ""X"" as an empty string is falsey":HIGH
+compare-to-empty-string:6:3:6:10::"""X is ''"" can be simplified to ""not X"", if ""X"" is strictly a string, as an empty string is falsey":HIGH
+compare-to-empty-string:9:3:9:14::"""Y is not ''"" can be simplified to ""Y"", if ""Y"" is strictly a string, as an empty string is falsey":HIGH
+compare-to-empty-string:12:3:12:10::"""X == ''"" can be simplified to ""not X"", if ""X"" is strictly a string, as an empty string is falsey":HIGH
+compare-to-empty-string:15:3:15:10::"""Y != ''"" can be simplified to ""Y"", if ""Y"" is strictly a string, as an empty string is falsey":HIGH
+compare-to-empty-string:18:3:18:10::"""'' == Y"" can be simplified to ""not Y"", if ""Y"" is strictly a string, as an empty string is falsey":HIGH
+compare-to-empty-string:21:3:21:10::"""'' != X"" can be simplified to ""X"", if ""X"" is strictly a string, as an empty string is falsey":HIGH


### PR DESCRIPTION
The extension `compare-to-empty-string` is only applicable when the expression being compared is strictly a `str`.  The extension `compare-to-zero` is only applicable when the expression being compared is strictly an `int`.

This PR adds the applicability notes of those two extensions in the docs and also in the messages.

## Type of Changes

| ✓   | :scroll: Docs          |

## Description

Closes #8592.
