### PR TITLE
[primer] Fix commit string generation

### DIFF
--- a/pylint/testutils/_primer/primer_prepare_command.py
+++ b/pylint/testutils/_primer/primer_prepare_command.py
@@ -15,7 +15,7 @@ class PrepareCommand(PrimerCommand):
     def run(self) -> None:
         commit_string = ""
         version_string = ".".join(str(x) for x in sys.version_info[:2])
-        # Shorten the SHA to avoid exceeeding GitHub's 512 char ceiling
+        # Shorten the SHA to avoid exceeding GitHub's 512 char ceiling
         if self.config.clone:
             for package, data in self.packages.items():
                 local_commit = data.lazy_clone()

--- a/pylint/testutils/_primer/primer_prepare_command.py
+++ b/pylint/testutils/_primer/primer_prepare_command.py
@@ -15,16 +15,17 @@ class PrepareCommand(PrimerCommand):
     def run(self) -> None:
         commit_string = ""
         version_string = ".".join(str(x) for x in sys.version_info[:2])
+        # Shorten the SHA to avoid exceeeding GitHub's 512 char ceiling
         if self.config.clone:
             for package, data in self.packages.items():
                 local_commit = data.lazy_clone()
                 print(f"Cloned '{package}' at commit '{local_commit}'.")
-                commit_string += local_commit + "_"
+                commit_string += local_commit[:8] + "_"
         elif self.config.check:
             for package, data in self.packages.items():
                 local_commit = Repo(data.clone_directory).head.object.hexsha
                 print(f"Found '{package}' at commit '{local_commit}'.")
-                commit_string += local_commit + "_"
+                commit_string += local_commit[:8] + "_"
         elif self.config.make_commit_string:
             for package, data in self.packages.items():
                 remote_sha1_commit = (


### PR DESCRIPTION
Follow-up to 87a4d672a8661aa61d5717fd902315d9563e33b6.

The shortening of the commit SHA to 8 chars was done in only 1 of 3 places, making it so the primer would fail the subsequent time after regenerating the list of projects.
