### PR TITLE
Pyreverse: print package import stats

### DIFF
--- a/doc/whatsnew/fragments/8973.feature
+++ b/doc/whatsnew/fragments/8973.feature
@@ -1,3 +1,0 @@
-Print package stats when running Pyreverse and add a --verbose flag for debugging output.
-
-Closes #8973

--- a/doc/whatsnew/fragments/8973.feature
+++ b/doc/whatsnew/fragments/8973.feature
@@ -1,0 +1,3 @@
+Print package stats when running Pyreverse and add a --verbose flag for debugging output.
+
+Closes #8973

--- a/doc/whatsnew/fragments/8973.user_action
+++ b/doc/whatsnew/fragments/8973.user_action
@@ -1,0 +1,3 @@
+Package stats are now printed when running Pyreverse and a ``--verbose`` flag was added to get the original output with parsed modules. You might need to activate the verbose option if you want to keep the old output.
+
+Closes #8973

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -260,7 +260,7 @@ OPTIONS: Options = (
         {
             "action": "store_true",
             "default": False,
-            "help": "print with verbose output",
+            "help": "Makes pyreverse more verbose/talkative. Mostly useful for debugging.",
         },
     ),
 )

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -309,6 +309,7 @@ class Run(_ArgumentsManager, _ArgumentsProvider):
                 args,
                 project_name=self.config.project,
                 black_list=self.config.ignore_list,
+                verbose=self.config.verbose,
             )
             linker = Linker(project, tag=True)
             handler = DiadefsHandler(self.config)

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -255,6 +255,14 @@ OPTIONS: Options = (
             "used to determine a package namespace for modules located under the source root.",
         },
     ),
+    (
+        "verbose",
+        {
+            "action": "store_true",
+            "default": False,
+            "help": "print with verbose output",
+        },
+    ),
 )
 
 

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -54,9 +54,12 @@ class DiagramWriter:
 
     def write_packages(self, diagram: PackageDiagram) -> None:
         """Write a package diagram."""
+        module_info: dict[str, dict[str, int]] = {}
+
         # sorted to get predictable (hence testable) results
         for module in sorted(diagram.modules(), key=lambda x: x.title):
             module.fig_id = module.node.qname()
+
             if self.config.no_standalone and not any(
                 module in (rel.from_object, rel.to_object)
                 for rel in diagram.get_relationships("depends")
@@ -68,20 +71,41 @@ class DiagramWriter:
                 type_=NodeType.PACKAGE,
                 properties=self.get_package_properties(module),
             )
+
+            module_info[module.fig_id] = {
+                "imports": 0,
+                "imported": 0,
+            }
+
         # package dependencies
         for rel in diagram.get_relationships("depends"):
+            from_id = rel.from_object.fig_id
+            to_id = rel.to_object.fig_id
+
             self.printer.emit_edge(
-                rel.from_object.fig_id,
-                rel.to_object.fig_id,
+                from_id,
+                to_id,
                 type_=EdgeType.USES,
             )
 
+            module_info[from_id]["imports"] += 1
+            module_info[to_id]["imported"] += 1
+
         for rel in diagram.get_relationships("type_depends"):
+            from_id = rel.from_object.fig_id
+            to_id = rel.to_object.fig_id
+
             self.printer.emit_edge(
-                rel.from_object.fig_id,
-                rel.to_object.fig_id,
+                from_id,
+                to_id,
                 type_=EdgeType.TYPE_DEPENDENCY,
             )
+
+            module_info[from_id]["imports"] += 1
+            module_info[to_id]["imported"] += 1
+
+        print(f"Modules: {len(module_info)}")
+        print(f'Imports: {sum(mod["imports"] for mod in module_info.values())}')
 
     def write_classes(self, diagram: ClassDiagram) -> None:
         """Write a class diagram."""

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -104,8 +104,10 @@ class DiagramWriter:
             module_info[from_id]["imports"] += 1
             module_info[to_id]["imported"] += 1
 
-        print(f"Modules: {len(module_info)}")
-        print(f'Imports: {sum(mod["imports"] for mod in module_info.values())}')
+        print(
+            f"Analysed {len(module_info)} modules with a total "
+            f"of {sum(mod['imports'] for mod in module_info.values())} imports"
+        )
 
     def write_classes(self, diagram: ClassDiagram) -> None:
         """Write a class diagram."""

--- a/tests/pyreverse/conftest.py
+++ b/tests/pyreverse/conftest.py
@@ -73,7 +73,7 @@ def get_project() -> GetProjectCallable:
         """Return an astroid project representation."""
 
         def _astroid_wrapper(
-            func: Callable[[str], Module], modname: str, verbose: bool = False
+            func: Callable[[str], Module], modname: str, _verbose: bool = False
         ) -> Module:
             return func(modname)
 

--- a/tests/pyreverse/conftest.py
+++ b/tests/pyreverse/conftest.py
@@ -72,7 +72,7 @@ def get_project() -> GetProjectCallable:
     def _get_project(module: str, name: str | None = "No Name") -> Project:
         """Return an astroid project representation."""
 
-        def _astroid_wrapper(func: Callable[[str], Module], modname: str) -> Module:
+        def _astroid_wrapper(func: Callable[[str], Module], modname: str, verbose: bool = False) -> Module:
             return func(modname)
 
         with augmented_sys_path([discover_package_path(module, [])]):

--- a/tests/pyreverse/conftest.py
+++ b/tests/pyreverse/conftest.py
@@ -72,7 +72,9 @@ def get_project() -> GetProjectCallable:
     def _get_project(module: str, name: str | None = "No Name") -> Project:
         """Return an astroid project representation."""
 
-        def _astroid_wrapper(func: Callable[[str], Module], modname: str, verbose: bool = False) -> Module:
+        def _astroid_wrapper(
+            func: Callable[[str], Module], modname: str, verbose: bool = False
+        ) -> Module:
             return func(modname)
 
         with augmented_sys_path([discover_package_path(module, [])]):

--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -128,6 +128,18 @@ def test_graphviz_unsupported_image_format(capsys: CaptureFixture) -> None:
     assert wrapped_sysexit.value.code == 32
 
 
+@mock.patch("pylint.pyreverse.main.Linker", new=mock.MagicMock())
+@mock.patch("pylint.pyreverse.main.DiadefsHandler", new=mock.MagicMock())
+@mock.patch("pylint.pyreverse.main.writer")
+@pytest.mark.usefixtures("mock_graphviz")
+def test_verbose(mock_writer: mock.MagicMock, capsys: CaptureFixture[str]) -> None:
+    """Test the --verbose flag."""
+    with pytest.raises(SystemExit) as wrapped_sysexit:
+        # we have to catch the SystemExit so the test execution does not stop
+        main.Run(["--verbose", TEST_DATA_DIR])
+    assert "parsing" in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     ("arg", "expected_default"),
     [

--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -132,7 +132,7 @@ def test_graphviz_unsupported_image_format(capsys: CaptureFixture) -> None:
 @mock.patch("pylint.pyreverse.main.DiadefsHandler", new=mock.MagicMock())
 @mock.patch("pylint.pyreverse.main.writer")
 @pytest.mark.usefixtures("mock_graphviz")
-def test_verbose(mock_writer: mock.MagicMock, capsys: CaptureFixture[str]) -> None:
+def test_verbose(_: mock.MagicMock, capsys: CaptureFixture[str]) -> None:
     """Test the --verbose flag."""
     with pytest.raises(SystemExit):
         # we have to catch the SystemExit so the test execution does not stop

--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -134,7 +134,7 @@ def test_graphviz_unsupported_image_format(capsys: CaptureFixture) -> None:
 @pytest.mark.usefixtures("mock_graphviz")
 def test_verbose(mock_writer: mock.MagicMock, capsys: CaptureFixture[str]) -> None:
     """Test the --verbose flag."""
-    with pytest.raises(SystemExit) as wrapped_sysexit:
+    with pytest.raises(SystemExit):
         # we have to catch the SystemExit so the test execution does not stop
         main.Run(["--verbose", TEST_DATA_DIR])
     assert "parsing" in capsys.readouterr().out


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Here is what Pyreverse currently prints:

```
$ pyreverse pylint/pyreverse/
parsing pylint/pyreverse/__init__.py...
parsing /home/nick/pylint/pylint/pyreverse/inspector.py...
parsing /home/nick/pylint/pylint/pyreverse/plantuml_printer.py...
parsing /home/nick/pylint/pylint/pyreverse/printer.py...
parsing /home/nick/pylint/pylint/pyreverse/mermaidjs_printer.py...
parsing /home/nick/pylint/pylint/pyreverse/writer.py...
parsing /home/nick/pylint/pylint/pyreverse/__init__.py...
parsing /home/nick/pylint/pylint/pyreverse/dot_printer.py...
parsing /home/nick/pylint/pylint/pyreverse/main.py...
parsing /home/nick/pylint/pylint/pyreverse/printer_factory.py...
parsing /home/nick/pylint/pylint/pyreverse/diadefslib.py...
parsing /home/nick/pylint/pylint/pyreverse/utils.py...
parsing /home/nick/pylint/pylint/pyreverse/diagrams.py...
```

Here is what it prints with this change:

```
$ pyreverse pylint/pyreverse/
Modules: 12
Imports: 25
```

There are many ways this could be changed, but I think this is a good first attempt for more useful printing.

Closes #8973
