### PR TITLE
changed desc of --indent-string

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -886,17 +886,9 @@ Standard Checkers
 
 --indent-string
 """""""""""""""
-*String used as indentation unit. This is usually*
+*String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1 tab).*
 
-::
-
-"    " (4 spaces) or "\t" (1 tab).
-
-**Default:**
-
-::
-
-``    ``
+**Default:**  ``    ``
 
 --max-line-length
 """""""""""""""""

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -886,10 +886,17 @@ Standard Checkers
 
 --indent-string
 """""""""""""""
-*String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1 tab).*
+*String used as indentation unit. This is usually*
 
-**Default:**  ``    ``
+::
 
+"    " (4 spaces) or "\t" (1 tab).
+
+**Default:**
+
+::
+
+``    ``
 
 --max-line-length
 """""""""""""""""

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -219,15 +219,13 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
         (
             "indent-string",
             {
-                "default": "::\n"
-                '\n'
-                '"    "',
+                "default": "::\n" "\n" '"    "',
                 "type": "non_empty_string",
                 "metavar": "<string>",
                 "help": "sssString used as indentation unit. This is usually \n"
-                '\n'
-                '::\n'
-                '\n'
+                "\n"
+                "::\n"
+                "\n"
                 '"    " (4 spaces) or "\\t" (1 tab)"',
             },
         ),

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -219,11 +219,16 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
         (
             "indent-string",
             {
-                "default": "    ",
+                "default": "::\n"
+                '\n'
+                '"    "',
                 "type": "non_empty_string",
                 "metavar": "<string>",
-                "help": "String used as indentation unit. This is usually "
-                '"    " (4 spaces) or "\\t" (1 tab).',
+                "help": "sssString used as indentation unit. This is usually \n"
+                '\n'
+                '::\n'
+                '\n'
+                '"    " (4 spaces) or "\\t" (1 tab)"',
             },
         ),
         (


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #8392 

Currently .rst to .html converter converts 4 spaces to monospace and removes the \ as an escape character.
Temporary fix as it changes documentation style but also does not provide false information. Shows as below - 
![image](https://github.com/pylint-dev/pylint/assets/77039163/48f569d9-f3fc-49be-839e-05a4191539b9)
