### PR TITLE
Fix a crash when calling `copy.copy()` without args

### DIFF
--- a/doc/user_guide/installation/ide_integration/index.rst
+++ b/doc/user_guide/installation/ide_integration/index.rst
@@ -40,7 +40,7 @@ Below you can find tutorials for some of the most common ones.
 .. _Sublime Text: https://packagecontrol.io/packages/SublimeLinter-pylint
 .. _Vim: https://www.vim.org/scripts/script.php?script_id=891
 .. _Visual Studio: https://docs.microsoft.com/visualstudio/python/code-pylint
-.. _Visual Studio Code: https://code.visualstudio.com/docs/python/linting#_pylint
+.. _Visual Studio Code: https://code.visualstudio.com/docs/python/linting
 .. _Visual Studio Code Pylint Extension: https://marketplace.visualstudio.com/items?itemName=ms-python.pylint
 .. _WingIDE: https://wingware.com/doc/warnings/external-checkers
 

--- a/doc/whatsnew/fragments/8774.bugfix
+++ b/doc/whatsnew/fragments/8774.bugfix
@@ -1,0 +1,3 @@
+Fixed a crash when calling ``copy.copy()`` without arguments.
+
+Closes #8774

--- a/tests/functional/s/shallow_copy_environ.py
+++ b/tests/functional/s/shallow_copy_environ.py
@@ -27,3 +27,11 @@ import copy
 import os
 
 copy.deepcopy(os.environ)
+
+# Edge cases
+copy.copy()  # [no-value-for-parameter]
+copy.copy(x=test_dict)
+copy.copy(x=os.environ)  # [shallow-copy-environ]
+copy.copy(**{"x": os.environ})  # [shallow-copy-environ]
+copy.copy(**{"y": os.environ})  # [unexpected-keyword-arg]
+copy.copy(y=os.environ)  # [no-value-for-parameter, unexpected-keyword-arg]

--- a/tests/functional/s/shallow_copy_environ.txt
+++ b/tests/functional/s/shallow_copy_environ.txt
@@ -1,2 +1,8 @@
-shallow-copy-environ:7:0:7:21::Using copy.copy(os.environ). Use os.environ.copy() instead.:UNDEFINED
-shallow-copy-environ:17:0:17:18::Using copy.copy(os.environ). Use os.environ.copy() instead.:UNDEFINED
+shallow-copy-environ:7:0:7:21::Using copy.copy(os.environ). Use os.environ.copy() instead.:HIGH
+shallow-copy-environ:17:0:17:18::Using copy.copy(os.environ). Use os.environ.copy() instead.:HIGH
+no-value-for-parameter:32:0:32:11::No value for argument 'x' in function call:UNDEFINED
+shallow-copy-environ:34:0:34:23::Using copy.copy(os.environ). Use os.environ.copy() instead.:HIGH
+shallow-copy-environ:35:0:35:30::Using copy.copy(os.environ). Use os.environ.copy() instead.:INFERENCE
+unexpected-keyword-arg:36:0:36:30::Unexpected keyword argument 'y' in function call:UNDEFINED
+no-value-for-parameter:37:0:37:23::No value for argument 'x' in function call:UNDEFINED
+unexpected-keyword-arg:37:0:37:23::Unexpected keyword argument 'y' in function call:UNDEFINED


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Closes #8774