### PR TITLE
Disallow isort 5.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies    = [
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
     "astroid>=3.0.1,<=3.1.0-dev0",
-    "isort>=4.2.5,<6",
+    "isort>=4.2.5,<6,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",
     "tomlkit>=0.10.1",


### PR DESCRIPTION
Refs #9270

`isort` 5.13.0 pulls in many dev dependencies as runtime dependencies, some of which cause behavior differences in astroid. See [logs](https://github.com/pylint-dev/astroid/actions/runs/7159322816/job/19492440429).

Refs https://github.com/PyCQA/isort/issues/2206