### PR TITLE
CI: Only run stale cron on upstream

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,8 @@ concurrency:
 
 jobs:
   analyze:
+    if:
+      ${{ github.repository_owner == 'pylint-dev' || github.event_name != 'schedule' }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   close-issues:
+    if: github.repository_owner == 'pylint-dev'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          debug-only: true
           days-before-issue-stale: 28
           days-before-issue-close: 7
           any-of-issue-labels:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

<!-- If this PR references an issue without fixing it: -->

There's no need to run the "close stale issues and pr" or CodeQL cron for forks.

More info: https://dev.to/hugovk/til-how-to-disable-cron-for-github-forks-2d0l


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
