### PR TITLE
Bump pylint to 2.17.6, update changelog

### DIFF
--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -29,6 +29,45 @@ so we find problems before the actual release.
 
 .. towncrier release notes start
 
+What's new in Pylint 2.17.6?
+----------------------------
+Release date: 2023-09-24
+
+
+Other Bug Fixes
+---------------
+
+- When parsing comma-separated lists of regular expressions in the config,
+  ignore
+  commas that are inside braces since those indicate quantifiers, not
+  delineation
+  between expressions.
+
+  Closes #7229 (`#7229 <https://github.com/pylint-dev/pylint/issues/7229>`_)
+
+- ``sys.argv`` is now always correctly considered as impossible to infer
+  (instead of
+  using the actual values given to pylint).
+
+  Closes #7710 (`#7710 <https://github.com/pylint-dev/pylint/issues/7710>`_)
+
+- Don't show class fields more than once in Pyreverse diagrams.
+
+  Closes #8189 (`#8189 <https://github.com/pylint-dev/pylint/issues/8189>`_)
+
+- Don't show arrows more than once in Pyreverse diagrams.
+
+  Closes #8522 (`#8522 <https://github.com/pylint-dev/pylint/issues/8522>`_)
+
+- Don't show duplicate type annotations in Pyreverse diagrams.
+
+  Closes #8888 (`#8888 <https://github.com/pylint-dev/pylint/issues/8888>`_)
+
+- Don't add `Optional` to `|` annotations with `None` in Pyreverse diagrams.
+
+  Closes #9014 (`#9014 <https://github.com/pylint-dev/pylint/issues/9014>`_)
+
+
 What's new in Pylint 2.17.5?
 ----------------------------
 Release date: 2023-07-26

--- a/doc/whatsnew/fragments/7229.bugfix
+++ b/doc/whatsnew/fragments/7229.bugfix
@@ -1,5 +1,0 @@
-When parsing comma-separated lists of regular expressions in the config, ignore
-commas that are inside braces since those indicate quantifiers, not delineation
-between expressions.
-
-Closes #7229

--- a/doc/whatsnew/fragments/7710.bugfix
+++ b/doc/whatsnew/fragments/7710.bugfix
@@ -1,4 +1,0 @@
-``sys.argv`` is now always correctly considered as impossible to infer (instead of
-using the actual values given to pylint).
-
-Closes #7710

--- a/doc/whatsnew/fragments/8189.bugfix
+++ b/doc/whatsnew/fragments/8189.bugfix
@@ -1,3 +1,0 @@
-Don't show class fields more than once in Pyreverse diagrams.
-
-Closes #8189

--- a/doc/whatsnew/fragments/8522.bugfix
+++ b/doc/whatsnew/fragments/8522.bugfix
@@ -1,3 +1,0 @@
-Don't show arrows more than once in Pyreverse diagrams.
-
-Closes #8522

--- a/doc/whatsnew/fragments/8888.bugfix
+++ b/doc/whatsnew/fragments/8888.bugfix
@@ -1,3 +1,0 @@
-Don't show duplicate type annotations in Pyreverse diagrams.
-
-Closes #8888

--- a/doc/whatsnew/fragments/9014.bugfix
+++ b/doc/whatsnew/fragments/9014.bugfix
@@ -1,3 +1,0 @@
-Don't add `Optional` to `|` annotations with `None` in Pyreverse diagrams.
-
-Closes #9014

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "2.17.5"
+__version__ = "2.17.6"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "2.17.5"
+current = "2.17.6"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "2.17.5"
+version = "2.17.6"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/2/2.17/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
Release date: 2023-09-24


Other Bug Fixes
---------------

- When parsing comma-separated lists of regular expressions in the config,
  ignore commas that are inside braces since those indicate quantifiers, not
  delineation between expressions.

  Closes #7229

- ``sys.argv`` is now always correctly considered as impossible to infer
  (instead of using the actual values given to pylint).

  Closes #9047 

- Don't show class fields more than once in Pyreverse diagrams.

  Closes #8189

- Don't show arrows more than once in Pyreverse diagrams.

  Closes #8522

- Don't show duplicate type annotations in Pyreverse diagrams.

  Closes #8888 

- Don't add `Optional` to `|` annotations with `None` in Pyreverse diagrams.

  Closes #9014
