### PR TITLE
Restore editable_mode=compat analogue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,12 +69,12 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          python -m pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
+          pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
       - name: Run functional tests with minimal messages config
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          python -m pytest -vv --minimal-messages-config tests/test_functional.py
+          pytest -vv --minimal-messages-config tests/test_functional.py
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -214,7 +214,7 @@ jobs:
         run: |
           . venv\\Scripts\\activate
           pip list | grep 'astroid\|pylint'
-          python -m pytest --durations=10 --benchmark-disable tests/
+          pytest --durations=10 --benchmark-disable tests/
 
   tests-macos:
     name: run / ${{ matrix.python-version }} / macOS
@@ -260,7 +260,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          python -m pytest --durations=10 --benchmark-disable tests/
+          pytest --durations=10 --benchmark-disable tests/
 
   tests-pypy:
     name: run / ${{ matrix.python-version }} / Linux
@@ -304,4 +304,4 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          python -m pytest --durations=10 --benchmark-disable tests/
+          pytest --durations=10 --benchmark-disable tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,12 +69,12 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
+          python -m pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
       - name: Run functional tests with minimal messages config
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          pytest -vv --minimal-messages-config tests/test_functional.py
+          python -m pytest -vv --minimal-messages-config tests/test_functional.py
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -214,7 +214,7 @@ jobs:
         run: |
           . venv\\Scripts\\activate
           pip list | grep 'astroid\|pylint'
-          pytest --durations=10 --benchmark-disable tests/
+          python -m pytest --durations=10 --benchmark-disable tests/
 
   tests-macos:
     name: run / ${{ matrix.python-version }} / macOS
@@ -260,7 +260,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          pytest --durations=10 --benchmark-disable tests/
+          python -m pytest --durations=10 --benchmark-disable tests/
 
   tests-pypy:
     name: run / ${{ matrix.python-version }} / Linux
@@ -304,4 +304,4 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          pytest --durations=10 --benchmark-disable tests/
+          python -m pytest --durations=10 --benchmark-disable tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,13 @@ license-files = ["LICENSE", "CONTRIBUTORS.txt"]  # Keep in sync with setup.cfg
 [tool.setuptools.packages.find]
 include = ["pylint*"]
 
+[tool.setuptools.package-dir]
+# Simulate editable_mode=compat, described at:
+# https://github.com/pypa/setuptools/issues/3767
+# TODO: remove after solving root cause described at:
+# https://github.com/pylint-dev/astroid/pull/2267#issuecomment-1666642781
+"" = "."
+
 [tool.setuptools.package-data]
 pylint = ["testutils/testing_pylintrc", "py.typed"]
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Follow-up to 2821efbd0a119a53c5ebd88ed9e1fab661208a65.

Too much of pylint's test suite assumes the repo root is on the path. Restore this workaround for now.

cc/ @DanielNoord this will ideally allow you to run a bare `pytest` invocation as before.

Sorry for the churn; I thought we could do without this workaround, but not if every contributor has to manipulate their path or invoke pytest differently.