### PR TITLE
Bump pylint to 3.0.1, update changelog

### DIFF
--- a/doc/exts/pylint_extensions.py
+++ b/doc/exts/pylint_extensions.py
@@ -145,9 +145,9 @@ def get_plugins_info(
     return by_checker
 
 
-def setup(app: Sphinx) -> dict[str, str]:
+def setup(app: Sphinx) -> dict[str, str | bool]:
     app.connect("builder-inited", builder_inited)
-    return {"version": sphinx.__display_version__}
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}
 
 
 if __name__ == "__main__":

--- a/doc/whatsnew/3/3.0/index.rst
+++ b/doc/whatsnew/3/3.0/index.rst
@@ -65,6 +65,28 @@ easier to parse and provides more info, here's a sample output.
 
 .. towncrier release notes start
 
+What's new in Pylint 3.0.1?
+---------------------------
+Release date: 2023-10-05
+
+
+False Positives Fixed
+---------------------
+
+- Fixed false positive for ``inherit-non-class`` for generic Protocols.
+
+  Closes #9106 (`#9106 <https://github.com/pylint-dev/pylint/issues/9106>`_)
+
+
+
+Other Changes
+-------------
+
+- Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.
+
+  Closes #9100 (`#9100 <https://github.com/pylint-dev/pylint/issues/9100>`_)
+
+
 What's new in Pylint 3.0.0?
 ---------------------------
 Release date: 2023-10-02

--- a/doc/whatsnew/fragments/9100.other
+++ b/doc/whatsnew/fragments/9100.other
@@ -1,3 +1,0 @@
-Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.
-
-Closes #9100

--- a/doc/whatsnew/fragments/9106.false_positive
+++ b/doc/whatsnew/fragments/9106.false_positive
@@ -1,3 +1,0 @@
-Fixed false positive for ``inherit-non-class`` for generic Protocols.
-
-Closes #9106

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.0.0"
+current = "3.0.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.0.0"
+version = "3.0.1"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.0/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
False Positives Fixed
---------------------

- Fixed false positive for ``inherit-non-class`` for generic Protocols.

  Closes #9106 



Other Changes
-------------

- Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.

  Closes #9100 