### PR TITLE
Bump pylint to 2.17.7, update changelog

### DIFF
--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -29,6 +29,30 @@ so we find problems before the actual release.
 
 .. towncrier release notes start
 
+What's new in Pylint 2.17.7?
+----------------------------
+Release date: 2023-09-30
+
+
+False Positives Fixed
+---------------------
+
+- Fix a regression in pylint 2.17.6 / astroid 2.15.7 causing various
+  messages for code involving ``TypeVar``.
+
+  Closes #9069 (`#9069 <https://github.com/pylint-dev/pylint/issues/9069>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fix crash in refactoring checker when unary operand used with variable in for
+  loop.
+
+  Closes #9074 (`#9074 <https://github.com/pylint-dev/pylint/issues/9074>`_)
+
+
 What's new in Pylint 2.17.6?
 ----------------------------
 Release date: 2023-09-24

--- a/doc/whatsnew/fragments/9069.false_positive
+++ b/doc/whatsnew/fragments/9069.false_positive
@@ -1,4 +1,0 @@
-Fix a regression in pylint 2.17.6 / astroid 2.15.7 causing various
-messages for code involving ``TypeVar``.
-
-Closes #9069

--- a/doc/whatsnew/fragments/9074.bugfix
+++ b/doc/whatsnew/fragments/9074.bugfix
@@ -1,3 +1,0 @@
-Fix crash in refactoring checker when unary operand used with variable in for loop.
-
-Closes #9074

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "2.17.6"
+__version__ = "2.17.7"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "2.17.6"
+current = "2.17.7"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "2.17.6"
+version = "2.17.7"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/2/2.17/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION


False Positives Fixed
---------------------

- Fix a regression in pylint 2.17.6 / astroid 2.15.7 causing various
  messages for code involving ``TypeVar``.

  Closes #9069



Other Bug Fixes
---------------

- Fix crash in refactoring checker when unary operand used with variable in for
  loop.

  Closes #9074

