### PR TITLE
Fix bug with unclear function signature #3613

### DIFF
--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1362,12 +1362,10 @@ def safe_infer(
                 return None
             if (
                 isinstance(inferred, nodes.FunctionDef)
-                and inferred.args.args is not None
                 and isinstance(value, nodes.FunctionDef)
-                and value.args.args is not None
-                and len(inferred.args.args) != len(value.args.args)
+                and inferred.args.format_args() != value.args.format_args()
             ):
-                return None  # Different number of arguments indicates ambiguity
+                return None  # Different arguments indicates ambiguity
     except astroid.InferenceError:
         return None  # There is some kind of ambiguity
     except StopIteration:

--- a/tests/functional/u/unexpected_keyword_arg.py
+++ b/tests/functional/u/unexpected_keyword_arg.py
@@ -116,3 +116,23 @@ def test_no_return():
 
 
 test_no_return(internal_arg=2)  # [unexpected-keyword-arg]
+
+
+def ambiguous_func1(arg1):
+    print(arg1)
+
+
+def ambiguous_func2(other_arg1):
+    print(other_arg1)
+
+
+func1 = ambiguous_func1 if unknown else ambiguous_func2
+func1(arg1=1)
+
+
+def ambiguous_func3(arg1=None):
+    print(arg1)
+
+
+func2 = ambiguous_func3 if unknown else ambiguous_func1
+func2()


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Fixes long open issue of getting tensorflow function signatures incorrect and producing false positives. Due to import/function definition of tensorflow functions sometimes infer finds multiple function definitions and picks wrong one. safe_infer does check that each function definition has same number of arguments, but it's possible the names/defaults vary. 

Also added a few simple test cases.

Closes #3613
