### PR TITLE
Respect py-version for ``inconsistent-quotes`` inside f-strings

### DIFF
--- a/doc/whatsnew/fragments/9113.bugfix
+++ b/doc/whatsnew/fragments/9113.bugfix
@@ -1,0 +1,3 @@
+Emit ``inconsistent-quotes`` for f-strings with 3.12 interpreter only if targeting pre-3.12 versions.
+
+Closes #9113

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -841,6 +841,7 @@ class StringConstantChecker(BaseTokenChecker, BaseRawFileChecker):
         # First, figure out which quote character predominates in the module
         for tok_type, token, _, _, _ in tokens:
             if sys.version_info[:2] >= (3, 12):
+                # pylint: disable=no-member,useless-suppression
                 if tok_type == tokenize.FSTRING_START:
                     inside_fstring = True
                 elif tok_type == tokenize.FSTRING_END:

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -19,6 +19,7 @@ from astroid.typing import SuccessfulInferenceResult
 
 from pylint.checkers import BaseChecker, BaseRawFileChecker, BaseTokenChecker, utils
 from pylint.checkers.utils import only_required_for_messages
+from pylint.constants import PY312_PLUS
 from pylint.interfaces import HIGH
 from pylint.typing import MessageDefinitionTuple
 
@@ -834,8 +835,21 @@ class StringConstantChecker(BaseTokenChecker, BaseRawFileChecker):
         """
         string_delimiters: Counter[str] = collections.Counter()
 
+        inside_fstring = False  # whether token is inside f-string (since 3.12)
+        target_py312 = self.linter.config.py_version >= (3, 12)
+
         # First, figure out which quote character predominates in the module
         for tok_type, token, _, _, _ in tokens:
+            if PY312_PLUS:
+                if tok_type == tokenize.FSTRING_START:
+                    inside_fstring = True
+                elif tok_type == tokenize.FSTRING_END:
+                    inside_fstring = False
+
+                if inside_fstring and not target_py312:
+                    # skip analysis of f-string contents
+                    continue
+
             if tok_type == tokenize.STRING and _is_quote_delimiter_chosen_freely(token):
                 string_delimiters[_get_quote_delimiter(token)] += 1
 

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import collections
 import re
+import sys
 import tokenize
 from collections import Counter
 from collections.abc import Iterable, Sequence
@@ -19,7 +20,6 @@ from astroid.typing import SuccessfulInferenceResult
 
 from pylint.checkers import BaseChecker, BaseRawFileChecker, BaseTokenChecker, utils
 from pylint.checkers.utils import only_required_for_messages
-from pylint.constants import PY312_PLUS
 from pylint.interfaces import HIGH
 from pylint.typing import MessageDefinitionTuple
 
@@ -840,7 +840,7 @@ class StringConstantChecker(BaseTokenChecker, BaseRawFileChecker):
 
         # First, figure out which quote character predominates in the module
         for tok_type, token, _, _, _ in tokens:
-            if PY312_PLUS:
+            if sys.version_info[:2] >= (3, 12):
                 if tok_type == tokenize.FSTRING_START:
                     inside_fstring = True
                 elif tok_type == tokenize.FSTRING_END:

--- a/tests/functional/i/inconsistent/inconsistent_quotes_fstring.py
+++ b/tests/functional/i/inconsistent/inconsistent_quotes_fstring.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-module-docstring
+
+dictionary = {'0': 0}
+f_string = f'{dictionary["0"]}'

--- a/tests/functional/i/inconsistent/inconsistent_quotes_fstring.rc
+++ b/tests/functional/i/inconsistent/inconsistent_quotes_fstring.rc
@@ -1,0 +1,5 @@
+[STRING]
+check-quote-consistency=yes
+
+[testoptions]
+max_pyver=3.12

--- a/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312.py
+++ b/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312.py
@@ -1,0 +1,5 @@
+# pylint: disable=missing-module-docstring
+
+dictionary = {'0': 0}
+# quotes are inconsistent when targetting Python 3.12 (use single quotes)
+f_string = f'{dictionary["0"]}'  # [inconsistent-quotes]

--- a/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312.rc
+++ b/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312.rc
@@ -1,0 +1,8 @@
+[STRING]
+check-quote-consistency=yes
+
+[main]
+py-version=3.12
+
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312.txt
+++ b/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312.txt
@@ -1,0 +1,1 @@
+inconsistent-quotes:5:0:None:None::"Quote delimiter "" is inconsistent with the rest of the file":UNDEFINED

--- a/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312_311.py
+++ b/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312_311.py
@@ -1,0 +1,5 @@
+# pylint: disable=missing-module-docstring
+
+dictionary = {'0': 0}
+# quotes are consistent when targetting 3.11 and earlier (cannot use single quotes here)
+f_string = f'{dictionary["0"]}'

--- a/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312_311.rc
+++ b/tests/functional/i/inconsistent/inconsistent_quotes_fstring_py312_311.rc
@@ -1,0 +1,8 @@
+[STRING]
+check-quote-consistency=yes
+
+[main]
+py-version=3.11
+
+[testoptions]
+min_pyver=3.12


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

When running pre-3.12 interpeter, f-strings are opaque and are represented as a STRING token (like 'f\'{dictionary["0"]}\' for the test case in the ticket). So they are not used in analysis.

With 3.12 PEG interpreter, f-string is a proper Python expression, even if we target pre-3.12. So this PR enables ``inconsistent-quotes`` checks for string literals only if a target version is 3.12 or later. 

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9113
