### PR TITLE
[todos] Fix the todos version and the warnings' text

### DIFF
--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -839,7 +839,7 @@ class SimilarChecker(BaseRawFileChecker, Similar):
         stream must implement the readlines method
         """
         if self.linter.current_name is None:
-            # TODO: 3.0 Fix current_name
+            # TODO: 4.0 Fix current_name
             warnings.warn(
                 (
                     "In pylint 3.0 the current_name attribute of the linter object should be a string. "

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2571,7 +2571,7 @@ class VariablesChecker(BaseChecker):
                 else_stmt, (nodes.Return, nodes.Raise, nodes.Break, nodes.Continue)
             ):
                 return
-            # TODO: 3.0: Consider using RefactoringChecker._is_function_def_never_returning
+            # TODO: 4.0: Consider using RefactoringChecker._is_function_def_never_returning
             if isinstance(else_stmt, nodes.Expr) and isinstance(
                 else_stmt.value, nodes.Call
             ):

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -243,7 +243,7 @@ class _GenerateRCFileAction(_AccessRunObjectAction):
         values: str | Sequence[Any] | None,
         option_string: str | None = "--generate-rcfile",
     ) -> None:
-        # TODO: 3.x: Deprecate this after the auto-upgrade functionality of
+        # TODO: 4.x: Deprecate this after the auto-upgrade functionality of
         # pylint-config is sufficient.
         self.run.linter._generate_config(skipsections=("Commands",))
         sys.exit(0)

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -110,13 +110,14 @@ def _config_initialization(
             "unrecognized-option", args=unrecognized_options_message, line=0
         )
 
-    # TODO 3.1: Change this to emit unknown-option-value
+    # TODO: Change this to be checked only when upgrading the configuration
     for exc_name in linter.config.overgeneral_exceptions:
         if "." not in exc_name:
             warnings.warn_explicit(
                 f"'{exc_name}' is not a proper value for the 'overgeneral-exceptions' option. "
                 f"Use fully qualified name (maybe 'builtins.{exc_name}' ?) instead. "
-                "This will cease to be checked at runtime in 3.1.0.",
+                "This will cease to be checked at runtime when the configuration "
+                "upgrader is released.",
                 category=UserWarning,
                 filename="pylint: Command line or configuration file",
                 lineno=1,

--- a/pylint/testutils/functional/test_file.py
+++ b/pylint/testutils/functional/test_file.py
@@ -56,7 +56,7 @@ class FunctionalTestFile:
     def __init__(self, directory: str, filename: str) -> None:
         self._directory = directory
         self.base = filename.replace(".py", "")
-        # TODO: 3.0: Deprecate FunctionalTestFile.options and related code
+        # TODO:4.0: Deprecate FunctionalTestFile.options and related code
         # We should just parse these options like a normal configuration file.
         self.options: TestFileOptions = {
             "min_pyver": (2, 5),

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -315,7 +315,7 @@ def format_section(
 ) -> None:
     """Format an option's section using the INI format."""
     warnings.warn(
-        "format_section has been deprecated. It will be removed in pylint 3.0.",
+        "format_section has been deprecated. It will be removed in pylint 4.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -330,7 +330,7 @@ def format_section(
 def _ini_format(stream: TextIO, options: list[tuple[str, OptionDict, Any]]) -> None:
     """Format options using the INI format."""
     warnings.warn(
-        "_ini_format has been deprecated. It will be removed in pylint 3.0.",
+        "_ini_format has been deprecated. It will be removed in pylint 4.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -269,7 +269,7 @@ class TestCheckParallelFramework:
         linter.load_plugin_modules(["pylint.extensions.overlapping_exceptions"])
         try:
             dill.dumps(linter)
-            # TODO: 3.0: Fix this test by raising this assertion again
+            # TODO: 4.0: Fix this test by raising this assertion again
             # raise AssertionError(
             #     "Plugins loaded were pickle-safe! This test needs altering"
             # )


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Follow up to 3.0 release, we did not clean some TODOs and most importantly a warning (that's why I'm backporting).
