### PR TITLE
Add stdlib deprecations from 3.12

### DIFF
--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -83,6 +83,10 @@ DEPRECATED_ARGUMENTS: dict[
         ),
     },
     (3, 9, 0): {"random.Random.shuffle": ((1, "random"),)},
+    (3, 12, 0): {
+        "coroutine.throw": ((1, "value"), (2, "traceback")),
+        "shutil.rmtree": ((2, "onerror"),),
+    },
 }
 
 DEPRECATED_DECORATORS: DeprecationDict = {
@@ -253,6 +257,12 @@ DEPRECATED_METHODS: dict[int, DeprecationDict] = {
             "unittest.TestLoader.loadTestsFromTestCase",
             "unittest.TestLoader.getTestCaseNames",
         },
+        (3, 12, 0): {
+            "builtins.bool.__invert__",
+            "datetime.datetime.utcfromtimestamp",
+            "datetime.datetime.utcnow",
+            "xml.etree.ElementTree.Element.__bool__",
+        },
     },
 }
 
@@ -311,6 +321,12 @@ DEPRECATED_CLASSES: dict[tuple[int, int, int], dict[str, set[str]]] = {
         },
         "webbrowser": {
             "MacOSX",
+        },
+    },
+    (3, 12, 0): {
+        "typing": {
+            "Hashable",
+            "Sized",
         },
     },
 }

--- a/tests/functional/t/try_except_raise_crash.py
+++ b/tests/functional/t/try_except_raise_crash.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring,too-many-ancestors, broad-except
 import collections.abc
-from typing import TYPE_CHECKING, Sized
+from typing import TYPE_CHECKING, Sized  # pylint: disable=deprecated-class
 
 if TYPE_CHECKING:
     BaseClass = Sized


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description
Add stdlib [deprecations from Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#deprecated). Some missing items are attributes, tracked in #8855.