### PR TITLE
Docs: optparse not removed in Python 3.12

### DIFF
--- a/doc/whatsnew/2/2.14/summary.rst
+++ b/doc/whatsnew/2/2.14/summary.rst
@@ -15,8 +15,7 @@ We migrated to ``argparse`` from ``optparse`` and refactored the configuration h
 thanks to Daniël van Noord. On the user side it should change the output of the
 ``--help`` command, and some inconsistencies and bugs should disappear. The behavior
 between options set in a config file versus on the command line will be more consistent. For us,
-it will permit to maintain this part of the code easily in the future and anticipate
-``optparse``'s removal in Python 3.12.
+it will permit to maintain this part of the code easily in the future.
 
 As a result of the refactor there are a lot of internal deprecations. If you're a library
 maintainer that depends on pylint, please verify that you're ready for pylint 3.0


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->


The optparse module is deprecated, and it's better to use argparse, but there's no current plans to remove it.

https://docs.python.org/3.12/library/optparse.html shows it's still present in 3.12 and says:

> _Deprecated since version 3.2:_ The [optparse](https://docs.python.org/3.12/library/optparse.html#module-optparse) module is deprecated and will not be developed further; development will continue with the [argparse](https://docs.python.org/3.12/library/argparse.html#module-argparse) module.


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

