### PR TITLE
Fix false positive for ``arguments-differ``

### DIFF
--- a/doc/whatsnew/fragments/8919.false_positive
+++ b/doc/whatsnew/fragments/8919.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for ``arguments-differ`` when overriding `__init_subclass__`.
+
+Closes #8919

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -370,14 +370,6 @@ def _different_parameters(
         if different_kwonly:
             output_messages += different_kwonly
 
-    if original.name in PYMETHODS:
-        # Ignore the difference for special methods. If the parameter
-        # numbers are different, then that is going to be caught by
-        # unexpected-special-method-signature.
-        # If the names are different, it doesn't matter, since they can't
-        # be used as keyword arguments anyway.
-        output_messages.clear()
-
     # Arguments will only violate LSP if there are variadics in the original
     # that are then removed from the overridden
     kwarg_lost = original.args.kwarg and not overridden.args.kwarg
@@ -385,6 +377,14 @@ def _different_parameters(
 
     if kwarg_lost or vararg_lost:
         output_messages += ["Variadics removed in"]
+
+    if original.name in PYMETHODS:
+        # Ignore the difference for special methods. If the parameter
+        # numbers are different, then that is going to be caught by
+        # unexpected-special-method-signature.
+        # If the names are different, it doesn't matter, since they can't
+        # be used as keyword arguments anyway.
+        output_messages.clear()
 
     return output_messages
 

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -358,3 +358,13 @@ class AClass:
 class ClassWithNewNonDefaultKeywordOnly(AClass):
     def method(self, *, arg2, arg1=None):  # [arguments-differ]
         ...
+
+
+# Exclude `__init_subclass__` from the check:
+class InitSubclassParent:
+    def __init_subclass__(cls, *args, **kwargs):
+        ...
+
+class InitSubclassChild(InitSubclassParent):
+    def __init_subclass__(cls, /, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Fix false positive for ``arguments-differ`` when overriding `__init_subclass__`.

Closes #8919
