### PR TITLE
``pylint`` equivalent to ``pylint .``

### DIFF
--- a/doc/whatsnew/fragments/5701.breaking
+++ b/doc/whatsnew/fragments/5701.breaking
@@ -1,0 +1,4 @@
+``pylint`` is now equivalent to ``pylint .`` and won't show the help by default anymore.
+The help is still available with ``pylint --help`` or ``pylint --long-help``.
+
+Closes #5701

--- a/doc/whatsnew/fragments/5701.breaking
+++ b/doc/whatsnew/fragments/5701.breaking
@@ -1,4 +1,6 @@
-``pylint`` is now equivalent to ``pylint .`` and won't show the help by default anymore.
-The help is still available with ``pylint --help`` or ``pylint --long-help``.
+``pylint`` invoked without any positional argument now lints the current
+working directory instead of exiting with code 32 and printing
+``No files to lint: exiting.``. The help message is still available via
+``pylint --help`` or ``pylint --long-help``.
 
 Closes #5701

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -223,12 +223,9 @@ class _ArgumentsManager:
         self, arguments: Sequence[str] | None = None
     ) -> list[str]:
         """Parse the arguments found on the command line into the namespace."""
-        arguments = sys.argv[1:] if arguments is None else arguments
-
         self.config, parsed_args = self._arg_parser.parse_known_args(
             arguments, self.config
         )
-
         return parsed_args
 
     def _generate_config(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -702,13 +702,14 @@ class PyLinter(
         files_or_modules is either a string or list of strings presenting modules to check.
         """
         self.initialize()
+        if not files_or_modules and not self.config.from_stdin:
+            files_or_modules = (str(Path().resolve()),)
         if self.config.recursive:
             files_or_modules = tuple(self._discover_files(files_or_modules))
         if self.config.from_stdin:
             if len(files_or_modules) != 1:
-                raise exceptions.InvalidArgsError(
-                    "Missing filename required for --from-stdin"
-                )
+                print("Missing filename required for --from-stdin")
+                sys.exit(32)
 
         extra_packages_paths = list(
             dict.fromkeys(
@@ -1052,7 +1053,14 @@ class PyLinter(
                 confidence=HIGH,
             )
         except astroid.AstroidBuildingError as ex:
-            self.add_message("parse-error", args=ex)
+            msg = str(ex)
+            if "Unable to load file" in msg and "__init__.py" in msg:
+                msg = (
+                    "No '__init__.py' in the given directory, give a python module, "
+                    "or use '--recursive=y' with the proper ignore option (in order"
+                    " to not lint your virtualenv)"
+                )
+            self.add_message("parse-error", args=msg)
         except Exception as ex:
             traceback.print_exc()
             # We raise BuildingError here as this is essentially an astroid issue

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -191,15 +191,15 @@ group are mutually exclusive.",
                 sys.exit(code)
             return
 
-        # Display help if there are no files to lint or only internal checks enabled (`--disable=all`)
+        # Display help if only internal checks enabled (`--disable=all`)
         disable_all_msg_set = set(
             msg.symbol for msg in linter.msgs_store.messages
         ) - set(msg[1] for msg in linter.default_enabled_messages.values())
-        if not linter.config.files or (
+        if (
             len(linter.config.enable) == 0
             and set(linter.config.disable) == disable_all_msg_set
         ):
-            print("No files to lint: exiting.")
+            print("No messages to check: exiting.")
             sys.exit(32)
 
         if linter.config.jobs < 0:

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -191,7 +191,7 @@ group are mutually exclusive.",
                 sys.exit(code)
             return
 
-        # Display help if only internal checks enabled (`--disable=all`)
+        # Exit early when every user-visible message is disabled (e.g. `--disable=all`)
         disable_all_msg_set = set(
             msg.symbol for msg in linter.msgs_store.messages
         ) - set(msg[1] for msg in linter.default_enabled_messages.values())

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -212,12 +212,12 @@ class TestRunTC:
         self._runtest(["--rcfile=/tmp/this_file_does_not_exist"], code=32)
 
     def test_error_missing_arguments(self) -> None:
-        self._runtest([], code=32)
+        self._runtest([], code=1)
 
     def test_disable_all(self) -> None:
         out = StringIO()
         self._runtest([UNNECESSARY_LAMBDA, "--disable=all"], out=out, code=32)
-        assert "No files to lint: exiting." in out.getvalue().strip()
+        assert "No messages to check: exiting." in out.getvalue().strip()
 
     def test_disable_all_enable_invalid(self) -> None:
         # Reproduces issue #9403. If disable=all is used no error was raised for invalid messages unless
@@ -575,8 +575,9 @@ class TestRunTC:
         )
 
     def test_no_crash_with_formatting_regex_defaults(self) -> None:
+        path = join(HERE, "regrtest_data", "empty.py")
         self._runtest(
-            ["--ignore-patterns=a"], reporter=TextReporter(StringIO()), code=32
+            [path, "--ignore-patterns=a"], reporter=TextReporter(StringIO()), code=0
         )
 
     def test_getdefaultencoding_crashes_with_lc_ctype_utf8(self) -> None:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

``pylint`` is now equivalent to ``pylint .`` and won't show the help by default anymore.
The help is still available with ``pylint --help`` or ``pylint --long-help``.

Closes #5701

