### PR TITLE
Fix crash in `invalid-metaclass` check

### DIFF
--- a/doc/whatsnew/fragments/8698.bugfix
+++ b/doc/whatsnew/fragments/8698.bugfix
@@ -1,0 +1,3 @@
+Fix crash in ``invalid-metaclass`` check when a metaclass had duplicate bases.
+
+Closes #8698

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -747,7 +747,10 @@ def _no_context_variadic(
 
 
 def _is_invalid_metaclass(metaclass: nodes.ClassDef) -> bool:
-    mro = metaclass.mro()
+    try:
+        mro = metaclass.mro()
+    except (astroid.DuplicateBasesError, astroid.InconsistentMroError):
+        return True
     return not any(is_builtin_object(cls) and cls.name == "type" for cls in mro)
 
 

--- a/tests/functional/i/invalid/invalid_metaclass.py
+++ b/tests/functional/i/invalid/invalid_metaclass.py
@@ -5,6 +5,8 @@
 # pylint: disable=multiple-statements
 
 import abc
+from pathlib import Path
+from typing import Protocol
 
 import six
 from unknown import Unknown
@@ -67,4 +69,26 @@ class Invalid(metaclass=invalid_metaclass_1):  # [invalid-metaclass]
 
 
 class InvalidSecond(metaclass=invalid_metaclass_2):  # [invalid-metaclass]
+    pass
+
+
+class MetaclassWithInvalidMRO(type(object), type(object)):  # [duplicate-bases]
+    pass
+
+
+class FifthInvalid(metaclass=MetaclassWithInvalidMRO):  # [invalid-metaclass]
+    pass
+
+
+class Proto(Protocol):
+    ...
+
+
+class MetaclassWithInconsistentMRO(type(Path), type(Proto)):  # [inconsistent-mro]
+    pass
+
+
+class SixthInvalid(  # [invalid-metaclass]
+    Path, Proto, metaclass=MetaclassWithInconsistentMRO
+):
     pass

--- a/tests/functional/i/invalid/invalid_metaclass.txt
+++ b/tests/functional/i/invalid/invalid_metaclass.txt
@@ -1,6 +1,10 @@
-invalid-metaclass:41:0:41:18:FirstInvalid:Invalid metaclass 'int' used:UNDEFINED
-invalid-metaclass:45:0:45:19:SecondInvalid:Invalid metaclass 'InvalidAsMetaclass' used:UNDEFINED
-invalid-metaclass:49:0:49:18:ThirdInvalid:Invalid metaclass '2' used:UNDEFINED
-invalid-metaclass:53:0:53:19:FourthInvalid:Invalid metaclass 'Instance of invalid_metaclass.InvalidAsMetaclass' used:UNDEFINED
-invalid-metaclass:65:0:65:13:Invalid:Invalid metaclass 'int' used:UNDEFINED
-invalid-metaclass:69:0:69:19:InvalidSecond:Invalid metaclass '1' used:UNDEFINED
+invalid-metaclass:43:0:43:18:FirstInvalid:Invalid metaclass 'int' used:UNDEFINED
+invalid-metaclass:47:0:47:19:SecondInvalid:Invalid metaclass 'InvalidAsMetaclass' used:UNDEFINED
+invalid-metaclass:51:0:51:18:ThirdInvalid:Invalid metaclass '2' used:UNDEFINED
+invalid-metaclass:55:0:55:19:FourthInvalid:Invalid metaclass 'Instance of invalid_metaclass.InvalidAsMetaclass' used:UNDEFINED
+invalid-metaclass:67:0:67:13:Invalid:Invalid metaclass 'int' used:UNDEFINED
+invalid-metaclass:71:0:71:19:InvalidSecond:Invalid metaclass '1' used:UNDEFINED
+duplicate-bases:75:0:75:29:MetaclassWithInvalidMRO:Duplicate bases for class 'MetaclassWithInvalidMRO':UNDEFINED
+invalid-metaclass:79:0:79:18:FifthInvalid:Invalid metaclass 'MetaclassWithInvalidMRO' used:UNDEFINED
+inconsistent-mro:87:0:87:34:MetaclassWithInconsistentMRO:Inconsistent method resolution order for class 'MetaclassWithInconsistentMRO':UNDEFINED
+invalid-metaclass:91:0:91:18:SixthInvalid:Invalid metaclass 'MetaclassWithInconsistentMRO' used:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Closes #8698

``mro()`` is documented as raising these two exceptions. Thus, we need to catch them.