### PR TITLE
Upgrade 'tox - docs' to match readthedoc online and for performance

### DIFF
--- a/doc/whatsnew/3/3.0/index.rst
+++ b/doc/whatsnew/3/3.0/index.rst
@@ -12,7 +12,12 @@
 Summary -- Release highlights
 =============================
 
-In 3.0.0...
+In ``3.0.0``, we're enacting necessary breaking changes and long
+announced deprecations.
+
+There's going to be frequent beta releases,
+before the official releases, everyone is welcome to try the betas
+so we find problems before the actual release.
 
 
 .. towncrier release notes start

--- a/doc/whatsnew/3/index.rst
+++ b/doc/whatsnew/3/index.rst
@@ -1,6 +1,8 @@
 3.x
 ===
 
+This is the full list of change in pylint 3.x minors, by categories.
+
 .. toctree::
    :maxdepth: 2
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,12 @@ changedir = doc/
 deps =
     -r {toxinidir}/doc/requirements.txt
 commands =
-    sphinx-build -W -b html -d _build/doctrees . _build/html
+    # Readthedoc launch a slightly different command see '.readthedocs.yaml'
+    # sphinx-build -T -W -E --keep-going -b html -d _build/doctrees -D language=en . _build/html
+    # Changes were made for performance reasons, add or remove only if you can't reproduce.
+    sphinx-build -T -W -j auto --keep-going -b html -d _build/doctrees -D language=en . _build/html
+    # -E: don't use a saved environment, always read all files
+    # -j auto: build in parallel with N processes where possible (special value "auto" will set N to cpu-count)
 
 [testenv:test_doc]
 deps =


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Small tox/doc upgrade following a readthedoc debug in #8630 
