### PR TITLE
Pyreverse: Don't show multiple class association arrows

### DIFF
--- a/doc/whatsnew/fragments/9045.bugfix
+++ b/doc/whatsnew/fragments/9045.bugfix
@@ -1,0 +1,3 @@
+Don't show multiple class association arrows.
+
+Refs #9045

--- a/doc/whatsnew/fragments/9045.bugfix
+++ b/doc/whatsnew/fragments/9045.bugfix
@@ -1,3 +1,3 @@
-Don't show multiple class association arrows.
+Pyreverse doesn't show multiple class association arrows anymore, but only the strongest one.
 
 Refs #9045

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import os
+from collections import defaultdict
 from collections.abc import Iterable
 
 from astroid import modutils, nodes
@@ -133,8 +134,10 @@ class DiagramWriter:
                 rel.to_object.fig_id,
                 type_=EdgeType.INHERITS,
             )
+        associations: dict[str, set[str]] = defaultdict(set)
         # generate associations
         for rel in diagram.get_relationships("association"):
+            associations[rel.from_object.fig_id].add(rel.to_object.fig_id)
             self.printer.emit_edge(
                 rel.from_object.fig_id,
                 rel.to_object.fig_id,
@@ -143,6 +146,8 @@ class DiagramWriter:
             )
         # generate aggregations
         for rel in diagram.get_relationships("aggregation"):
+            if rel.to_object.fig_id in associations[rel.from_object.fig_id]:
+                continue
             self.printer.emit_edge(
                 rel.from_object.fig_id,
                 rel.to_object.fig_id,

--- a/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
+++ b/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
@@ -21,4 +21,3 @@ classDiagram
   P --* D : x
   P --* E : x
   P --o B : x
-  P --o C : x


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes the multiple-association-arrows bug mentioned in #9045 