### PR TITLE
Fix `undefined-variable` etc for Python 3.12 generic type syntax

### DIFF
--- a/doc/whatsnew/fragments/9193.false_positive
+++ b/doc/whatsnew/fragments/9193.false_positive
@@ -1,0 +1,4 @@
+Fix false positives for ``undefined-variable`` and ``unused-argument`` for
+classes and functions using Python 3.12 generic type syntax.
+
+Closes #9193

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1864,12 +1864,6 @@ class VariablesChecker(BaseChecker):
                 or annotation_return
                 or isinstance(defstmt, nodes.Delete)
             ):
-                if (
-                    defined_by_stmt
-                    and isinstance(defstmt, nodes.ClassDef)
-                    and node.parent in defstmt.type_params
-                ):
-                    return (VariableVisitConsumerAction.RETURN, None)
                 if not utils.node_ignores_exception(node, NameError):
                     # Handle postponed evaluation of annotations
                     if not (

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1738,9 +1738,8 @@ class VariablesChecker(BaseChecker):
         elif consumer.scope_type == "function" and self._defined_in_function_definition(
             node, consumer.node
         ):
-            for param in consumer.node.type_params:
-                if node.name == param.name.name:
-                    return False
+            if any(node.name == param.name.name for param in consumer.node.type_params):
+                return False
 
             # If the name node is used as a function default argument's value or as
             # a decorator, then start from the parent frame of the function instead

--- a/tests/functional/u/undefined/undefined_variable_py312.py
+++ b/tests/functional/u/undefined/undefined_variable_py312.py
@@ -1,0 +1,7 @@
+# pylint: disable=missing-function-docstring,missing-module-docstring,missing-class-docstring,too-few-public-methods
+
+def f[T](a: T) -> T:
+    print(a)
+
+class ChildClass[T, *Ts, **P]:
+    ...

--- a/tests/functional/u/undefined/undefined_variable_py312.rc
+++ b/tests/functional/u/undefined/undefined_variable_py312.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Closes #9193
