### PR TITLE
Observe specific enables/disables even if followed by "all"

### DIFF
--- a/doc/whatsnew/fragments/3696.breaking
+++ b/doc/whatsnew/fragments/3696.breaking
@@ -1,0 +1,13 @@
+Enabling or disabling individual messages will now take effect even if an
+``--enable=all`` or ``disable=all`` follows in the same configuration file
+(or on the command line).
+
+This means for the following example, ``fixme`` messages will now be emitted::
+
+.. code-block::
+
+    pylint my_module --enable=fixme --disable=all
+
+To regain the prior behavior, remove the superfluous earlier option.
+
+Closes #3696

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -156,13 +156,13 @@ def _config_initialization(
     )
 
 
-def _order_all_first(config_args: list[str], *, joined: bool = True) -> list[str]:
+def _order_all_first(config_args: list[str], *, joined: bool) -> list[str]:
     """Reorder config_args such that --enable=all or --disable=all comes first.
 
     Raise if both are given.
 
-    If joined is True, expect args in the form `--enable=all,for-any-all`.
-    If joined is False, expect args in the form '--enable', 'all,for-any-all`.
+    If joined is True, expect args in the form '--enable=all,for-any-all'.
+    If joined is False, expect args in the form '--enable', 'all,for-any-all'.
     """
     indexes_to_prepend = []
     all_action = ""
@@ -184,18 +184,17 @@ def _order_all_first(config_args: list[str], *, joined: bool = True) -> list[str
                 "--enable=all and --disable=all are incompatible."
             )
         all_action = arg
+
         indexes_to_prepend.append(i)
+        if not joined:
+            indexes_to_prepend.append(i + 1)
 
     returned_args = []
     for i in indexes_to_prepend:
         returned_args.append(config_args[i])
-        if not joined:
-            returned_args.append(config_args[i + 1])
 
     for i, arg in enumerate(config_args):
         if i in indexes_to_prepend:
-            continue
-        if not joined and i - 1 in indexes_to_prepend:
             continue
         returned_args.append(arg)
 

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING
 
 from pylint import reporters
 from pylint.config.config_file_parser import _ConfigurationFileParser
-from pylint.config.exceptions import _UnrecognizedOptionError
+from pylint.config.exceptions import (
+    ArgumentPreprocessingError,
+    _UnrecognizedOptionError,
+)
 from pylint.utils import utils
 
 if TYPE_CHECKING:
@@ -46,6 +49,9 @@ def _config_initialization(
         print(ex, file=sys.stderr)
         sys.exit(32)
 
+    # Order --enable=all or --disable=all to come first.
+    config_args = _order_all_first(config_args, joined=False)
+
     # Run init hook, if present, before loading plugins
     if "init-hook" in config_data:
         exec(utils._unquote(config_data["init-hook"]))  # pylint: disable=exec-used
@@ -73,6 +79,7 @@ def _config_initialization(
 
     # Now we parse any options from the command line, so they can override
     # the configuration file
+    args_list = _order_all_first(args_list, joined=True)
     parsed_args_list = linter._parse_command_line_configuration(args_list)
 
     # Remove the positional arguments separator from the list of arguments if it exists
@@ -147,3 +154,49 @@ def _config_initialization(
             for arg in parsed_args_list
         )
     )
+
+
+def _order_all_first(config_args: list[str], *, joined: bool = True) -> list[str]:
+    """Reorder config_args such that --enable=all or --disable=all comes first.
+
+    Raise if both are given.
+
+    If joined is True, expect args in the form `--enable=all,for-any-all`.
+    If joined is False, expect args in the form '--enable', 'all,for-any-all`.
+    """
+    indexes_to_prepend = []
+    all_action = ""
+
+    for i, arg in enumerate(config_args):
+        if joined and (arg.startswith("--enable=") or arg.startswith("--disable=")):
+            value = arg.split("=")[1]
+        elif arg in {"--enable", "--disable"}:
+            value = config_args[i + 1]
+        else:
+            continue
+
+        if "all" not in (msg.strip() for msg in value.split(",")):
+            continue
+
+        arg = arg.split("=")[0]
+        if all_action and (arg != all_action):
+            raise ArgumentPreprocessingError(
+                "--enable=all and --disable=all are incompatible."
+            )
+        all_action = arg
+        indexes_to_prepend.append(i)
+
+    returned_args = []
+    for i in indexes_to_prepend:
+        returned_args.append(config_args[i])
+        if not joined:
+            returned_args.append(config_args[i + 1])
+
+    for i, arg in enumerate(config_args):
+        if i in indexes_to_prepend:
+            continue
+        if not joined and i - 1 in indexes_to_prepend:
+            continue
+        returned_args.append(arg)
+
+    return returned_args

--- a/tests/config/functional/toml/toml_with_mutually_exclusive_disable_enable_all.toml
+++ b/tests/config/functional/toml/toml_with_mutually_exclusive_disable_enable_all.toml
@@ -1,0 +1,3 @@
+[tool.pylint."messages control"]
+disable = "all"
+enable = "all"

--- a/tests/config/functional/toml/toml_with_specific_disable_before_enable_all.toml
+++ b/tests/config/functional/toml/toml_with_specific_disable_before_enable_all.toml
@@ -1,0 +1,3 @@
+[tool.pylint."messages control"]
+disable = "fixme"
+enable = "all"

--- a/tests/config/functional/toml/toml_with_specific_enable_before_disable_all.toml
+++ b/tests/config/functional/toml/toml_with_specific_enable_before_disable_all.toml
@@ -1,0 +1,3 @@
+[tool.pylint."messages control"]
+enable = "fixme"
+disable = "all"

--- a/tests/config/test_functional_config_loading.py
+++ b/tests/config/test_functional_config_loading.py
@@ -43,6 +43,11 @@ CONFIGURATION_PATHS = [
     str(path.relative_to(FUNCTIONAL_DIR))
     for ext in ACCEPTED_CONFIGURATION_EXTENSIONS
     for path in FUNCTIONAL_DIR.rglob(f"*.{ext}")
+    if (str_path := str(path))
+    # The enable/disable all tests are not practical with this framework.
+    # They require manually listing ~400 messages, which will
+    # require constant updates.
+    and "enable_all" not in str_path and "disable_all" not in str_path
 ]
 
 

--- a/tests/regrtest_data/fixme.py
+++ b/tests/regrtest_data/fixme.py
@@ -1,0 +1,1 @@
+# TODO: implement

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -266,7 +266,7 @@ class TestRunTC:
         """
         )
         self._test_output(
-            [module, "--disable=all", "--enable=all", "-rn"], expected_output=expected
+            [module, "--disable=I", "--enable=all", "-rn"], expected_output=expected
         )
 
     def test_wrong_import_position_when_others_disabled(self) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |

## Description
Let individual enables/disables take effect even if followed by `--enable=all` or `--disable=all`. Previously, this was order-specific, which is tolerable on the CLI but inconvenient for configuration files.

This means that for:
```
pylint my_module --enable=fixme --disable=all
```
...you'll now get the fixme messages, whereas before, you'd have to reverse the order of the arguments.  (If the new result is not what you want, you can get the prior behavior by removing the superfluous first argument.)

Order-dependence still applies for message categories such as "R", "W", etc. This PR just moves the `=all` arguments to the front.

Providing both `--enable=all` and `--disable=all` in any order now raises an exception.

Closes #3696