### PR TITLE
Fix crash and add new checker when nonlocal defined at module level

### DIFF
--- a/doc/data/messages/n/nonlocal-defined-at-module-level/bad.py
+++ b/doc/data/messages/n/nonlocal-defined-at-module-level/bad.py
@@ -1,0 +1,2 @@
+nonlocal colors  # [nonlocal-defined-at-module-level]
+colors = ["red", "green"]

--- a/doc/data/messages/n/nonlocal-defined-at-module-level/good.py
+++ b/doc/data/messages/n/nonlocal-defined-at-module-level/good.py
@@ -1,0 +1,5 @@
+class Fruit:
+    colors = ["red", "green"]
+
+    def get_color(self):
+        nonlocal colors

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -101,6 +101,9 @@ Basic checker Messages
   Emitted when format function is not called on str object. e.g doing
   print("value: {}").format(123) instead of print("value: {}".format(123)).
   This might not be what the user intended to do.
+:nonlocal-defined-at-module-level (E0120): *nonlocal name %s defined at module level*
+  Emitted when a nonlocal variable is defined at module-level which is a
+  SyntaxError
 :nonlocal-without-binding (E0117): *nonlocal name %s found without binding*
   Emitted when a nonlocal variable does not have an attached name somewhere in
   the parent scopes

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -130,6 +130,7 @@ All messages in the error category:
    error/non-iterator-returned
    error/nonexistent-operator
    error/nonlocal-and-global
+   error/nonlocal-defined-at-module-level
    error/nonlocal-without-binding
    error/not-a-mapping
    error/not-an-iterable

--- a/doc/whatsnew/fragments/8725.bugfix
+++ b/doc/whatsnew/fragments/8725.bugfix
@@ -1,0 +1,3 @@
+Enable ``deprecated-pragma`` by default.
+
+Closes #8725

--- a/doc/whatsnew/fragments/8735.other
+++ b/doc/whatsnew/fragments/8735.other
@@ -1,0 +1,4 @@
+Fix a crash when a ``nonlocal`` is defined at module-level.
+Add a new checker ``nonlocal-defined-at-module-level`` when a ``nonlocal`` is defined at module-level.
+
+Closes #8735

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -204,6 +204,12 @@ class BasicErrorChecker(_BasicChecker):
             "which results in an error since Python 3.6.",
             {"minversion": (3, 6)},
         ),
+        "E0120": (
+            "nonlocal name %s defined at module level",
+            "nonlocal-defined-at-module-level",
+            "Emitted when a nonlocal variable is defined at module-level "
+            "which is a SyntaxError",
+        ),
     }
 
     def open(self) -> None:
@@ -396,6 +402,15 @@ class BasicErrorChecker(_BasicChecker):
 
     def _check_nonlocal_without_binding(self, node: nodes.Nonlocal, name: str) -> None:
         current_scope = node.scope()
+        if isinstance(current_scope, nodes.Module):
+            self.add_message(
+                "nonlocal-defined-at-module-level",
+                args=(name,),
+                node=node,
+                confidence=HIGH,
+            )
+            return
+
         while current_scope.parent is not None:
             if not isinstance(current_scope, (nodes.ClassDef, nodes.FunctionDef)):
                 self.add_message("nonlocal-without-binding", args=(name,), node=node)
@@ -417,6 +432,7 @@ class BasicErrorChecker(_BasicChecker):
             )
 
     @utils.only_required_for_messages("nonlocal-without-binding")
+    @utils.only_required_for_messages("nonlocal-defined-at-module-level")
     def visit_nonlocal(self, node: nodes.Nonlocal) -> None:
         for name in node.names:
             self._check_nonlocal_without_binding(node, name)

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2913,7 +2913,7 @@ class VariablesChecker(BaseChecker):
                     elt.name for elt in target.elts if isinstance(elt, nodes.AssignName)
                 )
         scope = node.scope()
-        nonlocals_with_same_name = any(
+        nonlocals_with_same_name = node.scope().parent and any(
             child for child in scope.body if isinstance(child, nodes.Nonlocal)
         )
         if nonlocals_with_same_name:

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -388,6 +388,7 @@ class _MessageStateHandler:
                                 "deprecated-pragma",
                                 line=start[0],
                                 args=("disable=all", "skip-file"),
+                                confidence=HIGH,
                             )
                             self.linter.add_message("file-ignored", line=start[0])
                             self._ignore_file = True

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -196,7 +196,6 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         {
             "old_names": [("I0014", "deprecated-disable-all")],
             "scope": WarningScope.LINE,
-            "default_enabled": False,
         },
     ),
     "E0001": (

--- a/tests/functional/d/deprecated/deprecated_pragma.py
+++ b/tests/functional/d/deprecated/deprecated_pragma.py
@@ -1,0 +1,1 @@
+# pylint: disable=all  # [deprecated-pragma]

--- a/tests/functional/d/deprecated/deprecated_pragma.txt
+++ b/tests/functional/d/deprecated/deprecated_pragma.txt
@@ -1,0 +1,1 @@
+deprecated-pragma:1:0:None:None::"Pragma ""disable=all"" is deprecated, use ""skip-file"" instead":HIGH

--- a/tests/functional/n/nonlocal_defined_at_module_level.py
+++ b/tests/functional/n/nonlocal_defined_at_module_level.py
@@ -1,0 +1,5 @@
+"""Test ``nonlocal`` defined at module-level"""
+
+
+nonlocal APPLE  # [nonlocal-defined-at-module-level]
+APPLE = 42

--- a/tests/functional/n/nonlocal_defined_at_module_level.txt
+++ b/tests/functional/n/nonlocal_defined_at_module_level.txt
@@ -1,0 +1,1 @@
+nonlocal-defined-at-module-level:4:0:4:14::nonlocal name APPLE defined at module level:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Defining nonlocal at the module level is a SyntaxError.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8735
