### PR TITLE
Fix a false positive for ``no-member``.

### DIFF
--- a/doc/whatsnew/fragments/8759.false_positive
+++ b/doc/whatsnew/fragments/8759.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``no-member`` when accessing a no-value attribute that is annotated in a class body.
+
+Closes #8759

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1123,9 +1123,7 @@ accessed. Python regular expressions are accepted.",
 
             try:
                 attr_nodes = owner.getattr(node.attrname)
-            except AttributeError:
-                continue
-            except astroid.DuplicateBasesError:
+            except (AttributeError, astroid.DuplicateBasesError):
                 continue
             except astroid.NotFoundError:
                 # This can't be moved before the actual .getattr call,
@@ -1151,6 +1149,13 @@ accessed. Python regular expressions are accepted.",
             else:
                 for attr_node in attr_nodes:
                     attr_parent = attr_node.parent
+
+                    # If an annotation exists for this attribute, we don't emit `no-member`.
+                    if isinstance(
+                        owner, astroid.Instance
+                    ) and utils.is_attribute_typed_annotation(owner, node.attrname):
+                        break
+
                     # Skip augmented assignments
                     try:
                         if isinstance(attr_node.statement(), nodes.AugAssign) or (

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1151,9 +1151,11 @@ accessed. Python regular expressions are accepted.",
                     attr_parent = attr_node.parent
 
                     # If an annotation exists for this attribute, we don't emit `no-member`.
-                    if isinstance(
-                        owner, astroid.Instance
-                    ) and utils.is_attribute_typed_annotation(owner, node.attrname):
+                    if (
+                        isinstance(owner, astroid.Instance)
+                        and utils.is_attribute_typed_annotation(owner, node.attrname)
+                        and not isinstance(attr_node.statement(), nodes.AugAssign)
+                    ):
                         break
 
                     # Skip augmented assignments

--- a/tests/functional/n/no/no_member_augassign.py
+++ b/tests/functional/n/no/no_member_augassign.py
@@ -1,19 +1,24 @@
-"""Tests for no-member in relation to AugAssign operations."""
-# pylint: disable=missing-module-docstring, too-few-public-methods, missing-class-docstring, invalid-name
+"""Tests that no-member is not emitted for value-less annotations in relation
+   to AugAssign operations.
+"""
+# pylint: disable=too-few-public-methods, missing-class-docstring, invalid-name
+
 
 # Test for: https://github.com/pylint-dev/pylint/issues/4562
 class A:
     value: int
 
+
 obj_a = A()
-obj_a.value += 1  # [no-member]
+obj_a.value += 1
 
 
 class B:
     value: int
 
+
 obj_b = B()
-obj_b.value = 1 + obj_b.value  # [no-member]
+obj_b.value = 1 + obj_b.value
 
 
 class C:
@@ -21,5 +26,5 @@ class C:
 
 
 obj_c = C()
-obj_c.value += 1  # [no-member]
-obj_c.value = 1 + obj_c.value  # [no-member]
+obj_c.value += 1
+obj_c.value = 1 + obj_c.value

--- a/tests/functional/n/no/no_member_augassign.py
+++ b/tests/functional/n/no/no_member_augassign.py
@@ -10,7 +10,7 @@ class A:
 
 
 obj_a = A()
-obj_a.value += 1
+obj_a.value += 1  # [no-member]
 
 
 class B:

--- a/tests/functional/n/no/no_member_augassign.txt
+++ b/tests/functional/n/no/no_member_augassign.txt
@@ -1,4 +1,0 @@
-no-member:9:0:9:11::Instance of 'A' has no 'value' member:INFERENCE
-no-member:16:18:16:29::Instance of 'B' has no 'value' member:INFERENCE
-no-member:24:0:24:11::Instance of 'C' has no 'value' member:INFERENCE
-no-member:25:18:25:29::Instance of 'C' has no 'value' member:INFERENCE

--- a/tests/functional/n/no/no_member_augassign.txt
+++ b/tests/functional/n/no/no_member_augassign.txt
@@ -1,0 +1,1 @@
+no-member:13:0:13:11::Instance of 'A' has no 'value' member:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->
Fix a false positive for ``no-member`` when accessing a no-value attribute that is annotated in a class body.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8759
