### PR TITLE
[base checker] Fix the ordering of checkers for extensions

### DIFF
--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -58,19 +58,14 @@ class BaseChecker(_ArgumentsProvider):
         order, then extension checkers in alphabetical order.
         """
         if not isinstance(other, BaseChecker):
-            # print(f"{other} is not a base checker.")
             return False
         if self.name == MAIN_CHECKER_NAME:
-            # print(f"{self.name} is the main checker {other.name} is not")
             return False
         if other.name == MAIN_CHECKER_NAME:
-            # print(f"{other.name} is the main checker {self.name} is not")
             return True
         self_is_builtin = type(self).__module__.startswith("pylint.checkers")
         if self_is_builtin ^ type(other).__module__.startswith("pylint.checkers"):
-            # print(f"Checkers are different {self.name} is lower if it's builtin")
             return not self_is_builtin
-        # print(f"{self.name} and {other.name} are the same type of checker, sorting by name")
         return self.name > other.name
 
     def __eq__(self, other: Any) -> bool:

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -52,17 +52,25 @@ class BaseChecker(_ArgumentsProvider):
         _ArgumentsProvider.__init__(self, linter)
 
     def __gt__(self, other: Any) -> bool:
-        """Sorting of checkers."""
+        """Permits sorting checkers for stable doc and tests.
+
+        The main checker is always the first one, then builtin checkers in alphabetical
+        order, then extension checkers in alphabetical order.
+        """
         if not isinstance(other, BaseChecker):
+            # print(f"{other} is not a base checker.")
             return False
         if self.name == MAIN_CHECKER_NAME:
+            # print(f"{self.name} is the main checker {other.name} is not")
             return False
         if other.name == MAIN_CHECKER_NAME:
+            # print(f"{other.name} is the main checker {self.name} is not")
             return True
-        if type(self).__module__.startswith("pylint.checkers") and not type(
-            other
-        ).__module__.startswith("pylint.checkers"):
-            return False
+        self_is_builtin = type(self).__module__.startswith("pylint.checkers")
+        if self_is_builtin ^ type(other).__module__.startswith("pylint.checkers"):
+            # print(f"Checkers are different {self.name} is lower if it's builtin")
+            return not self_is_builtin
+        # print(f"{self.name} and {other.name} are the same type of checker, sorting by name")
         return self.name > other.name
 
     def __eq__(self, other: Any) -> bool:

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -10,6 +10,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.imports import ImportsChecker
 from pylint.checkers.typecheck import TypeChecker
 from pylint.exceptions import InvalidMessageError
+from pylint.extensions.broad_try_clause import BroadTryClauseChecker
 from pylint.extensions.while_used import WhileChecker
 from pylint.lint.pylinter import PyLinter
 
@@ -98,36 +99,57 @@ Basic checker Messages
 def test_base_checker_ordering() -> None:
     """Test ordering of checkers based on their __gt__ method."""
     linter = PyLinter()
-    fake_checker_1 = OtherBasicChecker()
-    fake_checker_2 = LessBasicChecker()
-    fake_checker_3 = DifferentBasicChecker()
-    import_checker = ImportsChecker(linter)
-    while_checker = WhileChecker(linter)
-    type_checker = TypeChecker(linter)
+    imports_builtin = ImportsChecker(linter)
+    typecheck_builtin = TypeChecker(linter)
+    basic_1_ext = OtherBasicChecker()
+    basic_2_ext = LessBasicChecker()
+    basic_3_ext = DifferentBasicChecker()
+    while_used_ext = WhileChecker(linter)
+    broad_try_clause_ext = BroadTryClauseChecker(linter)
 
     list_of_checkers = [
         1,
-        fake_checker_1,
-        fake_checker_2,
-        fake_checker_3,
-        type_checker,
-        import_checker,
-        while_checker,
+        basic_1_ext,
+        basic_2_ext,
+        basic_3_ext,
+        typecheck_builtin,
+        broad_try_clause_ext,
+        imports_builtin,
+        while_used_ext,
         linter,
     ]
     assert sorted(list_of_checkers) == [  # type: ignore[type-var]
         linter,
-        import_checker,
-        type_checker,
-        fake_checker_3,
-        fake_checker_1,
-        fake_checker_2,
-        while_checker,
+        imports_builtin,
+        typecheck_builtin,
+        basic_3_ext,
+        basic_1_ext,
+        basic_2_ext,
+        broad_try_clause_ext,
+        while_used_ext,
         1,
     ]
-    assert fake_checker_1 > fake_checker_3
-    assert fake_checker_2 > fake_checker_3
-    assert fake_checker_1 == fake_checker_2
+    # main checker is always smaller
+    assert linter < basic_1_ext
+    assert linter < while_used_ext
+    assert linter < imports_builtin
+    assert basic_2_ext > linter
+    assert while_used_ext > linter
+    assert imports_builtin > linter
+    # builtin are smaller than extension (even when not alphabetically)
+    assert imports_builtin < while_used_ext
+    assert imports_builtin < broad_try_clause_ext
+    assert while_used_ext > imports_builtin
+    assert broad_try_clause_ext > imports_builtin
+    # alphabetical order for builtin
+    assert imports_builtin < typecheck_builtin
+    assert typecheck_builtin > imports_builtin
+    # alphabetical order for extension
+    assert typecheck_builtin < while_used_ext
+    assert while_used_ext > typecheck_builtin
+    assert basic_1_ext > basic_3_ext
+    assert basic_2_ext > basic_3_ext
+    assert basic_1_ext == basic_2_ext
 
 
 def test_base_checker_invalid_message() -> None:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The comparison was not done properly for extension when the second values given was a builtin and the first one an extension. The tests were not testing this case properly because the alphabetical order made us think that everything went right. Added a test with a low alphabetical value extension checker.

Necessary for #8951
