### PR TITLE
Fix `used-before-assignment` FP for generic type syntax (Py 3.12)

### DIFF
--- a/doc/whatsnew/fragments/9110.false_positive
+++ b/doc/whatsnew/fragments/9110.false_positive
@@ -1,0 +1,3 @@
+Fix ``used-before-assignment`` false positive for generic type syntax (PEP 695, Python 3.12).
+
+Closes #9110

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -120,6 +120,7 @@ NODES_WITH_VALUE_ATTR = (
     nodes.Expr,
     nodes.Return,
     nodes.Match,
+    nodes.TypeAlias,
 )
 
 
@@ -2328,6 +2329,8 @@ class VariablesChecker(BaseChecker):
         if isinstance(defstmt, nodes.Match):
             return any(case.guard for case in defstmt.cases)
         if isinstance(defstmt, nodes.IfExp):
+            return True
+        if isinstance(defstmt, nodes.TypeAlias):
             return True
         if isinstance(defstmt.value, nodes.BaseContainer):
             return any(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.0.0,<=3.1.0-dev0",
+    "astroid>=3.0.1,<=3.1.0-dev0",
     "isort>=4.2.5,<6",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.0.0  # Pinned to a specific version for tests
+astroid==3.0.1  # Pinned to a specific version for tests
 typing-extensions~=4.8
 py~=1.11.0
 pytest~=7.4

--- a/tests/functional/u/used/used_before_assignment_py312.py
+++ b/tests/functional/u/used/used_before_assignment_py312.py
@@ -1,0 +1,6 @@
+"""used-before-assignment re: python 3.12 generic typing syntax (PEP 695)"""
+
+from typing import Callable
+type Point[T] = tuple[T, ...]
+type Alias[*Ts] = tuple[*Ts]
+type Alias[**P] = Callable[P]

--- a/tests/functional/u/used/used_before_assignment_py312.rc
+++ b/tests/functional/u/used/used_before_assignment_py312.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #9110
