### PR TITLE
Fixing inconsistent hashing issue in `BaseChecker` 

### DIFF
--- a/doc/whatsnew/fragments/9001.bugfix
+++ b/doc/whatsnew/fragments/9001.bugfix
@@ -1,0 +1,3 @@
+Fixing inconsistent hashing issue in `BaseChecker` causing some reports not being exported.
+
+Closes #9001

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -190,7 +190,8 @@ class BaseChecker(_ArgumentsProvider):
             default_scope = WarningScope.NODE
         options: ExtraMessageOptions = {}
         if len(msg_tuple) == 4:
-            (msg, symbol, descr, options) = msg_tuple  # type: ignore[misc]
+            (msg, symbol, descr, msg_options) = msg_tuple  # type: ignore[misc]
+            options = ExtraMessageOptions(**msg_options)
         elif len(msg_tuple) == 3:
             (msg, symbol, descr) = msg_tuple  # type: ignore[misc]
         else:

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -62,6 +62,18 @@ class DifferentBasicChecker(BaseChecker):
     }
 
 
+class MessageWithOptionsChecker(BaseChecker):
+    name = "message-with-options-checker"
+    msgs = {
+        "W0003": (
+            "Just a message with pre-defined options %s()",
+            "message-with-options",
+            "Message with options dict to test consistent hashing.",
+            {"old_names": [("W1003", "old-message-with-options")], "shared": True},
+        ),
+    }
+
+
 def test_base_checker_doc() -> None:
     basic = OtherBasicChecker()
     expected_beginning = """\
@@ -156,3 +168,18 @@ def test_base_checker_invalid_message() -> None:
     linter = PyLinter()
     with pytest.raises(InvalidMessageError):
         linter.register_checker(MissingFieldsChecker(linter))
+
+
+def test_base_checker_consistent_hash() -> None:
+    linter = PyLinter()
+    checker = MessageWithOptionsChecker(linter)
+    some_set = {checker}
+
+    original_hash = hash(checker)
+    assert checker in some_set
+
+    for msgid, msg in checker.msgs.items():
+        checker.create_message_definition_from_tuple(msgid, msg)
+
+    assert hash(checker) == original_hash
+    assert checker in some_set


### PR DESCRIPTION
Inconsistent hashing issue in `BaseChecker` was causing some reports not being exported.

If any of checker's message definition tuples provided extra message option (optional) `BaseChecker.create_message_definition_from_tuple()` method was overriding those options by adding default `scope` parameter to them. This resulted in message instances having incosistent hashes during their lifecycle and could not be found in reports dictionary when `ReportsHandlerMixIn.make_reports()` was called.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

Closes #9001
