### PR TITLE
Fix false positive when testing for-loops for unbalanced unpacking (W0644)

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2958,7 +2958,6 @@ class VariablesChecker(BaseChecker):
 
         if values is not None:
             if len(targets) != len(values):
-                breakpoint()
                 self._report_unbalanced_unpacking(
                     node, inferred, targets, values, details
                 )

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1326,9 +1326,11 @@ class VariablesChecker(BaseChecker):
             if any(isinstance(target, nodes.Starred) for target in targets):
                 return
 
-        if len(targets) != len(values):
-            details = _get_unpacking_extra_info(node, inferred)
-            self._report_unbalanced_unpacking(node, inferred, targets, values, details)
+        for value in values:
+            value_length = len(list(value.get_children()))
+            if len(targets) != value_length:
+                details = _get_unpacking_extra_info(node, inferred)
+                self._report_unbalanced_unpacking(node, inferred, targets, values, details)
 
     def leave_for(self, node: nodes.For) -> None:
         self._store_type_annotation_names(node)
@@ -2956,6 +2958,7 @@ class VariablesChecker(BaseChecker):
 
         if values is not None:
             if len(targets) != len(values):
+                breakpoint()
                 self._report_unbalanced_unpacking(
                     node, inferred, targets, values, details
                 )

--- a/tests/functional/u/unbalanced/unbalanced_dict_unpacking.py
+++ b/tests/functional/u/unbalanced/unbalanced_dict_unpacking.py
@@ -89,3 +89,33 @@ one, *others, last = {1: 2, 3: 4, 5: 6}.values()
 _, *others = {1: 2, 3: 4, 5: 6}.items()
 _, *others = {1: 2, 3: 4, 5: 6}.values()
 _, others = {1: 2, 3: 4, 5: 6}.values()  # [unbalanced-dict-unpacking]
+
+
+for value1, value2 in {1: 2, 3: 4}.values():  # [unbalanced-dict-unpacking]
+    pass
+
+for value1, value2 in {1: (2, 3), 4: 5}.values():  # [unbalanced-dict-unpacking]
+    pass
+
+for value1, value2 in {1: 2, 3: (4, 5)}.values():  # [unbalanced-dict-unpacking]
+    pass
+
+for value1, value2 in {1: (2, 3, 4), 5: (6, 7)}.values():  # [unbalanced-dict-unpacking]
+    pass
+
+for value1, value2, value3 in {1: (2, 3, 4), 5: (6, 7)}.values():  # [unbalanced-dict-unpacking]
+    pass
+
+# These should not raise unbalanced-dict since the there are two elements in every value
+for value1, value2 in {1: (2, 3), 4: (5, 6)}.values():
+    pass
+
+for value1, value2, value3 in {1: (2, 3, 4), 5: (6, 7, 8)}.values():
+    pass
+
+for value1, value2 in {1: [2, 3], 4: {5, 6}}.values():
+    pass
+
+for value1, value2 in {1: {2: 3, 4: 5}, 6: {7: 8, 9: 10}}.values():
+    pass
+

--- a/tests/functional/u/unbalanced/unbalanced_dict_unpacking.txt
+++ b/tests/functional/u/unbalanced/unbalanced_dict_unpacking.txt
@@ -14,3 +14,8 @@ unbalanced-dict-unpacking:67:0:68:14::"Possible unbalanced dict unpacking with {
 unbalanced-dict-unpacking:77:0:78:14::"Possible unbalanced dict unpacking with {'key': 'value', 1: 2, 20: 21}.values(): left side has 2 labels, right side has 3 values":INFERENCE
 unbalanced-dict-unpacking:80:0:81:14::"Possible unbalanced dict unpacking with {'key': 'value', 1: 2, 20: 21}.values(): left side has 2 labels, right side has 3 values":INFERENCE
 unbalanced-dict-unpacking:91:0:91:39::"Possible unbalanced dict unpacking with {1: 2, 3: 4, 5: 6}.values(): left side has 2 labels, right side has 3 values":INFERENCE
+unbalanced-dict-unpacking:94:0:95:8::"Possible unbalanced dict unpacking with {1: 2, 3: 4}.values(): left side has 2 labels, right side has 1 value":INFERENCE
+unbalanced-dict-unpacking:97:0:98:8::"Possible unbalanced dict unpacking with {1: (2, 3), 4: 5}.values(): left side has 2 labels, right side has 1 value":INFERENCE
+unbalanced-dict-unpacking:100:0:101:8::"Possible unbalanced dict unpacking with {1: 2, 3: (4, 5)}.values(): left side has 2 labels, right side has 1 value":INFERENCE
+unbalanced-dict-unpacking:103:0:104:8::"Possible unbalanced dict unpacking with {1: (2, 3, 4), 5: (6, 7)}.values(): left side has 2 labels, right side has 3 value":INFERENCE
+unbalanced-dict-unpacking:106:0:107:8::"Possible unbalanced dict unpacking with {1: (2, 3, 4), 5: (6, 7)}.values(): left side has 3 labels, right side has 2 value":INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR references an issue without fixing it: -->
When checking for-loops for unbalanced dict unpacking, Pylint would compare the length of the targets with the length of the values iterable. However, since the for-loop would iterate the values and unpack each value in turn, Pylint should compare the length of the targets with the length of *each value* (and not the total length of values).


Closes #8156
