### PR TITLE
[pointless-string-statement] Ignore docstrings on py3.12 type aliases

### DIFF
--- a/doc/data/messages/p/pointless-string-statement/related.rst
+++ b/doc/data/messages/p/pointless-string-statement/related.rst
@@ -1,0 +1,1 @@
+- `Discussion thread re: docstrings on assignments <https://discuss.python.org/t/docstrings-for-new-type-aliases-as-defined-in-pep-695/39816>`_

--- a/doc/whatsnew/fragments/9268.false_positive
+++ b/doc/whatsnew/fragments/9268.false_positive
@@ -1,0 +1,4 @@
+Fixed ``pointless-string-statement`` false positive for docstrings
+on Python 3.12 type aliases.
+
+Closes #9268

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -446,7 +446,9 @@ class BasicChecker(_BasicChecker):
                     if (
                         sibling is not None
                         and sibling.scope() is scope
-                        and isinstance(sibling, (nodes.Assign, nodes.AnnAssign))
+                        and isinstance(
+                            sibling, (nodes.Assign, nodes.AnnAssign, nodes.TypeAlias)
+                        )
                     ):
                         return
             self.add_message("pointless-string-statement", node=node)

--- a/tests/functional/s/statement_without_effect_py312.py
+++ b/tests/functional/s/statement_without_effect_py312.py
@@ -1,0 +1,7 @@
+"""Move this into statement_without_effect.py when python 3.12 is minimum."""
+
+type MyTuple = tuple[str, str]
+"""
+Multiline docstring
+for Python3.12 type alias (PEP 695)
+"""

--- a/tests/functional/s/statement_without_effect_py312.rc
+++ b/tests/functional/s/statement_without_effect_py312.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #9268