### PR TITLE
Fix Pyreverse line break bug

### DIFF
--- a/doc/whatsnew/fragments/8671.bugfix
+++ b/doc/whatsnew/fragments/8671.bugfix
@@ -1,0 +1,3 @@
+Fix a line break error in Pyreverse dot output.
+
+Closes #8671

--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -118,11 +118,11 @@ class DotPrinter(Printer):
         # Add class methods
         methods: list[nodes.FunctionDef] = properties.methods or []
         for func in methods:
-            args = self._get_method_arguments(func)
+            args = ", ".join(self._get_method_arguments(func)).replace("|", r"\|")
             method_name = (
                 f"<I>{func.name}</I>" if func.is_abstract() else f"{func.name}"
             )
-            label += rf"{method_name}({', '.join(args)})"
+            label += rf"{method_name}({args})"
             if func.returns:
                 annotation_label = get_annotation_label(func.returns)
                 label += ": " + self._escape_annotation_label(annotation_label)

--- a/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.dot
+++ b/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.dot
@@ -1,5 +1,5 @@
 digraph "classes" {
 rankdir=BT
 charset="utf-8"
-"line_breaks.A" [color="black", fontcolor="black", label=<{A|p : int \| None<br ALIGN="LEFT"/>|<I>f</I>(x: str | None | (list[A] | list[int]), y: A | (int | str) | None): int \| str \| list[A \| int]<br ALIGN="LEFT"/>}>, shape="record", style="solid"];
+"line_breaks.A" [color="black", fontcolor="black", label=<{A|p : int \| None<br ALIGN="LEFT"/>|<I>f</I>(x: str \| None \| (list[A] \| list[int]), y: A \| (int \| str) \| None): int \| str \| list[A \| int]<br ALIGN="LEFT"/>}>, shape="record", style="solid"];
 }

--- a/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.dot
+++ b/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.dot
@@ -1,5 +1,5 @@
 digraph "classes" {
 rankdir=BT
 charset="utf-8"
-"line_breaks.A" [color="black", fontcolor="black", label=<{A|<br ALIGN="LEFT"/>|<I>f</I>(x: str | None)<br ALIGN="LEFT"/>}>, shape="record", style="solid"];
+"line_breaks.A" [color="black", fontcolor="black", label=<{A|p : int \| None<br ALIGN="LEFT"/>|<I>f</I>(x: str | None | (list[A] | list[int]), y: A | (int | str) | None): int \| str \| list[A \| int]<br ALIGN="LEFT"/>}>, shape="record", style="solid"];
 }

--- a/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.mmd
+++ b/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.mmd
@@ -1,4 +1,5 @@
 classDiagram
   class A {
-    f(x: str | None)*
+    p : int | None
+    f(x: str | None | (list[A] | list[int]), y: A | (int | str) | None)* int | str | list[A | int]
   }

--- a/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.puml
+++ b/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.puml
@@ -1,6 +1,7 @@
 @startuml classes
 set namespaceSeparator none
 class "A" as line_breaks.A {
-  {abstract}f(x: str | None)
+  p : int | None
+  {abstract}f(x: str | None | (list[A] | list[int]), y: A | (int | str) | None) -> int | str | list[A | int]
 }
 @enduml

--- a/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.py
+++ b/tests/pyreverse/functional/class_diagrams/annotations/line_breaks.py
@@ -1,5 +1,10 @@
 # OPEN BUG: https://github.com/pylint-dev/pylint/issues/8671
 
 class A:
-    def f(self, x: str | None):
+    p: int | None
+
+    def f(self,
+          x: (str | None) | (list[A] | list[int]),
+          y: A | (int | str) | None,
+    ) -> int | str | list[A | int]:
         pass


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fix a line break error in Pyreverse dot output

Closes #8671