### PR TITLE
Bump Python to 3.12 on remaining CI jobs

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ on:
 env:
   CACHE_VERSION: 1
   KEY_PREFIX: base-venv
-  DEFAULT_PYTHON: "3.11"
+  DEFAULT_PYTHON: "3.12"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 concurrency:


### PR DESCRIPTION
Reveals some doc examples that need adjusting.