### PR TITLE
Fix a false positive for ``no-value-for-parameter``

### DIFF
--- a/doc/whatsnew/fragments/9036.false_positive
+++ b/doc/whatsnew/fragments/9036.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``no-value-for-parameter`` when a staticmethod is called in a class body.
+
+Closes #9036

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1504,10 +1504,10 @@ accessed. Python regular expressions are accepted.",
         # includes an implicit `self` argument which is not present in `called.args`.
         if (
             isinstance(node.frame(), nodes.ClassDef)
-            and isinstance(node.parent, (nodes.Assign, nodes.AnnAssign))
             and isinstance(called, nodes.FunctionDef)
             and called in node.frame().body
             and num_positional_args > 0
+            and "builtins.staticmethod" not in called.decoratornames()
         ):
             num_positional_args -= 1
 

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -320,3 +320,14 @@ name3(43)
 name4(1, param2=False)
 name5()
 name6(param1=43)
+
+
+# https://github.com/pylint-dev/pylint/issues/9036
+# No value for argument 'string' in staticmethod call (no-value-for-parameter)
+class Foo:
+    @staticmethod
+    def func(string):
+        return string
+
+    func(42)
+    a = func(42)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fix a false positive for ``no-value-for-parameter`` when a staticmethod is called in a class body.

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9036
