### PR TITLE
Avoid duplicate overgeneral-exceptions warnings with ``--jobs``

### DIFF
--- a/doc/whatsnew/fragments/7774.bugfix
+++ b/doc/whatsnew/fragments/7774.bugfix
@@ -1,0 +1,4 @@
+Avoid duplicative warnings for unqualified exception names in the ``overgeneral-exceptions``
+setting when running with ``--jobs``.
+
+Closes #7774

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import builtins
 import inspect
-import warnings
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
@@ -307,18 +306,6 @@ class ExceptionsChecker(checkers.BaseChecker):
 
     def open(self) -> None:
         self._builtin_exceptions = _builtin_exceptions()
-        # TODO 3.1: Remove this check and put it elsewhere
-        for exc_name in self.linter.config.overgeneral_exceptions:
-            if "." not in exc_name:
-                warnings.warn_explicit(
-                    f"'{exc_name}' is not a proper value for the 'overgeneral-exceptions' option. "
-                    f"Use fully qualified name (maybe 'builtins.{exc_name}' ?) instead. "
-                    "This will cease to be checked at runtime in 3.1.0.",
-                    category=UserWarning,
-                    filename="pylint: Command line or configuration file",
-                    lineno=1,
-                    module="pylint",
-                )
         super().open()
 
     @utils.only_required_for_messages(

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from glob import glob
 from itertools import chain
 from pathlib import Path
@@ -101,6 +102,19 @@ def _config_initialization(
         linter.add_message(
             "unrecognized-option", args=unrecognized_options_message, line=0
         )
+
+    # TODO 3.1: Change this to emit unknown-option-value
+    for exc_name in linter.config.overgeneral_exceptions:
+        if "." not in exc_name:
+            warnings.warn_explicit(
+                f"'{exc_name}' is not a proper value for the 'overgeneral-exceptions' option. "
+                f"Use fully qualified name (maybe 'builtins.{exc_name}' ?) instead. "
+                "This will cease to be checked at runtime in 3.1.0.",
+                category=UserWarning,
+                filename="pylint: Command line or configuration file",
+                lineno=1,
+                module="pylint",
+            )
 
     linter._emit_stashed_messages()
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
This warning was emitted multiple times when running with ``--jobs``, e.g. thousands of times (not just number of jobs).

It's a configuration sanity check: it belongs in the linter, not in the actual checker.

Closes #7774
