### PR TITLE
Release branch for 2.17.5

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -547,6 +547,7 @@ contributors:
 - Arun Persaud <arun@nubati.net>
 - Arthur Lutz <arthur.lutz@logilab.fr>
 - Antonio Ossa <aaossa@uc.cl>
+- Antonio <antonio@zoftko.com>
 - Anthony VEREZ <anthony.verez.external@cassidian.com>
 - Anthony Tan <tanant@users.noreply.github.com>
 - Anthony Foglia <afoglia@users.noreply.github.com> (Google): Added simple string slots check.

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -233,7 +233,7 @@ Standard Checkers
 
    confidence = ["HIGH", "CONTROL_FLOW", "INFERENCE", "INFERENCE_FAILURE", "UNDEFINED"]
 
-   disable = ["raw-checker-failed", "bad-inline-option", "locally-disabled", "file-ignored", "suppressed-message", "useless-suppression", "deprecated-pragma", "use-symbolic-message-instead", "consider-using-augmented-assign"]
+   disable = ["consider-using-augmented-assign"]
 
    enable = []
 

--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -29,6 +29,81 @@ so we find problems before the actual release.
 
 .. towncrier release notes start
 
+What's new in Pylint 2.17.5?
+----------------------------
+Release date: 2023-07-26
+
+
+False Positives Fixed
+---------------------
+
+- Fix a false positive for ``unused-variable`` when there is an import in a
+  ``if TYPE_CHECKING:`` block and ``allow-global-unused-variables`` is set to
+  ``no`` in the configuration.
+
+  Closes #8696 (`#8696 <https://github.com/pylint-dev/pylint/issues/8696>`_)
+
+- Fix false positives generated when supplying arguments as ``**kwargs`` to IO
+  calls like open().
+
+  Closes #8719 (`#8719 <https://github.com/pylint-dev/pylint/issues/8719>`_)
+
+- Fix a false positive where pylint was ignoring method calls annotated as
+  ``NoReturn`` during the ``inconsistent-return-statements`` check.
+
+  Closes #8747 (`#8747 <https://github.com/pylint-dev/pylint/issues/8747>`_)
+
+- Exempt parents with only type annotations from the ``invalid-enum-extension``
+  message.
+
+  Closes #8830 (`#8830 <https://github.com/pylint-dev/pylint/issues/8830>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fixed crash when a call to ``super()`` was placed after an operator (e.g.
+  ``not``).
+
+  Closes #8554 (`#8554 <https://github.com/pylint-dev/pylint/issues/8554>`_)
+
+- Fix crash for ``modified-while-iterating`` checker when deleting
+  members of a dict returned from a call.
+
+  Closes #8598 (`#8598 <https://github.com/pylint-dev/pylint/issues/8598>`_)
+
+- Fix crash in ``invalid-metaclass`` check when a metaclass had duplicate
+  bases.
+
+  Closes #8698 (`#8698 <https://github.com/pylint-dev/pylint/issues/8698>`_)
+
+- Avoid ``consider-using-f-string`` on modulos with brackets in template.
+
+  Closes #8720. (`#8720 <https://github.com/pylint-dev/pylint/issues/8720>`_)
+
+- Fix a crash when ``__all__`` exists but cannot be inferred.
+
+  Closes #8740 (`#8740 <https://github.com/pylint-dev/pylint/issues/8740>`_)
+
+- Fix crash when a variable is assigned to a class attribute of identical name.
+
+  Closes #8754 (`#8754 <https://github.com/pylint-dev/pylint/issues/8754>`_)
+
+- Fixed a crash when calling ``copy.copy()`` without arguments.
+
+  Closes #8774 (`#8774 <https://github.com/pylint-dev/pylint/issues/8774>`_)
+
+
+
+Other Changes
+-------------
+
+- Fix a crash when a ``nonlocal`` is defined at module-level.
+
+  Closes #8735 (`#8735 <https://github.com/pylint-dev/pylint/issues/8735>`_)
+
+
 What's new in Pylint 2.17.4?
 ----------------------------
 Release date: 2023-05-06

--- a/doc/whatsnew/fragments/8554.bugfix
+++ b/doc/whatsnew/fragments/8554.bugfix
@@ -1,3 +1,0 @@
-Fixed crash when a call to ``super()`` was placed after an operator (e.g. ``not``).
-
-Closes #8554

--- a/doc/whatsnew/fragments/8598.bugfix
+++ b/doc/whatsnew/fragments/8598.bugfix
@@ -1,4 +1,0 @@
-Fix crash for ``modified-while-iterating`` checker when deleting
-members of a dict returned from a call.
-
-Closes #8598

--- a/doc/whatsnew/fragments/8696.false_positive
+++ b/doc/whatsnew/fragments/8696.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``unused-variable`` when there is an import in a ``if TYPE_CHECKING:`` block and ``allow-global-unused-variables`` is set to ``no`` in the configuration.
-
-Closes #8696

--- a/doc/whatsnew/fragments/8698.bugfix
+++ b/doc/whatsnew/fragments/8698.bugfix
@@ -1,3 +1,0 @@
-Fix crash in ``invalid-metaclass`` check when a metaclass had duplicate bases.
-
-Closes #8698

--- a/doc/whatsnew/fragments/8719.false_positive
+++ b/doc/whatsnew/fragments/8719.false_positive
@@ -1,3 +1,0 @@
-Fix false positives generated when supplying arguments as ``**kwargs`` to IO calls like open().
-
-Closes #8719

--- a/doc/whatsnew/fragments/8720.bugfix
+++ b/doc/whatsnew/fragments/8720.bugfix
@@ -1,3 +1,0 @@
-Avoid ``consider-using-f-string`` on modulos with brackets in template.
-
-Closes #8720.

--- a/doc/whatsnew/fragments/8735.other
+++ b/doc/whatsnew/fragments/8735.other
@@ -1,3 +1,0 @@
-Fix a crash when a ``nonlocal`` is defined at module-level.
-
-Closes #8735

--- a/doc/whatsnew/fragments/8740.bugfix
+++ b/doc/whatsnew/fragments/8740.bugfix
@@ -1,3 +1,0 @@
-Fix a crash when ``__all__`` exists but cannot be inferred.
-
-Closes #8740

--- a/doc/whatsnew/fragments/8747.false_positive
+++ b/doc/whatsnew/fragments/8747.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive where pylint was ignoring method calls annotated as ``NoReturn`` during the ``inconsistent-return-statements`` check.
-
-Closes #8747

--- a/doc/whatsnew/fragments/8754.bugfix
+++ b/doc/whatsnew/fragments/8754.bugfix
@@ -1,3 +1,0 @@
-Fix crash when a variable is assigned to a class attribute of identical name.
-
-Closes #8754

--- a/doc/whatsnew/fragments/8774.bugfix
+++ b/doc/whatsnew/fragments/8774.bugfix
@@ -1,3 +1,0 @@
-Fixed a crash when calling ``copy.copy()`` without arguments.
-
-Closes #8774

--- a/doc/whatsnew/fragments/8830.false_positive
+++ b/doc/whatsnew/fragments/8830.false_positive
@@ -1,4 +1,0 @@
-Exempt parents with only type annotations from the ``invalid-enum-extension``
-message.
-
-Closes #8830

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "2.17.4"
+__version__ = "2.17.5"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "2.17.4"
+current = "2.17.5"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "2.17.4"
+version = "2.17.5"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/2/2.17/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 2.17.5?
----------------------------
Release date: 2023-07-26


False Positives Fixed
---------------------

- Fix a false positive for ``unused-variable`` when there is an import in a
  ``if TYPE_CHECKING:`` block and ``allow-global-unused-variables`` is set to
  ``no`` in the configuration.

  Closes #8696 

- Fix false positives generated when supplying arguments as ``**kwargs`` to IO
  calls like open().

  Closes #8719

- Fix a false positive where pylint was ignoring method calls annotated as
  ``NoReturn`` during the ``inconsistent-return-statements`` check.

  Closes #8747

- Exempt parents with only type annotations from the ``invalid-enum-extension``
  message.

  Closes #8830



Other Bug Fixes
---------------

- Fixed crash when a call to ``super()`` was placed after an operator (e.g.
  ``not``).

  Closes #8554 

- Fix crash for ``modified-while-iterating`` checker when deleting
  members of a dict returned from a call.

  Closes #8598 

- Fix crash in ``invalid-metaclass`` check when a metaclass had duplicate
  bases.

  Closes #8698 

- Avoid ``consider-using-f-string`` on modulos with brackets in template.

  Closes #8720. 

- Fix a crash when ``__all__`` exists but cannot be inferred.

  Closes #8740

- Fix crash when a variable is assigned to a class attribute of identical name.

  Closes #8754 

- Fixed a crash when calling ``copy.copy()`` without arguments.

  Closes #8774 



Other Changes
-------------

- Fix a crash when a ``nonlocal`` is defined at module-level.

  Closes #8735 