### PR TITLE
Regression fix for `unused-variable` false negative

### DIFF
--- a/doc/whatsnew/fragments/8595.false_negative
+++ b/doc/whatsnew/fragments/8595.false_negative
@@ -1,0 +1,3 @@
+Fix false negative regression caused by #8441.
+
+Closes #8595

--- a/doc/whatsnew/fragments/8595.false_negative
+++ b/doc/whatsnew/fragments/8595.false_negative
@@ -1,3 +1,0 @@
-Fix false negative regression caused by #8441.
-
-Closes #8595

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -950,7 +950,11 @@ scope_type : {self._atomic.scope_type}
             return True
         if isinstance(node, (nodes.ClassDef, nodes.FunctionDef)) and node.name == name:
             return True
-        if isinstance(node, nodes.ExceptHandler) and node.name and node.name.name == name:
+        if (
+            isinstance(node, nodes.ExceptHandler)
+            and node.name
+            and node.name.name == name
+        ):
             return True
         return False
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -962,11 +962,9 @@ scope_type : {self._atomic.scope_type}
     def _defines_name_raises_or_returns_recursive(
         name: str, node: nodes.NodeNG
     ) -> bool:
-        """Return True if `node` or some child of `node` defines the name `name`,
+        """Return True if some child of `node` defines the name `name`,
         raises, or returns.
         """
-        if NamesConsumer._defines_name_raises_or_returns(name, node):
-            return True
         for stmt in node.get_children():
             if NamesConsumer._defines_name_raises_or_returns(name, stmt):
                 return True

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -950,15 +950,19 @@ scope_type : {self._atomic.scope_type}
             return True
         if isinstance(node, (nodes.ClassDef, nodes.FunctionDef)) and node.name == name:
             return True
+        if isinstance(node, nodes.ExceptHandler) and node.name and node.name.name == name:
+            return True
         return False
 
     @staticmethod
     def _defines_name_raises_or_returns_recursive(
         name: str, node: nodes.NodeNG
     ) -> bool:
-        """Return True if some child of `node` defines the name `name`,
+        """Return True if `node` or some child of `node` defines the name `name`,
         raises, or returns.
         """
+        if NamesConsumer._defines_name_raises_or_returns(name, node):
+            return True
         for stmt in node.get_children():
             if NamesConsumer._defines_name_raises_or_returns(name, stmt):
                 return True

--- a/tests/functional/u/unused/unused_variable.py
+++ b/tests/functional/u/unused/unused_variable.py
@@ -199,3 +199,20 @@ def func6():
     nonlocal_writer()
 
     assert a == 9, a
+
+def test_regression_8595():
+    # pylint: disable=broad-exception-caught
+    import logging
+    def compute():
+        pass
+    try:
+        compute()
+        error = False
+    except Exception as e:
+        logging.error(e)
+        error = True
+    if error:
+        try:
+            compute()
+        except Exception as e:  # [unused-variable]
+            pass

--- a/tests/functional/u/unused/unused_variable.txt
+++ b/tests/functional/u/unused/unused_variable.txt
@@ -26,3 +26,4 @@ unused-variable:150:4:154:26:func4:Unused variable 'error':UNDEFINED
 redefined-outer-name:153:8:154:26:func4:Redefining name 'error' from outer scope (line 150):UNDEFINED
 unused-variable:161:4:162:12:main:Unused variable 'e':UNDEFINED
 undefined-loop-variable:168:10:168:11:main:Using possibly undefined loop variable 'e':UNDEFINED
+unused-variable:217:8:218:16:test_regression_8595:Unused variable 'e':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
This is a fix for a false negative regression caused by #8441. The issue lies in `_defines_name_raises_or_returns()`, which returns false even when an exception variable defines the given name.

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8595
