### PR TITLE
Remove pyupgrade use ruff, upgrade doc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,6 @@ repos:
         args: ["--notice=script/copyright.txt", "--enforce-all"]
         exclude: tests(/\w*)*/functional/|tests/input|doc/data/messages|examples/|setup.py|tests(/\w*)*data/
         types: [python]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.13.0
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-        exclude: *fixtures
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -129,11 +129,11 @@ Advised linters alongside pylint
 --------------------------------
 
 Projects that you might want to use alongside pylint include ruff_ (**really** fast,
-with builtin auto-fix and a growing number of checks taken from popular
-linters but implemented in ``rust``) or flake8_ (faster and simpler checks with very few false positives),
-mypy_, pyright_ or pyre_ (typing checks), bandit_ (security oriented checks), black_ and
-isort_ (auto-formatting), autoflake_ (automated removal of unused imports or variables),
-pyupgrade_ (automated upgrade to newer python syntax) and pydocstringformatter_ (automated pep257).
+with builtin auto-fix and a large number of checks taken from popular linters, but
+implemented in ``rust``) or flake8_ (a framework to implement your own checks in python using ``ast`` directly),
+mypy_, pyright_ / pylance or pyre_ (typing checks), bandit_ (security oriented checks), black_ and
+isort_ (auto-formatting), autoflake_ (automated removal of unused imports or variables), pyupgrade_
+(automated upgrade to newer python syntax) and pydocstringformatter_ (automated pep257).
 
 .. _ruff: https://github.com/charliermarsh/ruff
 .. _flake8: https://github.com/PyCQA/flake8

--- a/doc/data/messages/c/consider-using-dict-comprehension/details.rst
+++ b/doc/data/messages/c/consider-using-dict-comprehension/details.rst
@@ -1,3 +1,4 @@
-pyupgrade_ can fix this issue automatically.
+pyupgrade_ or ruff_ can fix this issue automatically.
 
 .. _pyupgrade: https://github.com/asottile/pyupgrade
+.. _ruff: https://docs.astral.sh/ruff/

--- a/doc/data/messages/c/consider-using-set-comprehension/details.rst
+++ b/doc/data/messages/c/consider-using-set-comprehension/details.rst
@@ -1,3 +1,4 @@
-pyupgrade_ can fix this issue automatically.
+pyupgrade_ or ruff_ can fix this issue automatically.
 
 .. _pyupgrade: https://github.com/asottile/pyupgrade
+.. _ruff: https://docs.astral.sh/ruff/

--- a/doc/whatsnew/2/2.11/summary.rst
+++ b/doc/whatsnew/2/2.11/summary.rst
@@ -6,7 +6,7 @@ Summary -- Release highlights
 
 In 2.11, we added a new default checker to advise using f-string as it's
 the most efficient way of formatting strings right now. You can use
-`pyupgrade`_ or `flynt`_ to migrate your old ``%`` and ``format()`` automatically.
+`pyupgrade`_, `ruff`_ or `flynt`_ to migrate your old ``%`` and ``format()`` automatically.
 
 We added a new extension ``SetMembershipChecker`` that will advise the
 use of set for membership test, as it's more performant than lists or tuples.
@@ -29,7 +29,7 @@ to provide knowledge or use case :)
 .. _possible-forgotten-f-prefix: https://github.com/pylint-dev/pylint/pull/4787
 .. _pyupgrade: https://github.com/asottile/pyupgrade
 .. _flynt: https://github.com/ikamensh/flynt
-
+.. _ruff: https://docs.astral.sh/ruff/
 
 New checkers
 ============

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -134,9 +134,7 @@ class BaseChecker(_ArgumentsProvider):
         if reports:
             result += get_rst_title(f"{checker_title} Reports", "^")
             for report in reports:
-                result += ":{}: {}\n".format(  # pylint: disable=consider-using-f-string
-                    *report[:2]
-                )
+                result += f":{report[0]}: {report[1]}\n"
             result += "\n"
         result += "\n"
         return result

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -134,8 +134,8 @@ class BaseChecker(_ArgumentsProvider):
         if reports:
             result += get_rst_title(f"{checker_title} Reports", "^")
             for report in reports:
-                result += (
-                    ":%s: %s\n" % report[:2]  # pylint: disable=consider-using-f-string
+                result += ":{}: {}\n".format(  # pylint: disable=consider-using-f-string
+                    *report[:2]
                 )
             result += "\n"
         result += "\n"

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -914,15 +914,15 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             return
 
         if operator in {"<", "<="}:
-            reduced_to = "{target} = max({target}, {item})".format(
-                target=target_assignation, item=body_value
+            reduced_to = (
+                f"{target_assignation} = max({target_assignation}, {body_value})"
             )
             self.add_message(
                 "consider-using-max-builtin", node=node, args=(reduced_to,)
             )
         elif operator in {">", ">="}:
-            reduced_to = "{target} = min({target}, {item})".format(
-                target=target_assignation, item=body_value
+            reduced_to = (
+                f"{target_assignation} = min({target_assignation}, {body_value})"
             )
             self.add_message(
                 "consider-using-min-builtin", node=node, args=(reduced_to,)

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -347,12 +347,10 @@ class SphinxDocstring(Docstring):
         [\(\[] [^\n\s]+ [\)\]]        # with the contents of the container
     """
 
-    re_multiple_simple_type = r"""
-        (?:{container_type}|{type})
-        (?:(?:\s+(?:of|or)\s+|\s*,\s*|\s+\|\s+)(?:{container_type}|{type}))*
-    """.format(
-        type=re_type, container_type=re_simple_container_type
-    )
+    re_multiple_simple_type = rf"""
+        (?:{re_simple_container_type}|{re_type})
+        (?:(?:\s+(?:of|or)\s+|\s*,\s*|\s+\|\s+)(?:{re_simple_container_type}|{re_type}))*
+    """
 
     re_xref = rf"""
         (?::\w+:)?                    # optional tag
@@ -549,12 +547,10 @@ class GoogleDocstring(Docstring):
         [\(\[] [^\n]+ [\)\]]          # with the contents of the container
     """
 
-    re_multiple_type = r"""
-        (?:{container_type}|{type}|{xref})
-        (?:(?:\s+(?:of|or)\s+|\s*,\s*|\s+\|\s+)(?:{container_type}|{type}|{xref}))*
-    """.format(
-        type=re_type, xref=re_xref, container_type=re_container_type
-    )
+    re_multiple_type = rf"""
+        (?:{re_container_type}|{re_type}|{re_xref})
+        (?:(?:\s+(?:of|or)\s+|\s*,\s*|\s+\|\s+)(?:{re_container_type}|{re_type}|{re_xref}))*
+    """
 
     _re_section_template = r"""
         ^([ ]*)   {0} \s*:   \s*$     # Google parameter header

--- a/pylint/testutils/constants.py
+++ b/pylint/testutils/constants.py
@@ -23,7 +23,7 @@ _MESSAGE = {"msg": r"[a-z][a-z\-]+"}
 _EXPECTED_RE = re.compile(
     r"\s*#\s*(?:(?P<line>[+-]?[0-9]+):)?"  # pylint: disable=consider-using-f-string
     r"(?:(?P<op>[><=]+) *(?P<version>[0-9.]+):)?"
-    r"\s*\[(?P<msgs>%(msg)s(?:,\s*%(msg)s)*)]" % _MESSAGE
+    r"\s*\[(?P<msgs>{msg}(?:,\s*{msg})*)]".format(**_MESSAGE)
 )
 
 _OPERATORS = {">": operator.gt, "<": operator.lt, ">=": operator.ge, "<=": operator.le}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,13 +158,3 @@ ignore = [
     "B905",  # `zip()` without an explicit `strict=` parameter
     "RUF012",  # mutable default values in class attributes
 ]
-
-fixable = [
-    "E",  # pycodestyle
-    "F",  # pyflakes
-    "W",  # pycodestyle
-    "B",  # bugbear
-    "I",  # isort
-    "RUF", # ruff
-    "UP", # pyupgrade
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ select = [
     "B",  # bugbear
     "I",  # isort
     "RUF", # ruff
+    "UP", # pyupgrade
 ]
 
 ignore = [
@@ -165,4 +166,5 @@ fixable = [
     "B",  # bugbear
     "I",  # isort
     "RUF", # ruff
+    "UP", # pyupgrade
 ]


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Stumbled upon a nasty bug of pyupgrade that created a syntax error. Making pyupgrade ignore the file is more work than migrating to ruff. Upgraded the doc where applicable too.