### PR TITLE
[config] Make the linter optional during config parsing

### DIFF
--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -28,9 +28,9 @@ class _RawConfParser:
 
     @staticmethod
     def parse_ini_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
-        """Parse and handle errors of a ini configuration file.
+        """Parse and handle errors of an ini configuration file.
 
-        Raises configparser.Error
+        Raises 'configparser.Error'.
         """
         parser = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
         # Use this encoding in order to strip the BOM marker, if any.
@@ -61,7 +61,7 @@ class _RawConfParser:
     def parse_toml_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
         """Parse and handle errors of a toml configuration file.
 
-        Raises tomllib.TOMLDecodeError
+        Raises 'tomllib.TOMLDecodeError'.
         """
         with open(file_path, mode="rb") as fp:
             content = tomllib.load(fp)
@@ -90,7 +90,7 @@ class _RawConfParser:
     ) -> tuple[dict[str, str], list[str]]:
         """Parse a config file and return str-str pairs.
 
-        Raises tomllib.TOMLDecodeError, configparser.Error
+        Raises 'tomllib.TOMLDecodeError', 'configparser.Error'.
         """
         if file_path is None:
             if verbose:

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -30,7 +30,7 @@ class _RawConfParser:
     def parse_ini_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
         """Parse and handle errors of an ini configuration file.
 
-        Raises 'configparser.Error'.
+        Raises ``configparser.Error``.
         """
         parser = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
         # Use this encoding in order to strip the BOM marker, if any.
@@ -61,7 +61,7 @@ class _RawConfParser:
     def parse_toml_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
         """Parse and handle errors of a toml configuration file.
 
-        Raises 'tomllib.TOMLDecodeError'.
+        Raises ``tomllib.TOMLDecodeError``.
         """
         with open(file_path, mode="rb") as fp:
             content = tomllib.load(fp)
@@ -90,7 +90,7 @@ class _RawConfParser:
     ) -> tuple[dict[str, str], list[str]]:
         """Parse a config file and return str-str pairs.
 
-        Raises 'tomllib.TOMLDecodeError', 'configparser.Error'.
+        Raises ``tomllib.TOMLDecodeError``, ``configparser.Error``.
         """
         if file_path is None:
             if verbose:

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -10,7 +10,7 @@ import configparser
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from pylint.config.utils import _parse_rich_type_value
 
@@ -22,12 +22,14 @@ else:
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
+PylintConfigFileData = Tuple[Dict[str, str], List[str]]
+
 
 class _RawConfParser:
     """Class to parse various formats of configuration files."""
 
     @staticmethod
-    def parse_ini_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
+    def parse_ini_file(file_path: Path) -> PylintConfigFileData:
         """Parse and handle errors of an ini configuration file.
 
         Raises ``configparser.Error``.
@@ -58,7 +60,7 @@ class _RawConfParser:
         return False
 
     @staticmethod
-    def parse_toml_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
+    def parse_toml_file(file_path: Path) -> PylintConfigFileData:
         """Parse and handle errors of a toml configuration file.
 
         Raises ``tomllib.TOMLDecodeError``.
@@ -87,7 +89,7 @@ class _RawConfParser:
     @staticmethod
     def parse_config_file(
         file_path: Path | None, verbose: bool
-    ) -> tuple[dict[str, str], list[str]]:
+    ) -> PylintConfigFileData:
         """Parse a config file and return str-str pairs.
 
         Raises ``tomllib.TOMLDecodeError``, ``configparser.Error``.
@@ -118,9 +120,7 @@ class _ConfigurationFileParser:
         self.verbose_mode = verbose
         self.linter = linter
 
-    def parse_config_file(
-        self, file_path: Path | None
-    ) -> tuple[dict[str, str], list[str]]:
+    def parse_config_file(self, file_path: Path | None) -> PylintConfigFileData:
         """Parse a config file and return str-str pairs."""
         try:
             return _RawConfParser.parse_config_file(file_path, self.verbose_mode)

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -23,24 +23,23 @@ if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
 
-class _ConfigurationFileParser:
+class _RawConfParser:
     """Class to parse various formats of configuration files."""
 
-    def __init__(self, verbose: bool, linter: PyLinter) -> None:
-        self.verbose_mode = verbose
-        self.linter = linter
+    @staticmethod
+    def parse_ini_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
+        """Parse and handle errors of a ini configuration file.
 
-    def _parse_ini_file(self, file_path: Path) -> tuple[dict[str, str], list[str]]:
-        """Parse and handle errors of a ini configuration file."""
+        Raises configparser.Error
+        """
         parser = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
-
         # Use this encoding in order to strip the BOM marker, if any.
         with open(file_path, encoding="utf_8_sig") as fp:
             parser.read_file(fp)
 
         config_content: dict[str, str] = {}
         options: list[str] = []
-        ini_file_with_sections = self._ini_file_with_sections(file_path)
+        ini_file_with_sections = _RawConfParser._ini_file_with_sections(file_path)
         for section in parser.sections():
             if ini_file_with_sections and not section.startswith("pylint"):
                 continue
@@ -58,15 +57,14 @@ class _ConfigurationFileParser:
             return True
         return False
 
-    def _parse_toml_file(self, file_path: Path) -> tuple[dict[str, str], list[str]]:
-        """Parse and handle errors of a toml configuration file."""
-        try:
-            with open(file_path, mode="rb") as fp:
-                content = tomllib.load(fp)
-        except tomllib.TOMLDecodeError as e:
-            self.linter.add_message("config-parse-error", line=0, args=str(e))
-            return {}, []
+    @staticmethod
+    def parse_toml_file(file_path: Path) -> tuple[dict[str, str], list[str]]:
+        """Parse and handle errors of a toml configuration file.
 
+        Raises tomllib.TOMLDecodeError
+        """
+        with open(file_path, mode="rb") as fp:
+            content = tomllib.load(fp)
         try:
             sections_values = content["tool"]["pylint"]
         except KeyError:
@@ -86,12 +84,16 @@ class _ConfigurationFileParser:
                 options += [f"--{opt}", values]
         return config_content, options
 
+    @staticmethod
     def parse_config_file(
-        self, file_path: Path | None
+        file_path: Path | None, verbose: bool
     ) -> tuple[dict[str, str], list[str]]:
-        """Parse a config file and return str-str pairs."""
+        """Parse a config file and return str-str pairs.
+
+        Raises tomllib.TOMLDecodeError, configparser.Error
+        """
         if file_path is None:
-            if self.verbose_mode:
+            if verbose:
                 print(
                     "No config file found, using default configuration", file=sys.stderr
                 )
@@ -101,13 +103,44 @@ class _ConfigurationFileParser:
         if not file_path.exists():
             raise OSError(f"The config file {file_path} doesn't exist!")
 
-        if self.verbose_mode:
+        if verbose:
             print(f"Using config file {file_path}", file=sys.stderr)
 
+        if file_path.suffix == ".toml":
+            return _RawConfParser.parse_toml_file(file_path)
+        return _RawConfParser.parse_ini_file(file_path)
+
+
+class _ConfigurationFileParser:
+    """Class to parse various formats of configuration files."""
+
+    def __init__(self, verbose: bool, linter: PyLinter) -> None:
+        self.verbose_mode = verbose
+        self.linter = linter
+
+    def _parse_ini_file(self, file_path: Path) -> tuple[dict[str, str], list[str]]:
+        """Parse and handle errors of a ini configuration file."""
+        return _RawConfParser.parse_ini_file(file_path)
+
+    @staticmethod
+    def _ini_file_with_sections(file_path: Path) -> bool:
+        """Return whether the file uses sections."""
+        return _RawConfParser._ini_file_with_sections(file_path)
+
+    def _parse_toml_file(self, file_path: Path) -> tuple[dict[str, str], list[str]]:
+        """Parse and handle errors of a toml configuration file."""
         try:
-            if file_path.suffix == ".toml":
-                return self._parse_toml_file(file_path)
-            return self._parse_ini_file(file_path)
+            return _RawConfParser.parse_toml_file(file_path)
+        except tomllib.TOMLDecodeError as e:
+            self.linter.add_message("config-parse-error", line=0, args=str(e))
+            return {}, []
+
+    def parse_config_file(
+        self, file_path: Path | None
+    ) -> tuple[dict[str, str], list[str]]:
+        """Parse a config file and return str-str pairs."""
+        try:
+            return _RawConfParser.parse_config_file(file_path, self.verbose_mode)
         except (configparser.Error, tomllib.TOMLDecodeError) as e:
             self.linter.add_message("config-parse-error", line=0, args=str(e))
             return {}, []

--- a/pylint/config/config_file_parser.py
+++ b/pylint/config/config_file_parser.py
@@ -118,23 +118,6 @@ class _ConfigurationFileParser:
         self.verbose_mode = verbose
         self.linter = linter
 
-    def _parse_ini_file(self, file_path: Path) -> tuple[dict[str, str], list[str]]:
-        """Parse and handle errors of a ini configuration file."""
-        return _RawConfParser.parse_ini_file(file_path)
-
-    @staticmethod
-    def _ini_file_with_sections(file_path: Path) -> bool:
-        """Return whether the file uses sections."""
-        return _RawConfParser._ini_file_with_sections(file_path)
-
-    def _parse_toml_file(self, file_path: Path) -> tuple[dict[str, str], list[str]]:
-        """Parse and handle errors of a toml configuration file."""
-        try:
-            return _RawConfParser.parse_toml_file(file_path)
-        except tomllib.TOMLDecodeError as e:
-            self.linter.add_message("config-parse-error", line=0, args=str(e))
-            return {}, []
-
     def parse_config_file(
         self, file_path: Path | None
     ) -> tuple[dict[str, str], list[str]]:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This will permit to parse config file without having to instantiate a linter for tool working on pylint configuration like #5462. another way to do this would be to extract the logic and create another class that we could use in ``_ConfigurationFileParser`` like here: https://github.com/Pierre-Sassoulas/pylint/commit/4ccbee1d1e73900f2d34dd67c00d5eb665cf2a04
