### PR TITLE
[coverage] Invoke pytest as `python -m pytest` to restore coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,10 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          pytest --durations=10 --benchmark-disable --cov=. --cov-report= tests/
+          cd ..
+          INSTALLED_PATH=$(python -c 'from pathlib import Path;import pylint;print(Path(pylint.__file__).parent)')
+          cd pylint
+          pytest --durations=10 --benchmark-disable --cov=$INSTALLED_PATH --cov-report= tests/
       - name: Run functional tests with minimal messages config
         run: |
           . venv/bin/activate

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,10 +69,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          cd ..
-          INSTALLED_PATH=$(python -c 'from pathlib import Path;import pylint;print(Path(pylint.__file__).parent)')
-          cd pylint
-          pytest --durations=10 --benchmark-disable --cov=$INSTALLED_PATH --cov-report= tests/
+          python -m pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
       - name: Run functional tests with minimal messages config
         run: |
           . venv/bin/activate

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
+          pytest --durations=10 --benchmark-disable --cov=. --cov-report= tests/
       - name: Run functional tests with minimal messages config
         run: |
           . venv/bin/activate

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -42,7 +42,7 @@ clean:
 
 install-dependencies:
 	@echo "Install dependencies"
-	cd ../ && $(PIP) install -r doc/requirements.txt && cd doc/
+	cd ../ && $(PIP) install . && $(PIP) install -r doc/requirements.txt && cd doc/
 
 build-html:
 	@echo "If you did not run 'make install-dependencies', you need to."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -42,7 +42,7 @@ clean:
 
 install-dependencies:
 	@echo "Install dependencies"
-	cd ../ && $(PIP) install . && $(PIP) install -r doc/requirements.txt && cd doc/
+	cd ../ && $(PIP) install -r doc/requirements.txt && cd doc/
 
 build-html:
 	@echo "If you did not run 'make install-dependencies', you need to."

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,7 +28,8 @@ sys.path.append(os.path.abspath(".."))
 
 # pylint: disable=wrong-import-position
 from pylint import __version__  # noqa: E402
-from pylint.__pkginfo__ import numversion   # noqa: E402
+from pylint.__pkginfo__ import numversion  # noqa: E402
+
 # pylint: enable=wrong-import-position
 
 # -- General configuration -----------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,9 +8,6 @@ import os
 import sys
 from datetime import datetime
 
-from pylint import __version__
-from pylint.__pkginfo__ import numversion
-
 # Pylint documentation build configuration file, created by
 # sphinx-quickstart on Thu Apr  4 20:31:25 2013.
 #
@@ -27,6 +24,10 @@ from pylint.__pkginfo__ import numversion
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use 'os.path.abspath' to make it absolute, like shown here.
 sys.path.append(os.path.abspath("exts"))
+sys.path.append(os.path.abspath(".."))
+
+from pylint import __version__
+from pylint.__pkginfo__ import numversion
 
 # -- General configuration -----------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,8 +26,10 @@ from datetime import datetime
 sys.path.append(os.path.abspath("exts"))
 sys.path.append(os.path.abspath(".."))
 
-from pylint import __version__
-from pylint.__pkginfo__ import numversion
+# pylint: disable=wrong-import-position
+from pylint import __version__  # noqa: E402
+from pylint.__pkginfo__ import numversion   # noqa: E402
+# pylint: enable=wrong-import-position
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #8878. Ideally this will restore the codecov calculations.