### PR TITLE
Prevent stats loss

### DIFF
--- a/doc/whatsnew/fragments/9059.bugfix
+++ b/doc/whatsnew/fragments/9059.bugfix
@@ -1,0 +1,5 @@
+Prevented data loss in the linter stats for messages relating
+to the linter itself (e.g. ``unknown-option-value``), fixing
+problems with score, fail-on, etc.
+
+Closes #9059

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1071,7 +1071,6 @@ class PyLinter(
 
     def open(self) -> None:
         """Initialize counters."""
-        self.stats = LinterStats()
         MANAGER.always_load_extensions = self.config.unsafe_load_any_extension
         MANAGER.max_inferable_values = self.config.limit_inference_results
         MANAGER.extension_package_whitelist.update(self.config.extension_pkg_allow_list)

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -41,7 +41,12 @@ from pylint.reporters import text
 from pylint.testutils import create_files
 from pylint.testutils._run import _Run as Run
 from pylint.typing import MessageLocationTuple
-from pylint.utils import FileState, print_full_documentation, tokenize_module
+from pylint.utils import (
+    FileState,
+    LinterStats,
+    print_full_documentation,
+    tokenize_module,
+)
 
 if os.name == "java":
     if os.name == "nt":
@@ -1030,6 +1035,8 @@ def test_by_module_statement_value(initialized_linter: PyLinter) -> None:
     by_module_stats = linter.stats.by_module
     for module, module_stats in by_module_stats.items():
         linter2 = initialized_linter
+        linter2.stats = LinterStats()
+
         if module == "data":
             linter2.check([os.path.join(os.path.dirname(__file__), "data/__init__.py")])
         else:

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -382,6 +382,7 @@ class TestCheckParallel:
         # now run the regular mode of checking files and check that, in this proc, we
         # collect the right data
         filepath = [single_file_container[0][1]]  # get the filepath element
+        linter.stats = LinterStats()
         linter.check(filepath)
         assert {
             "input.similar1": {  # module is the only change from previous

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -20,6 +20,7 @@ import pytest
 
 from pylint import testutils
 from pylint.lint.pylinter import PyLinter
+from pylint.utils.linterstats import LinterStats
 
 REGR_DATA = join(dirname(abspath(__file__)), "regrtest_data")
 sys.path.insert(1, REGR_DATA)
@@ -116,6 +117,7 @@ def test_check_package___init__(finalize_linter: PyLinter) -> None:
     assert sorted(checked) == sorted(filename)
 
     os.chdir(join(REGR_DATA, "package"))
+    finalize_linter.stats = LinterStats()
     finalize_linter.check(["__init__"])
     checked = list(finalize_linter.stats.by_module.keys())
     assert checked == ["__init__"]

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -768,6 +768,15 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (<unknown>, line 1)' (syntax-er
             (["--disable=C0116", "--fail-on=C0116"], 16),
             # Ensure order does not matter
             (["--fail-on=C0116", "--disable=C0116"], 16),
+            # Message emitted by PyLinter itself
+            (
+                [
+                    "--fail-on=unknown-option-value",
+                    "--disable=all",
+                    "--enable=unknown-option-value, trigger",
+                ],
+                4,
+            ),
         ],
     )
     def test_fail_on_edge_case(self, opts: list[str], out: int) -> None:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #9059

Some messages are emitted before the checkers are opened, so this was clearing stats too soon.
