### PR TITLE
Emit assignment-from-no-return for builtin methods like dict.update()

### DIFF
--- a/doc/whatsnew/fragments/8714.false_negative
+++ b/doc/whatsnew/fragments/8714.false_negative
@@ -1,3 +1,6 @@
-Emit ``assignment-from-none`` for calls to builtin methods like ``dict.update()``.
+Emit ``assignment-from-no-return`` for calls to builtin methods like ``dict.update()``.
+(Calls to ``list.sort()`` now raise ``assignment-from-no-return``
+rather than ``assignment-from-none`` for consistency.)
 
 Closes #8714
+Closes #8810

--- a/doc/whatsnew/fragments/8714.false_negative
+++ b/doc/whatsnew/fragments/8714.false_negative
@@ -1,5 +1,6 @@
 Emit ``assignment-from-no-return`` for calls to builtin methods like ``dict.update()``.
-(Calls to ``list.sort()`` now raise ``assignment-from-no-return``
-rather than ``assignment-from-none`` for consistency.)
+Calls to ``list.sort()`` now raise ``assignment-from-no-return``
+rather than ``assignment-from-none`` for consistency.
 
-Closes #8714, #8810
+Closes #8714
+Closes #8810

--- a/doc/whatsnew/fragments/8714.false_negative
+++ b/doc/whatsnew/fragments/8714.false_negative
@@ -2,5 +2,4 @@ Emit ``assignment-from-no-return`` for calls to builtin methods like ``dict.upda
 (Calls to ``list.sort()`` now raise ``assignment-from-no-return``
 rather than ``assignment-from-none`` for consistency.)
 
-Closes #8714
-Closes #8810
+Closes #8714, #8810

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -74,7 +74,7 @@ TYPE_ANNOTATION_NODES_TYPES = (
     nodes.Arguments,
     nodes.FunctionDef,
 )
-BUILTINS_RETURN_NONE = {
+BUILTINS_IMPLICIT_RETURN_NONE = {
     "builtins.dict": {"clear", "update"},
     "builtins.list": {
         "append",
@@ -1278,7 +1278,9 @@ accessed. Python regular expressions are accepted.",
 
         # Handle builtins such as list.sort() or dict.update()
         if self._is_builtin_no_return(node):
-            self.add_message("assignment-from-none", node=node, confidence=INFERENCE)
+            self.add_message(
+                "assignment-from-no-return", node=node, confidence=INFERENCE
+            )
             return
 
         if not function_node.root().fully_defined():
@@ -1319,7 +1321,7 @@ accessed. Python regular expressions are accepted.",
             and bool(inferred := utils.safe_infer(node.value.func.expr))
             and isinstance(inferred, bases.Instance)
             and node.value.func.attrname
-            in BUILTINS_RETURN_NONE.get(inferred.pytype(), ())
+            in BUILTINS_IMPLICIT_RETURN_NONE.get(inferred.pytype(), ())
         )
 
     def _check_dundername_is_string(self, node: nodes.Assign) -> None:

--- a/tests/functional/a/assignment/assignment_from_no_return_2.py
+++ b/tests/functional/a/assignment/assignment_from_no_return_2.py
@@ -32,11 +32,11 @@ def func_implicit_return_none():
 A = func_implicit_return_none()  # [assignment-from-none]
 
 lst = [3, 2]
-A = lst.sort()  # [assignment-from-none]
+A = lst.sort()  # [assignment-from-no-return]
 my_dict = {3: 2}
-B = my_dict.update({2: 1})  # [assignment-from-none]
+B = my_dict.update({2: 1})  # [assignment-from-no-return]
 my_set = set()
-C = my_set.symmetric_difference_update([6])  # [assignment-from-none]
+C = my_set.symmetric_difference_update([6])  # [assignment-from-no-return]
 
 def func_return_none_and_smth():
     """function returning none and something else"""

--- a/tests/functional/a/assignment/assignment_from_no_return_2.txt
+++ b/tests/functional/a/assignment/assignment_from_no_return_2.txt
@@ -1,6 +1,6 @@
 assignment-from-no-return:17:0:17:20::Assigning result of a function call, where the function has no return:UNDEFINED
 assignment-from-none:25:0:25:22::Assigning result of a function call, where the function returns None:UNDEFINED
 assignment-from-none:32:0:32:31::Assigning result of a function call, where the function returns None:UNDEFINED
-assignment-from-none:35:0:35:14::Assigning result of a function call, where the function returns None:INFERENCE
-assignment-from-none:37:0:37:26::Assigning result of a function call, where the function returns None:INFERENCE
-assignment-from-none:39:0:39:43::Assigning result of a function call, where the function returns None:INFERENCE
+assignment-from-no-return:35:0:35:14::Assigning result of a function call, where the function has no return:INFERENCE
+assignment-from-no-return:37:0:37:26::Assigning result of a function call, where the function has no return:INFERENCE
+assignment-from-no-return:39:0:39:43::Assigning result of a function call, where the function has no return:INFERENCE


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Follow-up to 32effc5dab2288ca15c4f1638389f60087a1504f.

Since we won't be merging `assignment-from-no-return` with `assignment-from-none`, we should emit the correct message for builtins like `list.sort()` and `dict.update()`. Only `list.sort()` is a behavior change from stable versions.

Closes #8810