### PR TITLE
Extend test cases for 'condition-evals-to-constant'

### DIFF
--- a/tests/functional/c/condition_evals_to_constant.py
+++ b/tests/functional/c/condition_evals_to_constant.py
@@ -44,3 +44,10 @@ if True:  # pylint: disable=using-constant-test
 CONSTANT or True
 bool(CONSTANT or OTHER)
 bool(func(CONSTANT or True))
+
+# Strings also evaluate as True (they are constants)
+if func("a") == "b" or "c":  # [condition-evals-to-constant]
+    pass
+
+if 1 == func(2) or "fermi":  # [condition-evals-to-constant]
+    pass

--- a/tests/functional/c/condition_evals_to_constant.txt
+++ b/tests/functional/c/condition_evals_to_constant.txt
@@ -13,3 +13,5 @@ condition-evals-to-constant:33:7:33:19::Boolean condition 'True or True' will al
 condition-evals-to-constant:34:7:34:21::Boolean condition 'False or False' will always evaluate to 'False':UNDEFINED
 condition-evals-to-constant:35:7:35:20::Boolean condition 'True and True' will always evaluate to 'True':UNDEFINED
 condition-evals-to-constant:36:7:36:22::Boolean condition 'False and False' will always evaluate to 'False':UNDEFINED
+condition-evals-to-constant:49:3:49:26::Boolean condition 'func('a') == 'b' or 'c'' will always evaluate to ''c'':UNDEFINED
+condition-evals-to-constant:52:3:52:26::Boolean condition '1 == func(2) or 'fermi'' will always evaluate to ''fermi'':UNDEFINED


### PR DESCRIPTION
Closes #7933.

The original issue reported pylint as missing bugs in comparisons like:

`if get_text() == "string A" or "string B":`

In reality this is already covered by the message
'condition-evals-to-constant', however test cases with strings were missing, they have been added to self-document other cases this checker applies to and extend coverage.