### PR TITLE
Fix crash in refactoring checker from unaryop with variable

### DIFF
--- a/doc/whatsnew/fragments/9074.bugfix
+++ b/doc/whatsnew/fragments/9074.bugfix
@@ -1,0 +1,3 @@
+Fix crash in refactoring checker when unary operand used with variable in for loop.
+
+Closes #9074

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2362,7 +2362,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         if (
             isinstance(node, (nodes.Name, nodes.Call, nodes.Attribute))
             or isinstance(node, nodes.UnaryOp)
-            and isinstance(node.operand, nodes.Attribute)
+            and isinstance(node.operand, (nodes.Attribute, nodes.Name))
         ):
             inferred = utils.safe_infer(node)
             start_val = inferred.value if inferred else None

--- a/tests/functional/r/regression/regression_9074_refactor_loop_with_unary_variable.py
+++ b/tests/functional/r/regression/regression_9074_refactor_loop_with_unary_variable.py
@@ -1,0 +1,7 @@
+"""Regression test."""
+def crash_on_unary_op_with_name():
+    """Should not crash with -idx."""
+    mylist = []
+    idx = 5
+    for _i, _val in enumerate(mylist, start=-idx):
+        pass


### PR DESCRIPTION
Fixes:
```
  File "python3.10/site-packages/pylint/utils/ast_walker.py", line 91, in walk
    callback(astroid)
  File "python3.10/site-packages/pylint/checkers/refactoring/refactoring_checker.py", line 700, in visit_for
    self._check_unnecessary_list_index_lookup(node)
  File "python3.10/site-packages/pylint/checkers/refactoring/refactoring_checker.py", line 2227, in _check_unnecessary_list_index_lookup
    has_start_arg, confidence = self._enumerate_with_start(node)
  File "python3.10/site-packages/pylint/checkers/refactoring/refactoring_checker.py", line 2352, in _enumerate_with_start
    start_val, confidence = self._get_start_value(keyword.value)
  File "python3.10/site-packages/pylint/checkers/refactoring/refactoring_checker.py", line 2369, in _get_start_value
    return node.operand.value, HIGH
AttributeError: 'Name' object has no attribute 'value'
```

Crash is reproducible if you have something like this:

```python
x=5
for _ in enumerate(range, start=-x):
    ...
```

As a workaround, remove the unary op before `for` loop (i.e. change the variable used).

Closes #9074

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |