### PR TITLE
Release branch 2.17.4

### DIFF
--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -29,6 +29,37 @@ so we find problems before the actual release.
 
 .. towncrier release notes start
 
+What's new in Pylint 2.17.4?
+----------------------------
+Release date: 2023-05-06
+
+
+False Positives Fixed
+---------------------
+
+- Fix a false positive for ``bad-dunder-name`` when there is a user-defined
+  ``__index__`` method.
+
+  Closes #8613 (`#8613 <https://github.com/PyCQA/pylint/issues/8613>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- ``pyreverse``: added escaping of vertical bar character in annotation labels
+  produced by DOT printer to ensure it is not treated as field separator of
+  record-based nodes.
+
+  Closes #8603 (`#8603 <https://github.com/PyCQA/pylint/issues/8603>`_)
+
+- Fixed a crash when generating a configuration file:
+  ``tomlkit.exceptions.TOMLKitError: Can't add a table to a dotted key``
+  caused by tomlkit ``v0.11.8``.
+
+  Closes #8632 (`#8632 <https://github.com/PyCQA/pylint/issues/8632>`_)
+
+
 What's new in Pylint 2.17.3?
 ----------------------------
 Release date: 2023-04-24

--- a/doc/whatsnew/fragments/8603.bugfix
+++ b/doc/whatsnew/fragments/8603.bugfix
@@ -1,3 +1,0 @@
-``pyreverse``: added escaping of vertical bar character in annotation labels produced by DOT printer to ensure it is not treated as field separator of record-based nodes.
-
-Closes #8603

--- a/doc/whatsnew/fragments/8613.false_positive
+++ b/doc/whatsnew/fragments/8613.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``bad-dunder-name`` when there is a user-defined ``__index__`` method.
-
-Closes #8613

--- a/doc/whatsnew/fragments/8632.bugfix
+++ b/doc/whatsnew/fragments/8632.bugfix
@@ -1,4 +1,0 @@
-Fixed a crash when generating a configuration file: ``tomlkit.exceptions.TOMLKitError: Can't add a table to a dotted key``
-caused by tomlkit ``v0.11.8``.
-
-Closes #8632

--- a/doc/whatsnew/fragments/8632.bugfix
+++ b/doc/whatsnew/fragments/8632.bugfix
@@ -1,0 +1,4 @@
+Fixed a crash when generating a configuration file: ``tomlkit.exceptions.TOMLKitError: Can't add a table to a dotted key``
+caused by tomlkit ``v0.11.8``.
+
+Closes #8632

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "2.17.3"
+__version__ = "2.17.4"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/PyCQA/pylint"
 
 [version]
-current = "2.17.3"
+current = "2.17.4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "2.17.3"
+version = "2.17.4"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/2/2.17/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION

False Positives Fixed
---------------------

- Fix a false positive for ``bad-dunder-name`` when there is a user-defined
  ``__index__`` method.

  Closes #8613 



Other Bug Fixes
---------------

- ``pyreverse``: added escaping of vertical bar character in annotation labels
  produced by DOT printer to ensure it is not treated as field separator of
  record-based nodes.

  Closes #8603 

- Fixed a crash when generating a configuration file:
  ``tomlkit.exceptions.TOMLKitError: Can't add a table to a dotted key``
  caused by tomlkit ``v0.11.8``.

  Closes #8632 
