### PR TITLE
Bump astroid to 3.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.0.1,<=3.1.0-dev0",
+    "astroid>=3.0.2,<=3.1.0-dev0",
     "isort>=4.2.5,<6,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.0.1  # Pinned to a specific version for tests
+astroid==3.0.2  # Pinned to a specific version for tests
 typing-extensions~=4.8
 py~=1.11.0
 pytest~=7.4


### PR DESCRIPTION
Should reduce primer noise. Let's not backport until there's more of a reason.