### PR TITLE
Skip codecov uploads on forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,6 +83,7 @@ jobs:
 
   coverage:
     name: process / coverage
+    if: github.repository_owner == 'pylint-dev'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: tests-linux


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Prevents [failures](https://github.com/jacobtylerwalls/pylint/actions/runs/5350620476/jobs/9703599437) on forks like
```
[2023-06-22T21:57:58.791Z] ['verbose'] The error stack is: Error: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Could not find a repository, try using repo upload token', code='not_found')}
```

I don't think it should be required to set up a repo with CodeCov to fork pylint. WDYT?