### PR TITLE
Fix false positive for ``inherit-non-class`` for generic Protocols

### DIFF
--- a/doc/whatsnew/fragments/9106.false_positive
+++ b/doc/whatsnew/fragments/9106.false_positive
@@ -1,0 +1,3 @@
+Fixed false positive for ``inherit-non-class`` for generic Protocols.
+
+Closes #9106

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -957,8 +957,9 @@ a metaclass class method.",
             ancestor = safe_infer(base)
             if not ancestor:
                 continue
-            if isinstance(ancestor, astroid.Instance) and ancestor.is_subtype_of(
-                "builtins.type"
+            if isinstance(ancestor, astroid.Instance) and (
+                ancestor.is_subtype_of("builtins.type")
+                or ancestor.is_subtype_of(".Protocol")
             ):
                 continue
 

--- a/tests/functional/i/inherit_non_class.py
+++ b/tests/functional/i/inherit_non_class.py
@@ -4,6 +4,7 @@ a class emits a warning. """
 # pylint: disable=import-error, invalid-name, using-constant-test
 # pylint: disable=missing-docstring, too-few-public-methods, useless-object-inheritance
 
+from typing import Protocol, TypeVar
 from missing import Missing
 
 if 1:
@@ -101,3 +102,18 @@ class Child2(ParentBad[int]):  # [inherit-non-class]
 # Classes that don't implement '__class_getitem__' are marked as unsubscriptable
 class Child3(Empty[int]):  # [unsubscriptable-object]
     pass
+
+
+T = TypeVar("T")
+
+
+class Channel(Protocol[T]):
+    """A generic Protocol."""
+
+    async def get(self) -> T:
+        """A get method using the generic."""
+
+
+class DirectChannel(Channel[T]):
+    async def get(self) -> T:
+        """An implementation of the generic."""

--- a/tests/functional/i/inherit_non_class.txt
+++ b/tests/functional/i/inherit_non_class.txt
@@ -1,11 +1,11 @@
-inherit-non-class:21:0:21:9:Bad:Inheriting '1', which is not a class.:UNDEFINED
-inherit-non-class:24:0:24:10:Bad1:"Inheriting 'lambda abc: 42', which is not a class.":UNDEFINED
-inherit-non-class:27:0:27:10:Bad2:Inheriting 'object()', which is not a class.:UNDEFINED
-inherit-non-class:30:0:30:10:Bad3:Inheriting 'return_class', which is not a class.:UNDEFINED
-inherit-non-class:33:0:33:10:Bad4:Inheriting 'Empty()', which is not a class.:UNDEFINED
-inherit-non-class:68:0:68:24:NotInheritableBool:Inheriting 'bool', which is not a class.:UNDEFINED
-inherit-non-class:72:0:72:25:NotInheritableRange:Inheriting 'range', which is not a class.:UNDEFINED
-inherit-non-class:76:0:76:25:NotInheritableSlice:Inheriting 'slice', which is not a class.:UNDEFINED
-inherit-non-class:80:0:80:30:NotInheritableMemoryView:Inheriting 'memoryview', which is not a class.:UNDEFINED
-inherit-non-class:98:0:98:12:Child2:Inheriting 'ParentBad[int]', which is not a class.:UNDEFINED
-unsubscriptable-object:102:13:102:18:Child3:Value 'Empty' is unsubscriptable:UNDEFINED
+inherit-non-class:22:0:22:9:Bad:Inheriting '1', which is not a class.:UNDEFINED
+inherit-non-class:25:0:25:10:Bad1:"Inheriting 'lambda abc: 42', which is not a class.":UNDEFINED
+inherit-non-class:28:0:28:10:Bad2:Inheriting 'object()', which is not a class.:UNDEFINED
+inherit-non-class:31:0:31:10:Bad3:Inheriting 'return_class', which is not a class.:UNDEFINED
+inherit-non-class:34:0:34:10:Bad4:Inheriting 'Empty()', which is not a class.:UNDEFINED
+inherit-non-class:69:0:69:24:NotInheritableBool:Inheriting 'bool', which is not a class.:UNDEFINED
+inherit-non-class:73:0:73:25:NotInheritableRange:Inheriting 'range', which is not a class.:UNDEFINED
+inherit-non-class:77:0:77:25:NotInheritableSlice:Inheriting 'slice', which is not a class.:UNDEFINED
+inherit-non-class:81:0:81:30:NotInheritableMemoryView:Inheriting 'memoryview', which is not a class.:UNDEFINED
+inherit-non-class:99:0:99:12:Child2:Inheriting 'ParentBad[int]', which is not a class.:UNDEFINED
+unsubscriptable-object:103:13:103:18:Child3:Value 'Empty' is unsubscriptable:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes https://github.com/pylint-dev/pylint/issues/9106.

Thought I would make a PR, has been a while 😄 

Fixes a false positive which is apparently a regression in `3.x`.
