### PR TITLE
Fix false positive `unspecified-encoding` when using kwargs

### DIFF
--- a/doc/whatsnew/fragments/8719.false_positive
+++ b/doc/whatsnew/fragments/8719.false_positive
@@ -1,0 +1,3 @@
+Fix false positives generated when supplying arguments as ``**kwargs`` to IO calls like open().
+
+Closes #8719

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -16,7 +16,7 @@ from astroid.typing import InferenceResult
 
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
-from pylint.interfaces import INFERENCE
+from pylint.interfaces import HIGH, INFERENCE
 from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
@@ -699,6 +699,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     ) -> None:
         """Various checks for an open call."""
         mode_arg = None
+        confidence = HIGH
         try:
             if open_module == "_io":
                 mode_arg = utils.get_argument_from_call(
@@ -709,11 +710,12 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                     node, position=0, keyword="mode"
                 )
         except utils.NoSuchArgumentError:
-            pass
+            mode_arg = utils.infer_kwarg_from_call(node, keyword="mode")
+            if mode_arg:
+                confidence = INFERENCE
 
         if mode_arg:
             mode_arg = utils.safe_infer(mode_arg)
-
             if (
                 func_name in OPEN_FILES_MODE
                 and isinstance(mode_arg, nodes.Const)
@@ -723,6 +725,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                     "bad-open-mode",
                     node=node,
                     args=mode_arg.value or str(mode_arg.value),
+                    confidence=confidence,
                 )
 
         if (
@@ -730,7 +733,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             or isinstance(mode_arg, nodes.Const)
             and (not mode_arg.value or "b" not in str(mode_arg.value))
         ):
-            encoding_arg = None
+            confidence = HIGH
             try:
                 if open_module == "pathlib":
                     if node.func.attrname == "read_text":
@@ -750,13 +753,21 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                         node, position=3, keyword="encoding"
                     )
             except utils.NoSuchArgumentError:
-                self.add_message("unspecified-encoding", node=node)
+                encoding_arg = utils.infer_kwarg_from_call(node, keyword="encoding")
+                if encoding_arg:
+                    confidence = INFERENCE
+                else:
+                    self.add_message(
+                        "unspecified-encoding", node=node, confidence=confidence
+                    )
 
             if encoding_arg:
                 encoding_arg = utils.safe_infer(encoding_arg)
 
                 if isinstance(encoding_arg, nodes.Const) and encoding_arg.value is None:
-                    self.add_message("unspecified-encoding", node=node)
+                    self.add_message(
+                        "unspecified-encoding", node=node, confidence=confidence
+                    )
 
     def _check_env_function(self, node: nodes.Call, infer: nodes.FunctionDef) -> None:
         env_name_kwarg = "key"

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -736,6 +736,25 @@ def get_argument_from_call(
     raise NoSuchArgumentError
 
 
+def infer_kwarg_from_call(call_node: nodes.Call, keyword: str) -> nodes.Name | None:
+    """Returns the specified argument from a function's kwargs.
+
+    :param nodes.Call call_node: Node representing a function call to check.
+    :param str keyword: Name of the argument to be extracted.
+
+    :returns: The node representing the argument, None if the argument is not found.
+    :rtype: nodes.Name
+    """
+    for arg in call_node.kwargs:
+        inferred = safe_infer(arg.value)
+        if isinstance(inferred, nodes.Dict):
+            for item in inferred.items:
+                if item[0].value == keyword:
+                    return item[1]
+
+    return None
+
+
 def inherit_from_std_ex(node: nodes.NodeNG | astroid.Instance) -> bool:
     """Return whether the given class node is subclass of
     exceptions.Exception.

--- a/tests/functional/b/bad_open_mode.txt
+++ b/tests/functional/b/bad_open_mode.txt
@@ -1,6 +1,6 @@
-bad-open-mode:12:0:12:35::"""rwx"" is not a valid mode for open.":UNDEFINED
-bad-open-mode:13:0:13:34::"""rr"" is not a valid mode for open.":UNDEFINED
-bad-open-mode:14:0:14:33::"""+"" is not a valid mode for open.":UNDEFINED
-bad-open-mode:15:0:15:34::"""xw"" is not a valid mode for open.":UNDEFINED
-bad-open-mode:21:0:21:34::"""Ua"" is not a valid mode for open.":UNDEFINED
-bad-open-mode:22:0:22:36::"""Ur++"" is not a valid mode for open.":UNDEFINED
+bad-open-mode:12:0:12:35::"""rwx"" is not a valid mode for open.":HIGH
+bad-open-mode:13:0:13:34::"""rr"" is not a valid mode for open.":HIGH
+bad-open-mode:14:0:14:33::"""+"" is not a valid mode for open.":HIGH
+bad-open-mode:15:0:15:34::"""xw"" is not a valid mode for open.":HIGH
+bad-open-mode:21:0:21:34::"""Ua"" is not a valid mode for open.":HIGH
+bad-open-mode:22:0:22:36::"""Ur++"" is not a valid mode for open.":HIGH

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -162,3 +162,35 @@ open(FILENAME, mode=None)  # [bad-open-mode, unspecified-encoding]
 
 # Test for crash reported in https://github.com/pylint-dev/pylint/issues/6414
 open('foo', mode=2)  # [bad-open-mode, unspecified-encoding]
+
+# Infer kwargs
+KWARGS = {"mode": "rb"}
+open(FILENAME, **KWARGS)
+
+KWARGS = {"mode": "w", "encoding": "utf-8"}
+open(FILENAME, **KWARGS)
+io.open(FILENAME, **KWARGS)
+Path(FILENAME).open(**KWARGS)
+
+KWARGS = {"mode": 5}
+open(FILENAME, **KWARGS)  # [bad-open-mode, unspecified-encoding]
+io.open(FILENAME, **KWARGS)  # [bad-open-mode, unspecified-encoding]
+
+KWARGS = {"mode": "wt", "encoding": None}
+with open(FILENAME, **KWARGS) as fd:  # [unspecified-encoding]
+    pass
+
+Path(FILENAME).open(**KWARGS)  # [unspecified-encoding]
+
+KWARGS = {"encoding": None}
+Path(FILENAME).write_text("hello", **KWARGS)  # [unspecified-encoding]
+
+KWARGS = {"encoding": "utf-8"}
+Path(FILENAME).write_text("goodbye", **KWARGS)
+
+# No one does it this way, but it is a possibility
+KWARGS = {"encoding": None}
+Path(FILENAME).read_text(**KWARGS)  # [unspecified-encoding]
+
+KWARGS = {"encoding": "utf-8"}
+Path(FILENAME).read_text(**KWARGS)

--- a/tests/functional/u/unspecified_encoding_py38.txt
+++ b/tests/functional/u/unspecified_encoding_py38.txt
@@ -1,33 +1,41 @@
-unspecified-encoding:13:0:13:14::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:14:0:14:20::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:15:0:15:20::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:16:0:16:34::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:17:0:17:19::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:26:5:26:19::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:29:5:29:34::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:33:5:33:45::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:38:0:38:17::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:39:0:39:23::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:40:0:40:23::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:41:0:41:37::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:50:5:50:22::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:53:5:53:37::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:57:5:57:48::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:66:0:66:26::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:67:0:67:39::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:68:0:68:50::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:75:0:75:35::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:76:0:76:50::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:77:0:77:61::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:81:0:81:21::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:82:0:82:25::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:83:0:83:25::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:84:0:84:39::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:149:0:149:23::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:152:0:152:28::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:155:0:155:26::Using open without explicitly specifying an encoding:UNDEFINED
-unspecified-encoding:158:0:158:35::Using open without explicitly specifying an encoding:UNDEFINED
-bad-open-mode:161:0:161:25::"""None"" is not a valid mode for open.":UNDEFINED
-unspecified-encoding:161:0:161:25::Using open without explicitly specifying an encoding:UNDEFINED
-bad-open-mode:164:0:164:19::"""2"" is not a valid mode for open.":UNDEFINED
-unspecified-encoding:164:0:164:19::Using open without explicitly specifying an encoding:UNDEFINED
+unspecified-encoding:13:0:13:14::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:14:0:14:20::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:15:0:15:20::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:16:0:16:34::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:17:0:17:19::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:26:5:26:19::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:29:5:29:34::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:33:5:33:45::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:38:0:38:17::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:39:0:39:23::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:40:0:40:23::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:41:0:41:37::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:50:5:50:22::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:53:5:53:37::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:57:5:57:48::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:66:0:66:26::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:67:0:67:39::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:68:0:68:50::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:75:0:75:35::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:76:0:76:50::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:77:0:77:61::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:81:0:81:21::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:82:0:82:25::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:83:0:83:25::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:84:0:84:39::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:149:0:149:23::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:152:0:152:28::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:155:0:155:26::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:158:0:158:35::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:161:0:161:25::"""None"" is not a valid mode for open.":HIGH
+unspecified-encoding:161:0:161:25::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:164:0:164:19::"""2"" is not a valid mode for open.":HIGH
+unspecified-encoding:164:0:164:19::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:176:0:176:24::"""5"" is not a valid mode for open.":INFERENCE
+unspecified-encoding:176:0:176:24::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:177:0:177:27::"""5"" is not a valid mode for open.":INFERENCE
+unspecified-encoding:177:0:177:27::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:180:5:180:29::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:183:0:183:29::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:186:0:186:44::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:193:0:193:34::Using open without explicitly specifying an encoding:INFERENCE


### PR DESCRIPTION
False positives were being generated when passing arguments as kwargs to open() calls. This has been resolved by using inference inside `get_argument_from_call`.

This is an opt-in function, for inference to be used, `infer=True` must be specified when calling `get_argument_from_call`. This ensures that the rest of the codebase does not suffer a performance hit unnecessarily.

Closes #8719
