### PR TITLE
[governance] Upgrade governance for pylint plugin maintainers

### DIFF
--- a/doc/development_guide/contributor_guide/governance.rst
+++ b/doc/development_guide/contributor_guide/governance.rst
@@ -19,6 +19,10 @@ Reporting a bug is being a contributor already.
 How to become a triager ?
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Create a pylint plugin, then migrate it to the 'pylint-dev' github organization.
+
+Or:
+
 - Contribute for more than 3 releases consistently.
 - Do not be too opinionated, follow the code of conduct without requiring emotional
   works from the maintainers. It does not mean that disagreements are impossible,
@@ -30,7 +34,7 @@ How to become a triager ?
 How to become a maintainer ?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Create a pylint plugin, then migrate it to the 'pylint-dev' github organization.
+
 - Take ownership of a part of the code that is not maintained well at the moment
   or that you contributed personally (if we feel we can't merge something without
   your review, you're going to be able to merge those yourself soon).

--- a/doc/development_guide/contributor_guide/governance.rst
+++ b/doc/development_guide/contributor_guide/governance.rst
@@ -30,13 +30,17 @@ How to become a triager ?
 How to become a maintainer ?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Create a pylint plugin, then migrate it to the 'pylint-dev' github organization.
+- Take ownership of a part of the code that is not maintained well at the moment
+  or that you contributed personally (if we feel we can't merge something without
+  your review, you're going to be able to merge those yourself soon).
+
+Or:
+
 - Contribute two big code merge requests over multiple releases (for example
   one checker in 2.13 and the following bug after release and one complicated
   bug fixes in 2.14). Otherwise contributing for more than 3 releases consistently
   with great technical and interpersonal skills.
-- Take ownership of a part of the code that is not maintained well at the moment
-  or that you contributed personally (if we feel we can't merge something without
-  your review, you're going to be able to merge those yourself soon).
 - Triage for multiple months (close duplicate, clean up issues, answer questions...)
 - Have an admin suggest that you become maintainer, without you asking
 - Get unanimous approval or neutral agreement from current maintainers.


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

This is up for discussion: do we give pylint's maintenance right for plugin maintainers that want to migrate their plugin to pylint-dev ? Previously we invited Carl Crowder for pylint-django, when he wanted to migrate his plugin to pylint-dev but he was a PyCQA member, and already pretty invested in pylint so already had maintainer's rights. How about a master student that did their plugin in isolation and the plugin is not yet widely adopted ?

We can also create separate rights' groups in the org (admin / member / plugin owner).
