### PR TITLE
Upgrade astroid to 3.0.0a6

### DIFF
--- a/examples/custom.py
+++ b/examples/custom.py
@@ -56,7 +56,7 @@ class MyAstroidChecker(BaseChecker):
             and node.func.attrname == "create"
         ):
             return
-        in_class = node.frame(future=True)
+        in_class = node.frame()
         for param in node.args:
             in_class.locals[param.name] = node
 

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -390,7 +390,7 @@ class BasicChecker(_BasicChecker):
         assert isinstance(test, nodes.Name)
         emit = False
         maybe_generator_call = None
-        lookup_result = test.frame(future=True).lookup(test.name)
+        lookup_result = test.frame().lookup(test.name)
         if not lookup_result:
             return emit, maybe_generator_call
         maybe_generator_assigned = (
@@ -717,7 +717,7 @@ class BasicChecker(_BasicChecker):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
             # locals nor globals scope)
-            if not (name in node.frame(future=True) or name in node.root()):
+            if not (name in node.frame() or name in node.root()):
                 if name == "exec":
                     self.add_message("exec-used", node=node)
                 elif name == "reversed":

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -249,7 +249,7 @@ class BasicErrorChecker(_BasicChecker):
             # PEP 448 unpacking.
             return
 
-        stmt = node.statement(future=True)
+        stmt = node.statement()
         if not isinstance(stmt, nodes.Assign):
             return
 
@@ -356,7 +356,7 @@ class BasicErrorChecker(_BasicChecker):
 
     @utils.only_required_for_messages("return-outside-function")
     def visit_return(self, node: nodes.Return) -> None:
-        if not isinstance(node.frame(future=True), nodes.FunctionDef):
+        if not isinstance(node.frame(), nodes.FunctionDef):
             self.add_message("return-outside-function", node=node)
 
     @utils.only_required_for_messages("yield-outside-function")
@@ -469,7 +469,7 @@ class BasicErrorChecker(_BasicChecker):
             )
 
     def _check_yield_outside_func(self, node: nodes.Yield) -> None:
-        if not isinstance(node.frame(future=True), (nodes.FunctionDef, nodes.Lambda)):
+        if not isinstance(node.frame(), (nodes.FunctionDef, nodes.Lambda)):
             self.add_message("yield-outside-function", node=node)
 
     def _check_else_on_loop(self, node: nodes.For | nodes.While) -> None:
@@ -509,7 +509,7 @@ class BasicErrorChecker(_BasicChecker):
         self, redeftype: str, node: nodes.Call | nodes.FunctionDef
     ) -> None:
         """Check for redefinition of a function / method / class name."""
-        parent_frame = node.parent.frame(future=True)
+        parent_frame = node.parent.frame()
 
         # Ignore function stubs created for type information
         redefinitions = [

--- a/pylint/checkers/base/docstring_checker.py
+++ b/pylint/checkers/base/docstring_checker.py
@@ -123,15 +123,15 @@ class DocStringChecker(_BasicChecker):
             ):
                 return
 
-            if isinstance(node.parent.frame(future=True), nodes.ClassDef):
+            if isinstance(node.parent.frame(), nodes.ClassDef):
                 overridden = False
                 confidence = (
                     interfaces.INFERENCE
-                    if utils.has_known_bases(node.parent.frame(future=True))
+                    if utils.has_known_bases(node.parent.frame())
                     else interfaces.INFERENCE_FAILURE
                 )
                 # check if node is from a method overridden by its ancestor
-                for ancestor in node.parent.frame(future=True).ancestors():
+                for ancestor in node.parent.frame().ancestors():
                     if ancestor.qname() == "builtins.object":
                         continue
                     if node.name in ancestor and isinstance(
@@ -142,7 +142,7 @@ class DocStringChecker(_BasicChecker):
                 self._check_docstring(
                     ftype, node, report_missing=not overridden, confidence=confidence  # type: ignore[arg-type]
                 )
-            elif isinstance(node.parent.frame(future=True), nodes.Module):
+            elif isinstance(node.parent.frame(), nodes.Module):
                 self._check_docstring(ftype, node)  # type: ignore[arg-type]
             else:
                 return

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -370,11 +370,11 @@ class NameChecker(_BasicChecker):
         # of a base class method.
         confidence = interfaces.HIGH
         if node.is_method():
-            if utils.overrides_a_method(node.parent.frame(future=True), node.name):
+            if utils.overrides_a_method(node.parent.frame(), node.name):
                 return
             confidence = (
                 interfaces.INFERENCE
-                if utils.has_known_bases(node.parent.frame(future=True))
+                if utils.has_known_bases(node.parent.frame())
                 else interfaces.INFERENCE_FAILURE
             )
 
@@ -402,7 +402,7 @@ class NameChecker(_BasicChecker):
         self, node: nodes.AssignName
     ) -> None:
         """Check module level assigned names."""
-        frame = node.frame(future=True)
+        frame = node.frame()
         assign_type = node.assign_type()
 
         # Check names defined in comprehensions

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -507,7 +507,7 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
         elif isinstance(node.parent, nodes.Module):
             prev_line = 0
         else:
-            prev_line = node.parent.statement(future=True).fromlineno
+            prev_line = node.parent.statement().fromlineno
         line = node.fromlineno
         assert line, node
         if prev_line == line and self._visited_lines.get(line) != 2:

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -985,7 +985,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         ) and not self.linter.is_message_enabled("shadowed-import"):
             return
 
-        frame = node.frame(future=True)
+        frame = node.frame()
         root = node.root()
         contexts = [(frame, level)]
         if root is not frame:

--- a/pylint/checkers/newstyle.py
+++ b/pylint/checkers/newstyle.py
@@ -53,7 +53,7 @@ class NewStyleConflictChecker(BaseChecker):
         # ignore actual functions or method within a new style class
         if not node.is_method():
             return
-        klass = node.parent.frame(future=True)
+        klass = node.parent.frame()
         for stmt in node.nodes_of_class(nodes.Call):
             if node_frame_class(stmt) != node_frame_class(node):
                 # Don't look down in other scopes.

--- a/pylint/checkers/refactoring/not_checker.py
+++ b/pylint/checkers/refactoring/not_checker.py
@@ -61,7 +61,7 @@ class NotChecker(checkers.BaseChecker):
             if operator not in self.reverse_op:
                 return
             # Ignore __ne__ as function of __eq__
-            frame = node.frame(future=True)
+            frame = node.frame()
             if frame.name == "__ne__" and operator == "==":
                 return
             for _type in (utils.node_type(left), utils.node_type(right)):

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -124,7 +124,7 @@ def _is_trailing_comma(tokens: list[tokenize.TokenInfo], index: int) -> bool:
 
 
 def _is_inside_context_manager(node: nodes.Call) -> bool:
-    frame = node.frame(future=True)
+    frame = node.frame()
     if not isinstance(
         frame, (nodes.FunctionDef, astroid.BoundMethod, astroid.UnboundMethod)
     ):
@@ -135,7 +135,7 @@ def _is_inside_context_manager(node: nodes.Call) -> bool:
 
 
 def _is_a_return_statement(node: nodes.Call) -> bool:
-    frame = node.frame(future=True)
+    frame = node.frame()
     for parent in node.node_ancestors():
         if parent is frame:
             break
@@ -148,7 +148,7 @@ def _is_part_of_with_items(node: nodes.Call) -> bool:
     """Checks if one of the node's parents is a ``nodes.With`` node and that the node
     itself is located somewhere under its ``items``.
     """
-    frame = node.frame(future=True)
+    frame = node.frame()
     current = node
     while current != frame:
         if isinstance(current, nodes.With):
@@ -998,7 +998,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
 
     def _check_stop_iteration_inside_generator(self, node: nodes.Raise) -> None:
         """Check if an exception of type StopIteration is raised inside a generator."""
-        frame = node.frame(future=True)
+        frame = node.frame()
         if not isinstance(frame, nodes.FunctionDef) or not frame.is_generator():
             return
         if utils.node_ignores_exception(node, StopIteration):
@@ -1176,7 +1176,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             isinstance(inferred, nodes.FunctionDef)
             and inferred.qname() == "builtins.next"
         ):
-            frame = node.frame(future=True)
+            frame = node.frame()
             # The next builtin can only have up to two
             # positional arguments and no keyword arguments
             has_sentinel_value = len(node.args) > 1
@@ -1579,9 +1579,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 or not isinstance(assignee, (nodes.AssignName, nodes.AssignAttr))
             ):
                 continue
-            stack = self._consider_using_with_stack.get_stack_for_frame(
-                node.frame(future=True)
-            )
+            stack = self._consider_using_with_stack.get_stack_for_frame(node.frame())
             varname = (
                 assignee.name
                 if isinstance(assignee, nodes.AssignName)
@@ -1610,7 +1608,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         if (
             node
             in self._consider_using_with_stack.get_stack_for_frame(
-                node.frame(future=True)
+                node.frame()
             ).values()
         ):
             # the result of this call was already assigned to a variable and will be

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -2168,7 +2168,7 @@ accessed. Python regular expressions are accepted.",
             return
 
         if getattr(inferred, "decorators", None):
-            first_decorator = astroid.helpers.safe_infer(inferred.decorators.nodes[0])
+            first_decorator = astroid.util.safe_infer(inferred.decorators.nodes[0])
             if isinstance(first_decorator, nodes.ClassDef):
                 inferred = first_decorator.instantiate_class()
             else:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -692,7 +692,7 @@ def _has_parent_of_type(
 
 
 def _no_context_variadic_keywords(node: nodes.Call, scope: nodes.Lambda) -> bool:
-    statement = node.statement(future=True)
+    statement = node.statement()
     variadics = []
 
     if (
@@ -735,7 +735,7 @@ def _no_context_variadic(
     is_in_lambda_scope = not isinstance(scope, nodes.FunctionDef) and isinstance(
         scope, nodes.Lambda
     )
-    statement = node.statement(future=True)
+    statement = node.statement()
     for name in statement.nodes_of_class(nodes.Name):
         if name.name != variadic_name:
             continue
@@ -753,7 +753,7 @@ def _no_context_variadic(
             # so we need to go the lambda instead
             inferred_statement = inferred.parent.parent
         else:
-            inferred_statement = inferred.statement(future=True)
+            inferred_statement = inferred.statement()
 
         if not length and isinstance(
             inferred_statement, (nodes.Lambda, nodes.FunctionDef)
@@ -1175,9 +1175,7 @@ accessed. Python regular expressions are accepted.",
                     attr_parent = attr_node.parent
                     # Skip augmented assignments
                     try:
-                        if isinstance(
-                            attr_node.statement(future=True), nodes.AugAssign
-                        ) or (
+                        if isinstance(attr_node.statement(), nodes.AugAssign) or (
                             isinstance(attr_parent, nodes.Assign)
                             and utils.is_augmented_assign(attr_parent)[0]
                         ):

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -386,7 +386,7 @@ def is_defined_before(var_node: nodes.Name) -> bool:
             ):
                 return True
     # possibly multiple statements on the same line using semicolon separator
-    stmt = var_node.statement(future=True)
+    stmt = var_node.statement()
     _node = stmt.previous_sibling()
     lineno = stmt.fromlineno
     while _node and _node.fromlineno == lineno:
@@ -672,7 +672,7 @@ def node_frame_class(node: nodes.NodeNG) -> nodes.ClassDef | None:
     The function returns a class for a method node (or a staticmethod or a
     classmethod), otherwise it returns `None`.
     """
-    klass = node.frame(future=True)
+    klass = node.frame()
     nodes_to_check = (
         nodes.NodeNG,
         astroid.UnboundMethod,
@@ -686,14 +686,14 @@ def node_frame_class(node: nodes.NodeNG) -> nodes.ClassDef | None:
         if klass.parent is None:
             return None
 
-        klass = klass.parent.frame(future=True)
+        klass = klass.parent.frame()
 
     return klass
 
 
 def get_outer_class(class_node: astroid.ClassDef) -> astroid.ClassDef | None:
     """Return the class that is the outer class of given (nested) class_node."""
-    parent_klass = class_node.parent.frame(future=True)
+    parent_klass = class_node.parent.frame()
 
     return parent_klass if isinstance(parent_klass, astroid.ClassDef) else None
 
@@ -1171,7 +1171,7 @@ def class_is_abstract(node: nodes.ClassDef) -> bool:
             return True
 
     for method in node.methods():
-        if method.parent.frame(future=True) is node:
+        if method.parent.frame() is node:
             if method.is_abstract(pass_is_abstract=False):
                 return True
     return False

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -140,7 +140,7 @@ def possible_exc_types(node: nodes.NodeNG) -> set[nodes.ClassDef]:
             for ret in target.nodes_of_class(nodes.Return):
                 if ret.value is None:
                     continue
-                if ret.frame(future=True) != target:
+                if ret.frame() != target:
                     # return from inner function - ignore it
                     continue
 

--- a/pylint/extensions/bad_builtin.py
+++ b/pylint/extensions/bad_builtin.py
@@ -54,7 +54,7 @@ class BadBuiltinChecker(BaseChecker):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
             # locals nor globals scope)
-            if not (name in node.frame(future=True) or name in node.root()):
+            if not (name in node.frame() or name in node.root()):
                 if name in self.linter.config.bad_functions:
                     hint = BUILTIN_HINTS.get(name)
                     args = f"{name!r}. {hint}" if hint else repr(name)

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -274,7 +274,7 @@ class DocstringParameterChecker(BaseChecker):
             self.add_message("redundant-yields-doc", node=node)
 
     def visit_raise(self, node: nodes.Raise) -> None:
-        func_node = node.frame(future=True)
+        func_node = node.frame()
         if not isinstance(func_node, astroid.FunctionDef):
             return
 
@@ -332,7 +332,7 @@ class DocstringParameterChecker(BaseChecker):
         if self.linter.config.accept_no_return_doc:
             return
 
-        func_node: astroid.FunctionDef = node.frame(future=True)
+        func_node: astroid.FunctionDef = node.frame()
 
         # skip functions that match the 'no-docstring-rgx' config option
         no_docstring_rgx = self.linter.config.no_docstring_rgx
@@ -358,7 +358,7 @@ class DocstringParameterChecker(BaseChecker):
         if self.linter.config.accept_no_yields_doc:
             return
 
-        func_node: astroid.FunctionDef = node.frame(future=True)
+        func_node: astroid.FunctionDef = node.frame()
 
         # skip functions that match the 'no-docstring-rgx' config option
         no_docstring_rgx = self.linter.config.no_docstring_rgx

--- a/pylint/extensions/no_self_use.py
+++ b/pylint/extensions/no_self_use.py
@@ -80,7 +80,7 @@ class NoSelfUseChecker(BaseChecker):
             first = self._first_attrs.pop()
             if first is None:
                 return
-            class_node = node.parent.frame(future=True)
+            class_node = node.parent.frame()
             if (
                 self._meth_could_be_func
                 and node.type == "method"

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -190,8 +190,8 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         if hasattr(node, "_handled"):
             return
         node._handled = True
-        if node.name in node.frame(future=True):
-            frame = node.frame(future=True)
+        if node.name in node.frame():
+            frame = node.frame()
         else:
             # the name has been defined as 'global' in the frame and belongs
             # there.

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -111,7 +111,7 @@ def diff_string(old: int | float, new: int | float) -> str:
 
 def get_module_and_frameid(node: nodes.NodeNG) -> tuple[str, str]:
     """Return the module name and the frame id in the module."""
-    frame = node.frame(future=True)
+    frame = node.frame()
     module, obj = "", []
     while frame:
         if isinstance(frame, Module):
@@ -119,7 +119,7 @@ def get_module_and_frameid(node: nodes.NodeNG) -> tuple[str, str]:
         else:
             obj.append(getattr(frame, "name", "<lambda>"))
         try:
-            frame = frame.parent.frame(future=True)
+            frame = frame.parent.frame()
         except AttributeError:
             break
     obj.reverse()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.0.0a6,<=3.1.0-dev0",
+    "astroid @ git+https://github.com/pylint-dev/astroid.git@a7ab0880dea776e45c4c7e440298c4041d945e6d",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.0.0a5,<=3.1.0-dev0",
+    "astroid>=3.0.0a6,<=3.1.0-dev0",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.0.0a5  # Pinned to a specific version for tests
+astroid==3.0.0a6  # Pinned to a specific version for tests
 typing-extensions~=4.7
 py~=1.11.0
 pytest~=7.4

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.0.0a6  # Pinned to a specific version for tests
+astroid @ git+https://github.com/pylint-dev/astroid.git@a7ab0880dea776e45c4c7e440298c4041d945e6d
 typing-extensions~=4.7
 py~=1.11.0
 pytest~=7.4


### PR DESCRIPTION

## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description
Prerequisite for adding Python 3.12 compatibility. 3.12 CI jobs will be added later in #8718.

Skipping news because we have several pre-releases to go before announcing the astroid version to be used for 3.0 final.