### PR TITLE
[primer] Skip regenerate cache step for cache hits

### DIFF
--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -78,6 +78,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-${{
             steps.commitstring.outputs.commitstring }}-primer
       - name: Regenerate cache
+        if: steps.cache-projects.outputs.cache-hit != 'true'
         run: |
           . venv/bin/activate
           python tests/primer/__main__.py prepare --clone


### PR DESCRIPTION
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
If there's a cache hit on the primer projects, don't clone them again. Saves a few seconds. I don't expect that this is the source of any commit drift between the step that creates the commit string and this one, but it can't hurt to skip this step and be _sure_ there's no source of drift here.

[Example](https://github.com/jacobtylerwalls/pylint/actions/runs/5495063672/jobs/10016521468) of this working.