### PR TITLE
[not-an-iterable] Add regression test for uninferable instances

### DIFF
--- a/tests/functional/i/iterable_context.py
+++ b/tests/functional/i/iterable_context.py
@@ -116,8 +116,7 @@ for i in 8.5:  # [not-an-iterable]
 for i in 10:  # [not-an-iterable]
     pass
 
-
-# skip uninferable instances
+# skip uninferable bases
 from some_missing_module import Iterable
 
 class MyClass(Iterable):
@@ -126,6 +125,11 @@ class MyClass(Iterable):
 m = MyClass()
 for i in m:
     print(i)
+
+# skip uninferable instances
+ambiguous = range(i) or range(i)
+for j in ambiguous:
+    print(j)
 
 # skip checks if statement is inside mixin/base/abstract class
 class ManagedAccessViewMixin:


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description
While investigating #9253, I found that the regression test for suppressing `not-an-iterable` for Uninferable instances was not testing what it intended. Inference had improved over eight years, and we were testing an `Instance` instead, not `Uninferable`.


Refs #9253