### PR TITLE
Support `duplicate-code` message with `--jobs`

### DIFF
--- a/doc/whatsnew/fragments/374.bugfix
+++ b/doc/whatsnew/fragments/374.bugfix
@@ -1,0 +1,3 @@
+Support ``duplicate-code`` message when parallelizing with ``--jobs``.
+
+Closes #374

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -889,8 +889,11 @@ class SimilarChecker(BaseRawFileChecker, Similar):
         """Reduces and recombines data into a format that we can report on.
 
         The partner function of get_map_data()
+
+        Calls self.close() to actually calculate and report duplicate code.
         """
         Similar.combine_mapreduce_data(self, linesets_collection=data)
+        self.close()
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -130,7 +130,7 @@ def check_parallel(
     """Use the given linter to lint the files with given amount of workers (jobs).
 
     This splits the work filestream-by-filestream. If you need to do work across
-    multiple files, as in the similarity-checker, then implement the map/reduce mixin functionality.
+    multiple files, as in the similarity-checker, then implement the map/reduce functionality.
     """
     # The linter is inherited by all the pool's workers, i.e. the linter
     # is identical to the linter object here. This is required so that

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -233,7 +233,6 @@ class TestRunTC:
                 join(HERE, "functional", "a", "arguments.py"),
             ],
             out=out,
-            # We expect similarities to fail and an error
             code=MSG_TYPES_STATUS["E"],
         )
         assert (

--- a/tests/test_similar.py
+++ b/tests/test_similar.py
@@ -82,6 +82,23 @@ class TestSimilarCodeChecker:
             expected_output=expected_output,
         )
 
+    @pytest.mark.needs_two_cores
+    def test_duplicate_code_parallel(self) -> None:
+        path = join(DATA, "raw_strings_all")
+        expected_output = "Similar lines in 2 files"
+        self._test_output(
+            [
+                path,
+                "--disable=all",
+                "--enable=duplicate-code",
+                "--ignore-imports=no",
+                "--ignore-signatures=no",
+                "--min-similarity-lines=4",
+                "--jobs=2",
+            ],
+            expected_output=expected_output,
+        )
+
     def test_duplicate_code_raw_strings_disable_file(self) -> None:
         """Tests disabling duplicate-code at the file level in a single file."""
         path = join(DATA, "raw_strings_disable_file")


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

All the groundwork for detecting `duplicate-code` with `--jobs` was laid in #4007, but it was only unit tested without actually checking that messages were emitted.

Closes #374 (I moved the remaining cyclic-import issue to #4171)
