### PR TITLE
Skip flaky `regression_5408.py` test on PyPy

### DIFF
--- a/tests/functional/r/regression_02/regression_5408.rc
+++ b/tests/functional/r/regression_02/regression_5408.rc
@@ -1,2 +1,3 @@
 [testoptions]
 min_pyver=3.9
+except_implementations=PyPy


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Similar skip as in astroid, see pylint-dev/astroid@1f9ba55.

Discussed [here](https://github.com/pylint-dev/pylint/pull/8685#issuecomment-1579447820).
