### PR TITLE
Bump astroid to 2.15.6 on maintenance branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=2.15.5,<=2.17.0-dev0",
+    "astroid>=2.15.6,<=2.17.0-dev0",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 -e .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==2.15.5  # Pinned to a specific version for tests
+astroid==2.15.6  # Pinned to a specific version for tests
 typing-extensions~=4.7
 py~=1.11.0
 pytest~=7.2


### PR DESCRIPTION
Allows us to mark the astroid 2.15.6 issues as fixed in the 2.17.x maintenance branch of pylint.