### PR TITLE
Fix false positive for ``unnecessary-lambda`` with kwargs in the call but not the lambda

### DIFF
--- a/doc/whatsnew/fragments/9148.false_positive
+++ b/doc/whatsnew/fragments/9148.false_positive
@@ -1,0 +1,3 @@
+Fixed false positive for ``unnecessary-lambda`` when the call has keyword arguments but not the lambda.
+
+Closes #9148

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -519,7 +519,6 @@ class BasicChecker(_BasicChecker):
         )
 
     @utils.only_required_for_messages("unnecessary-lambda")
-    # pylint: disable-next=too-many-return-statements
     def visit_lambda(self, node: nodes.Lambda) -> None:
         """Check whether the lambda is suspicious."""
         # if the body of the lambda is a call expression with the same
@@ -544,28 +543,19 @@ class BasicChecker(_BasicChecker):
             # return something else (but we don't check that, yet).
             return
 
-        call_site = astroid.arguments.CallSite.from_call(call)
         ordinary_args = list(node.args.args)
         new_call_args = list(self._filter_vararg(node, call.args))
         if node.args.kwarg:
-            if self._has_variadic_argument(call.kwargs, node.args.kwarg):
+            if self._has_variadic_argument(call.keywords, node.args.kwarg):
                 return
+        elif call.keywords:
+            return
 
         if node.args.vararg:
             if self._has_variadic_argument(call.starargs, node.args.vararg):
                 return
         elif call.starargs:
             return
-
-        if call.keywords:
-            # Look for additional keyword arguments that are not part
-            # of the lambda's signature
-            lambda_kwargs = {keyword.name for keyword in node.args.defaults}
-            if len(lambda_kwargs) != len(call_site.keyword_arguments):
-                # Different lengths, so probably not identical
-                return
-            if set(call_site.keyword_arguments).difference(lambda_kwargs):
-                return
 
         # The "ordinary" arguments must be in a correspondence such that:
         # ordinary_args[i].name == call.args[i].name.

--- a/tests/functional/u/unnecessary/unnecessary_lambda.py
+++ b/tests/functional/u/unnecessary/unnecessary_lambda.py
@@ -52,6 +52,10 @@ _ = lambda: _ANYARGS(**{'three': 3})
 _ = lambda: _ANYARGS(*[3], **{'three': 3})
 _ = lambda: _ANYARGS(func=42)
 
+# pylint: disable=missing-function-docstring
+def f(d):
+    print(lambda x: str(x, **d))
+
 # Don't warn about this.
 _ = lambda: code().analysis()
 


### PR DESCRIPTION
I might have missed something because I don't understand why `call_site.keyword_arguments` has been used here instead of simply comparing `node.args.kwarg` with `call.keywords`. Maybe this is not the right way to fix the issue.

```python
        if call.keywords:
            # Look for additional keyword arguments that are not part
            # of the lambda's signature
            lambda_kwargs = {keyword.name for keyword in node.args.defaults}
            if len(lambda_kwargs) != len(call_site.keyword_arguments):
                # Different lengths, so probably not identical
                return
            if set(call_site.keyword_arguments).difference(lambda_kwargs):
                return
```

As far as I can tell, `lambda_kwargs` here is always empty because of [this condition](https://github.com/pylint-dev/pylint/blob/main/pylint/checkers/base/basic_checker.py#L528) at the beginning of the check

```python
        if node.args.defaults:
            return
```

Also, `call_site.keyword_arguments` is empty in the case of the example I added to the tests, with causes the false positive.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR references an issue without fixing it: -->




<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9148 
