### PR TITLE
[Doc] Minor fixup in launching_test.rst

### DIFF
--- a/doc/development_guide/contributor_guide/tests/launching_test.rst
+++ b/doc/development_guide/contributor_guide/tests/launching_test.rst
@@ -7,7 +7,7 @@ pytest
 Since we use pytest_ to run the tests, you can also use it on its own.
 We do recommend using the tox_ command though::
 
-    pytest pylint -k test_functional
+    pytest tests/ -k test_functional
 
 You can use pytest_ directly. If you want to run tests on a specific portion of the
 code with pytest_ and your local python version::


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Without this minor fixup, I get the error already described in #8341:
```
$ pytest pylint -k my_new_func_test_name
...
collected 0 items / 1 error

============================================================== ERRORS ===============================================================
_____________________________________ ERROR collecting pylint/testutils/functional/test_file.py _____________________________________
.../python3.8/site-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
.../python3.8/site-packages/_pytest/runner.py:372: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
.../python3.8/site-packages/_pytest/python.py:817: in collect
    self.warn(
.../python3.8/site-packages/_pytest/nodes.py:302: in warn
    warnings.warn_explicit(
E   pytest.PytestCollectionWarning: cannot collect test class 'TestFileOptions' because it has a __init__ constructor (from: pylint/testutils/functional/test_file.py)
====================================================== short test summary info ======================================================
ERROR pylint/testutils/functional/test_file.py::TestFileOptions - pytest.PytestCollectionWarning: cannot collect test class 'TestFileOptions' because it has a __init__ constructor (from: pylint/...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========================================================= 1 error in 13.23s =========================================================
```