### PR TITLE
[bugfix] Find files with ./ as input with a __init__.py file

### DIFF
--- a/doc/whatsnew/fragments/9210.bugfix
+++ b/doc/whatsnew/fragments/9210.bugfix
@@ -1,4 +1,4 @@
-Fix bug for not being able to walk through files when work on `./` as input
-at a directory with a `__init__.py` file.
+Fix a bug where pylint was unable to walk recursively through a directory if the
+directory has an `__init__.py` file.
 
 Closes #9210

--- a/doc/whatsnew/fragments/9210.bugfix
+++ b/doc/whatsnew/fragments/9210.bugfix
@@ -1,0 +1,4 @@
+Fix bug for not being able to walk through files when work on `./` as input
+at a directory with a `__init__.py` file.
+
+Closes #9210

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -144,8 +144,9 @@ def expand_modules(
         )
         if has_init or is_namespace or is_directory:
             for subfilepath in modutils.get_module_files(
-                os.path.dirname(filepath), ignore_list, list_all=is_namespace
+                os.path.dirname(filepath) or ".", ignore_list, list_all=is_namespace
             ):
+                subfilepath = os.path.normpath(subfilepath)
                 if filepath == subfilepath:
                     continue
                 if _is_in_ignore_list_re(

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import copy
 import os
 import re
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 import copy
 import os
-from pathlib import Path
 import re
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -134,13 +134,15 @@ def _list_expected_package_modules_relative() -> tuple[dict[str, object], ...]:
     """Generates reusable list of modules for our package with relative path input."""
     abs_result = copy.deepcopy(_list_expected_package_modules())
     for item in abs_result:
+        assert isinstance(item["basepath"], str)
+        assert isinstance(item["path"], str)
         item["basepath"] = os.path.relpath(item["basepath"],  str(Path(__file__).parent))
         item["path"] = os.path.relpath(item["path"],  str(Path(__file__).parent))
     return abs_result
 
 
 @contextmanager
-def pushd(path: Path) -> Iterator[str]:
+def pushd(path: Path) -> Iterator[None]:
     prev = os.getcwd()
     os.chdir(path)
     try:
@@ -194,11 +196,12 @@ class TestExpandModules(CheckerTestCase):
     @pytest.mark.parametrize(
         "files_or_modules,expected",
         [
-            ([Path(__file__).name], {
-                this_file_relative_to_parent["path"]: this_file_relative_to_parent
-            }),
             (
-                ['./'],
+                [Path(__file__).name],
+                {this_file_relative_to_parent["path"]: this_file_relative_to_parent},
+            ),
+            (
+                ["./"],
                 {
                     module["path"]: module  # pylint: disable=unsubscriptable-object
                     for module in _list_expected_package_modules_relative()

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -4,8 +4,12 @@
 
 from __future__ import annotations
 
-import re
+from contextlib import contextmanager
+import copy
+import os
 from pathlib import Path
+import re
+from typing import Iterator
 
 import pytest
 
@@ -28,13 +32,22 @@ def test__is_in_ignore_list_re_match() -> None:
 
 TEST_DIRECTORY = Path(__file__).parent.parent
 INIT_PATH = str(TEST_DIRECTORY / "lint/__init__.py")
-EXPAND_MODULES = str(TEST_DIRECTORY / "lint/unittest_expand_modules.py")
+EXPAND_MODULES_BASE = "unittest_expand_modules.py"
+EXPAND_MODULES = str(TEST_DIRECTORY / "lint" / EXPAND_MODULES_BASE)
 this_file = {
     "basename": "lint.unittest_expand_modules",
     "basepath": EXPAND_MODULES,
     "isarg": True,
     "name": "lint.unittest_expand_modules",
     "path": EXPAND_MODULES,
+}
+
+this_file_relative_to_parent = {
+    "basename": "lint.unittest_expand_modules",
+    "basepath": EXPAND_MODULES_BASE,
+    "isarg": True,
+    "name": "lint.unittest_expand_modules",
+    "path": EXPAND_MODULES_BASE,
 }
 
 this_file_from_init = {
@@ -117,6 +130,25 @@ def _list_expected_package_modules(
     )
 
 
+def _list_expected_package_modules_relative() -> tuple[dict[str, object], ...]:
+    """Generates reusable list of modules for our package with relative path input."""
+    abs_result = copy.deepcopy(_list_expected_package_modules())
+    for item in abs_result:
+        item["basepath"] = os.path.relpath(item["basepath"],  str(Path(__file__).parent))
+        item["path"] = os.path.relpath(item["path"],  str(Path(__file__).parent))
+    return abs_result
+
+
+@contextmanager
+def pushd(path: Path) -> Iterator[str]:
+    prev = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
 class TestExpandModules(CheckerTestCase):
     """Test the expand_modules function while allowing options to be set."""
 
@@ -158,6 +190,41 @@ class TestExpandModules(CheckerTestCase):
         )
         assert modules == expected
         assert not errors
+
+    @pytest.mark.parametrize(
+        "files_or_modules,expected",
+        [
+            ([Path(__file__).name], {
+                this_file_relative_to_parent["path"]: this_file_relative_to_parent
+            }),
+            (
+                ['./'],
+                {
+                    module["path"]: module  # pylint: disable=unsubscriptable-object
+                    for module in _list_expected_package_modules_relative()
+                },
+            ),
+        ],
+    )
+    @set_config(ignore_paths="")
+    def test_expand_modules_relative_path(
+        self, files_or_modules: list[str], expected: dict[str, ModuleDescriptionDict]
+    ) -> None:
+        """Test expand_modules with the default value of ignore-paths and relative path as input."""
+        ignore_list: list[str] = []
+        ignore_list_re: list[re.Pattern[str]] = []
+        with pushd(Path(__file__).parent):
+            modules, errors = expand_modules(
+                files_or_modules,
+                [],
+                ignore_list,
+                ignore_list_re,
+                self.linter.config.ignore_paths,
+            )
+            print(modules)
+            print(expected)
+            assert modules == expected
+            assert not errors
 
     @pytest.mark.parametrize(
         "files_or_modules,expected",

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -136,8 +136,8 @@ def _list_expected_package_modules_relative() -> tuple[dict[str, object], ...]:
     for item in abs_result:
         assert isinstance(item["basepath"], str)
         assert isinstance(item["path"], str)
-        item["basepath"] = os.path.relpath(item["basepath"],  str(Path(__file__).parent))
-        item["path"] = os.path.relpath(item["path"],  str(Path(__file__).parent))
+        item["basepath"] = os.path.relpath(item["basepath"], str(Path(__file__).parent))
+        item["path"] = os.path.relpath(item["path"], str(Path(__file__).parent))
     return abs_result
 
 

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -224,8 +224,6 @@ class TestExpandModules(CheckerTestCase):
                 ignore_list_re,
                 self.linter.config.ignore_paths,
             )
-            print(modules)
-            print(expected)
             assert modules == expected
             assert not errors
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

When working as `pylint --recursive=y ./` or `pylint --recursive=y .` on a directory with a `__init__.py` file, pylilnt will not be able to walk through other files due to an empty input for `modutils.get_module_files` because `os.path.dirname("__init__.py") == ""`. This PR tries to fix this behavior.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9210
