### PR TITLE
Escape special symbols and newlines in messages.

### DIFF
--- a/doc/whatsnew/fragments/7874.bugfix
+++ b/doc/whatsnew/fragments/7874.bugfix
@@ -1,0 +1,3 @@
+Escape special symbols and newlines in messages.
+
+Closes #7874

--- a/pylint/extensions/magic_value.py
+++ b/pylint/extensions/magic_value.py
@@ -84,9 +84,9 @@ class MagicValueChecker(BaseChecker):
 
         operand_value = None
         if const_operands[LEFT_OPERAND] and self._is_magic_value(left_operand):
-            operand_value = left_operand.value
+            operand_value = left_operand.as_string()
         elif const_operands[RIGHT_OPERAND] and self._is_magic_value(right_operand):
-            operand_value = right_operand.value
+            operand_value = right_operand.as_string()
         if operand_value is not None:
             self.add_message(
                 "magic-value-comparison",

--- a/tests/functional/ext/magic_value_comparison/magic_value_comparison.py
+++ b/tests/functional/ext/magic_value_comparison/magic_value_comparison.py
@@ -34,3 +34,5 @@ shouldnt_raise = var == ""
 
 shouldnt_raise = var == '\n'
 shouldnt_raise = var == '\\b'
+
+should_escape = var == "foo\nbar"  # [magic-value-comparison]

--- a/tests/functional/ext/magic_value_comparison/magic_value_comparison.txt
+++ b/tests/functional/ext/magic_value_comparison/magic_value_comparison.txt
@@ -5,3 +5,4 @@ comparison-of-constants:24:17:24:22::"Comparison between constants: '5 > 7' has 
 singleton-comparison:29:17:29:28::Comparison 'var == True' should be 'var is True' if checking for the singleton value True, or 'bool(var)' if testing for truthiness:UNDEFINED
 singleton-comparison:30:17:30:29::Comparison 'var == False' should be 'var is False' if checking for the singleton value False, or 'not var' if testing for falsiness:UNDEFINED
 singleton-comparison:31:17:31:28::Comparison 'var == None' should be 'var is None':UNDEFINED
+magic-value-comparison:38:16:38:33::Consider using a named constant or an enum instead of ''foo\nbar''.:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|     | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

I skimmed through all the `args` usage in messages and tested a few suspicious strings. Everything looks good and uses `as_string()` call. The only thing to fix is a `magic-value-comparison` from the referenced ticket.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7874
