### PR TITLE
Fix a crash when `__all__` exists but cannot be inferred

### DIFF
--- a/doc/whatsnew/fragments/8740.bugfix
+++ b/doc/whatsnew/fragments/8740.bugfix
@@ -1,0 +1,3 @@
+Fix a crash when ``__all__`` exists but cannot be inferred.
+
+Closes #8740

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3046,7 +3046,10 @@ class VariablesChecker(BaseChecker):
     def _check_all(
         self, node: nodes.Module, not_consumed: dict[str, list[nodes.NodeNG]]
     ) -> None:
-        assigned = next(node.igetattr("__all__"))
+        try:
+            assigned = next(node.igetattr("__all__"))
+        except astroid.InferenceError:
+            return
         if isinstance(assigned, util.UninferableBase):
             return
         if assigned.pytype() not in {"builtins.list", "builtins.tuple"}:

--- a/tests/functional/u/undefined/undefined_all_variable_edge_case.py
+++ b/tests/functional/u/undefined/undefined_all_variable_edge_case.py
@@ -1,0 +1,5 @@
+"""Edge case: __all__ exists in module's locals, but cannot be inferred.
+
+Other tests for undefined-all-variable in tests/functional/n/names_in__all__.py"""
+
+__all__ += []  # [undefined-variable]

--- a/tests/functional/u/undefined/undefined_all_variable_edge_case.txt
+++ b/tests/functional/u/undefined/undefined_all_variable_edge_case.txt
@@ -1,0 +1,1 @@
+undefined-variable:5:0:5:7::Undefined variable '__all__':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #8740