### PR TITLE
Fix a crash for Enum class decorated with dataclass

### DIFF
--- a/doc/whatsnew/fragments/9100.other
+++ b/doc/whatsnew/fragments/9100.other
@@ -1,0 +1,3 @@
+Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.
+
+Closes #9100

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2281,8 +2281,9 @@ def is_enum_member(node: nodes.AssignName) -> bool:
     ):
         return False
 
-    try:
-        enum_member_objects = frame.locals.get("__members__")[0].items
-    except TypeError:
+    members = frame.locals.get("__members__")
+    # A dataclass is one known case for when `members` can be `None`
+    if members is None:
         return False
+    enum_member_objects = members[0].items
     return node.name in [name_obj.name for value, name_obj in enum_member_objects]

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2285,5 +2285,4 @@ def is_enum_member(node: nodes.AssignName) -> bool:
     # A dataclass is one known case for when `members` can be `None`
     if members is None:
         return False
-    enum_member_objects = members[0].items
-    return node.name in [name_obj.name for value, name_obj in enum_member_objects]
+    return node.name in [name_obj.name for value, name_obj in members[0].items]

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2281,5 +2281,8 @@ def is_enum_member(node: nodes.AssignName) -> bool:
     ):
         return False
 
-    enum_member_objects = frame.locals.get("__members__")[0].items
+    try:
+        enum_member_objects = frame.locals.get("__members__")[0].items
+    except TypeError:
+        return False
     return node.name in [name_obj.name for value, name_obj in enum_member_objects]

--- a/tests/functional/i/invalid/invalid_name/invalid_name_enum.py
+++ b/tests/functional/i/invalid/invalid_name/invalid_name_enum.py
@@ -1,5 +1,5 @@
 """ Tests for invalid-name checker in the context of enums. """
-# pylint: disable=too-few-public-methods, missing-class-docstring
+# pylint: disable=too-few-public-methods
 
 
 from dataclasses import dataclass
@@ -33,4 +33,7 @@ class Color(Enum):
 
 @dataclass
 class Something(str, Enum):
-    asd: str = 'sdf'
+    """ A false positive for ``invalid-name``
+    which should be fixed by https://github.com/pylint-dev/astroid/issues/2317
+    """
+    ASD: str = 1  # [invalid-name]

--- a/tests/functional/i/invalid/invalid_name/invalid_name_enum.py
+++ b/tests/functional/i/invalid/invalid_name/invalid_name_enum.py
@@ -1,7 +1,8 @@
 """ Tests for invalid-name checker in the context of enums. """
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods, missing-class-docstring
 
 
+from dataclasses import dataclass
 from enum import Enum
 
 
@@ -28,3 +29,8 @@ class Color(Enum):
     def as_hex(self) -> str:
         """Get hex 'abcdef' representation for a color."""
         return f'{self.red:0{2}x}{self.green:0{2}x}{self.blue:0{2}x}'
+
+
+@dataclass
+class Something(str, Enum):
+    asd: str = 'sdf'

--- a/tests/functional/i/invalid/invalid_name/invalid_name_enum.txt
+++ b/tests/functional/i/invalid/invalid_name/invalid_name_enum.txt
@@ -1,1 +1,2 @@
 invalid-name:17:4:17:14:Color:"Class constant name ""aquamarine"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:39:4:None:None:Something:"Attribute name ""ASD"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/i/invalid/invalid_name/invalid_name_enum.txt
+++ b/tests/functional/i/invalid/invalid_name/invalid_name_enum.txt
@@ -1,1 +1,1 @@
-invalid-name:16:4:16:14:Color:"Class constant name ""aquamarine"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:17:4:17:14:Color:"Class constant name ""aquamarine"" doesn't conform to UPPER_CASE naming style":HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.

Closes #9100
