### PR TITLE
Fix a false positive for ``unused-variable``

### DIFF
--- a/doc/whatsnew/fragments/8696.false_positive
+++ b/doc/whatsnew/fragments/8696.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``unused-variable`` when there is an import in a ``if TYPE_CHECKING:`` block and ``allow-global-unused-variables`` is set to ``no`` in the configuration.
+
+Closes #8696

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3101,6 +3101,8 @@ class VariablesChecker(BaseChecker):
             return
         for name, node_lst in not_consumed.items():
             for node in node_lst:
+                if in_type_checking_block(node):
+                    continue
                 self.add_message("unused-variable", args=(name,), node=node)
 
     # pylint: disable = too-many-branches

--- a/tests/functional/u/unused/unused_global_variable2.py
+++ b/tests/functional/u/unused/unused_global_variable2.py
@@ -1,2 +1,11 @@
 # pylint: disable=missing-docstring
+
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    import math
+
+
 VAR = 'pylint'  # [unused-variable]

--- a/tests/functional/u/unused/unused_global_variable2.txt
+++ b/tests/functional/u/unused/unused_global_variable2.txt
@@ -1,1 +1,1 @@
-unused-variable:2:0:2:3::Unused variable 'VAR':UNDEFINED
+unused-variable:11:0:11:3::Unused variable 'VAR':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fix a false positive for ``unused-variable`` when there is an import in a ``if TYPE_CHECKING:`` block and ``allow-global-unused-variables`` is set to ``no`` in the configuration.

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8696
