### PR TITLE
Cope with removal of `EnumType.__getattr__` in 3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          pytest -vv --minimal-messages-config tests/test_functional.py
+          python -m pytest -vv --minimal-messages-config tests/test_functional.py
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -214,7 +214,7 @@ jobs:
         run: |
           . venv\\Scripts\\activate
           pip list | grep 'astroid\|pylint'
-          pytest --durations=10 --benchmark-disable tests/
+          python -m pytest --durations=10 --benchmark-disable tests/
 
   tests-macos:
     name: run / ${{ matrix.python-version }} / macOS

--- a/tests/functional/e/enum_self_defined_member_5138.rc
+++ b/tests/functional/e/enum_self_defined_member_5138.rc
@@ -1,3 +1,0 @@
-[testoptions]
-# https://github.com/python/cpython/issues/106762
-max_pyver=3.12


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Refs www.github.com/python/cpython/issues/106762