### PR TITLE
[doc] Document invalid characters that exists because of the genericity of the unicode checker

### DIFF
--- a/doc/data/messages/i/invalid-character-carriage-return/details.rst
+++ b/doc/data/messages/i/invalid-character-carriage-return/details.rst
@@ -1,1 +1,5 @@
-You can help us make the doc better `by contributing <https://github.com/pylint-dev/pylint/issues/5953>`_ !
+This message exists because one of our checkers is very generic, but it's never going to
+raise during normal use as it's a ``syntax-error`` that would prevent the python ast
+(and thus pylint) from constructing a code representation of the file.
+
+You could encounter it by feeding a properly constructed node directly to the checker.

--- a/doc/data/messages/i/invalid-character-carriage-return/good.py
+++ b/doc/data/messages/i/invalid-character-carriage-return/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+STRING = "Valid carriage return: \r"

--- a/doc/data/messages/i/invalid-character-nul/details.rst
+++ b/doc/data/messages/i/invalid-character-nul/details.rst
@@ -1,1 +1,2 @@
-You can help us make the doc better `by contributing <https://github.com/pylint-dev/pylint/issues/5953>`_ !
+There's no need to use end-of-string characters. String objects maintain their
+own length.

--- a/doc/data/messages/i/invalid-character-nul/good.py
+++ b/doc/data/messages/i/invalid-character-nul/good.py
@@ -1,1 +1,1 @@
-# This is a placeholder for correct code for this message.
+STRING = "Valid nul terminator: \x00"

--- a/doc/data/messages/i/invalid-character-nul/related.rst
+++ b/doc/data/messages/i/invalid-character-nul/related.rst
@@ -1,0 +1,1 @@
+- `Null terminator in python  <https://stackoverflow.com/a/24410304/2519059>`_


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Refs #5953 

As far as I know it's impossible to raise those two messages unless you construct a theoretical node in a unit test. 

