### PR TITLE
Fix cyclic import edge exclusion with `--jobs`

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -488,15 +488,23 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
             for cycle in get_cycles(graph, vertices=vertices):
                 self.add_message("cyclic-import", args=" -> ".join(cycle))
 
-    def get_map_data(self) -> defaultdict[str, set[str]]:
-        return self.import_graph
+    def get_map_data(
+        self,
+    ) -> tuple[defaultdict[str, set[str]], defaultdict[str, set[str]]]:
+        return (self.import_graph, self._excluded_edges)
 
     def reduce_map_data(
-        self, linter: PyLinter, data: list[defaultdict[str, set[str]]]
+        self,
+        linter: PyLinter,
+        data: list[tuple[defaultdict[str, set[str]], defaultdict[str, set[str]]]],
     ) -> None:
         self.import_graph = defaultdict(set)
-        for graph in data:
+        self._excluded_edges = defaultdict(set)
+        for to_update in data:
+            graph, excluded_edges = to_update
             self.import_graph.update(graph)
+            self._excluded_edges.update(excluded_edges)
+
         self.close()
 
     def deprecated_modules(self) -> set[str]:

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -655,3 +655,30 @@ class TestCheckParallel:
             )
 
         assert "cyclic-import" in linter.stats.by_msg
+
+    @pytest.mark.needs_two_cores
+    def test_cyclic_import_parallel_disabled(self) -> None:
+        tests_dir = Path("tests")
+        package_path = Path("input") / "func_noerror_cycle"
+        linter = PyLinter(reporter=Reporter())
+        linter.register_checker(ImportsChecker(linter))
+
+        with _test_cwd(tests_dir):
+            check_parallel(
+                linter,
+                jobs=2,
+                files=[
+                    FileItem(
+                        name="input.func_noerror_cycle.a",
+                        filepath=str(package_path / "a.py"),
+                        modpath="input.func_noerror_cycle",
+                    ),
+                    FileItem(
+                        name="input.func_noerror_cycle.b",
+                        filepath=str(package_path / "b.py"),
+                        modpath="input.func_noerror_cycle",
+                    ),
+                ],
+            )
+
+        assert "cyclic-import" not in linter.stats.by_msg


### PR DESCRIPTION

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Follow-up to bf8051b632afdba6792e55c20faec712b0ebebaf. I need to also combine the data collected during the multiprocessing about excluded edges. I wondered about this during development but unfortunately didn't fully test it.

(Sorry for all the PR volume! It won't be like this forever. No rush on the reviews.)