### PR TITLE
Optimize parallel runs when `cyclic-import` disabled

### DIFF
--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -498,14 +498,15 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         linter: PyLinter,
         data: list[tuple[defaultdict[str, set[str]], defaultdict[str, set[str]]]],
     ) -> None:
-        self.import_graph = defaultdict(set)
-        self._excluded_edges = defaultdict(set)
-        for to_update in data:
-            graph, excluded_edges = to_update
-            self.import_graph.update(graph)
-            self._excluded_edges.update(excluded_edges)
+        if self.linter.is_message_enabled("cyclic-import"):
+            self.import_graph = defaultdict(set)
+            self._excluded_edges = defaultdict(set)
+            for to_update in data:
+                graph, excluded_edges = to_update
+                self.import_graph.update(graph)
+                self._excluded_edges.update(excluded_edges)
 
-        self.close()
+            self.close()
 
     def deprecated_modules(self) -> set[str]:
         """Callback returning the deprecated modules."""

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -491,7 +491,9 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
     def get_map_data(
         self,
     ) -> tuple[defaultdict[str, set[str]], defaultdict[str, set[str]]]:
-        return (self.import_graph, self._excluded_edges)
+        if self.linter.is_message_enabled("cyclic-import"):
+            return (self.import_graph, self._excluded_edges)
+        return (defaultdict(set), defaultdict(set))
 
     def reduce_map_data(
         self,

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -36,6 +36,7 @@ from pylint.utils import LinterStats, ModuleStats
 
 if TYPE_CHECKING:
     from astroid import nodes
+    from unittest.mock import MagicMock
 
 
 def _gen_file_data(idx: int = 0) -> FileItem:
@@ -658,7 +659,7 @@ class TestCheckParallel:
 
     @pytest.mark.needs_two_cores
     @patch("pylint.checkers.imports.ImportsChecker.close")
-    def test_cyclic_import_parallel_disabled_globally(self, mock) -> None:
+    def test_cyclic_import_parallel_disabled_globally(self, mock: MagicMock) -> None:
         tests_dir = Path("tests")
         package_path = Path("input") / "func_w0401_package"
         linter = PyLinter(reporter=Reporter())

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -657,7 +657,37 @@ class TestCheckParallel:
         assert "cyclic-import" in linter.stats.by_msg
 
     @pytest.mark.needs_two_cores
-    def test_cyclic_import_parallel_disabled(self) -> None:
+    @patch("pylint.checkers.imports.ImportsChecker.close")
+    def test_cyclic_import_parallel_disabled_globally(self, mock) -> None:
+        tests_dir = Path("tests")
+        package_path = Path("input") / "func_w0401_package"
+        linter = PyLinter(reporter=Reporter())
+        linter.register_checker(ImportsChecker(linter))
+        linter.disable("cyclic-import")
+
+        with _test_cwd(tests_dir):
+            check_parallel(
+                linter,
+                jobs=2,
+                files=[
+                    FileItem(
+                        name="input.func_w0401_package.all_the_things",
+                        filepath=str(package_path / "all_the_things.py"),
+                        modpath="input.func_w0401_package",
+                    ),
+                    FileItem(
+                        name="input.func_w0401_package.thing2",
+                        filepath=str(package_path / "thing2.py"),
+                        modpath="input.func_w0401_package",
+                    ),
+                ],
+            )
+
+        mock.assert_not_called()
+        assert "cyclic-import" not in linter.stats.by_msg
+
+    @pytest.mark.needs_two_cores
+    def test_cyclic_import_parallel_disabled_locally(self) -> None:
         tests_dir = Path("tests")
         package_path = Path("input") / "func_noerror_cycle"
         linter = PyLinter(reporter=Reporter())


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Follow-up to f815e9f5fcdd5caffc04e335fc4590a65989ef21.

Discussed at https://github.com/pylint-dev/pylint/pull/8820#issuecomment-1627530624.