### PR TITLE
Load custom plugins when linting in parallel

### DIFF
--- a/doc/user_guide/usage/run.rst
+++ b/doc/user_guide/usage/run.rst
@@ -160,10 +160,10 @@ This will spawn 4 parallel Pylint sub-process, where each provided module will
 be checked in parallel. Discovered problems by checkers are not displayed
 immediately. They are shown just after checking a module is complete.
 
-There are some limitations in running checks in parallel in the current
-implementation. It is not possible to use custom plugins
-(i.e. ``--load-plugins`` option), nor it is not possible to use
-initialization hooks (i.e. the ``--init-hook`` option).
+There is one known limitation with running checks in parallel as currently
+implemented. Since the division of files into worker processes is indeterminate,
+checkers that depend on comparing multiple files (e.g. ``cyclic-import``
+and ``duplicate-code``) can produce indeterminate results.
 
 Exit codes
 ----------

--- a/doc/whatsnew/fragments/4874.bugfix
+++ b/doc/whatsnew/fragments/4874.bugfix
@@ -1,0 +1,5 @@
+``--jobs`` can now be used with ``--load-plugins``.
+
+This had regressed in astroid 2.5.0.
+
+Closes #4874

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -52,6 +52,11 @@ def _worker_initialize(
     _worker_linter.set_reporter(reporters.CollectingReporter())
     _worker_linter.open()
 
+    # Re-register dynamic plugins, since the pool does not have access to the
+    # astroid module that existed when the linter was pickled.
+    _worker_linter.load_plugin_modules(_worker_linter._dynamic_plugins, force=True)
+    _worker_linter.load_plugin_configuration()
+
     if extra_packages_paths:
         _augment_sys_path(extra_packages_paths)
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -363,15 +363,18 @@ class PyLinter(
         checkers.initialize(self)
         reporters.initialize(self)
 
-    def load_plugin_modules(self, modnames: list[str]) -> None:
+    def load_plugin_modules(self, modnames: list[str], force: bool = False) -> None:
         """Check a list of pylint plugins modules, load and register them.
 
         If a module cannot be loaded, never try to load it again and instead
         store the error message for later use in ``load_plugin_configuration``
         below.
+
+        If `force` is True (useful when multiprocessing), then the plugin is
+        reloaded regardless if an entry exists in self._dynamic_plugins.
         """
         for modname in modnames:
-            if modname in self._dynamic_plugins:
+            if modname in self._dynamic_plugins and not force:
                 continue
             try:
                 module = astroid.modutils.load_module_from_name(modname)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -13,7 +13,7 @@ import sys
 import tokenize
 import traceback
 from collections import defaultdict
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from io import TextIOWrapper
 from pathlib import Path
 from re import Pattern

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -18,7 +18,7 @@ from io import TextIOWrapper
 from pathlib import Path
 from re import Pattern
 from types import ModuleType
-from typing import Any, Protocol
+from typing import Any, Iterable, Protocol
 
 import astroid
 from astroid import nodes
@@ -363,7 +363,7 @@ class PyLinter(
         checkers.initialize(self)
         reporters.initialize(self)
 
-    def load_plugin_modules(self, modnames: list[str], force: bool = False) -> None:
+    def load_plugin_modules(self, modnames: Iterable[str], force: bool = False) -> None:
         """Check a list of pylint plugins modules, load and register them.
 
         If a module cannot be loaded, never try to load it again and instead

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -18,7 +18,7 @@ from io import TextIOWrapper
 from pathlib import Path
 from re import Pattern
 from types import ModuleType
-from typing import Any, Iterable, Protocol
+from typing import Any, Protocol
 
 import astroid
 from astroid import nodes


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Load custom plugins when processing in parallel.

The current implementation of multiprocessing launches a pool, and unpickles a `PyLinter` object that contains all the configuration information. The workers in the pool will not have access to the AstroidManager that had the configuration options (custom plugins, init hooks) applied to it.

The solution here is to just re-register the custom plugins during the initialization of the pool. It's inelegant to do this multiple times, but I'm suggesting not over-optimizing a multiprocessing design that's flawed in other ways. (See #2525.) We can optimize this infelicity out later if it's still even relevant after the overhaul for #2525.

(It's possible some custom code in `--init-hook` still might not execute, but the main use case for `--init-hook` is for manipulating sys.path so that custom plugins will work, and they _do_ work now, so I removed the caveat in the docs. No one on the issue board has presented another use case for `--init-hook` and `--jobs`.)

Closes #4874
Closes #3232


The MRE in #4874 passes now :tada: