### PR TITLE
Fixed false positive nested-min-max for nested lists

### DIFF
--- a/doc/whatsnew/fragments/9307.false_positive
+++ b/doc/whatsnew/fragments/9307.false_positive
@@ -1,0 +1,7 @@
+Fixed false positive nested-min-max for nested lists
+
+Nesting is useful for finding the maximum in a matrix.
+Therefore, pylint now allows nesting of the form:
+max(max([[1, 2, 3], [4, 5, 6]]))
+
+Closes #9307

--- a/doc/whatsnew/fragments/9307.false_positive
+++ b/doc/whatsnew/fragments/9307.false_positive
@@ -1,7 +1,3 @@
-Fixed false positive nested-min-max for nested lists
-
-Nesting is useful for finding the maximum in a matrix.
-Therefore, pylint now allows nesting of the form:
-max(max([[1, 2, 3], [4, 5, 6]]))
+Fixed false positive nested-min-max for nested lists.
 
 Closes #9307

--- a/pylint/checkers/nested_min_max.py
+++ b/pylint/checkers/nested_min_max.py
@@ -67,7 +67,7 @@ class NestedMinMaxChecker(BaseChecker):
                 and arg.func.name == node.func.name
                 # Nesting is useful for finding the maximum in a matrix.
                 # Allow: max(max([[1, 2, 3], [4, 5, 6]]))
-                # Meaning, redunant call only if parent max call has more than 1 arg.
+                # Meaning, redundant call only if parent max call has more than 1 arg.
                 and len(arg.parent.args) > 1
             )
         ]

--- a/pylint/checkers/nested_min_max.py
+++ b/pylint/checkers/nested_min_max.py
@@ -62,7 +62,14 @@ class NestedMinMaxChecker(BaseChecker):
         return [
             arg
             for arg in node.args
-            if cls.is_min_max_call(arg) and arg.func.name == node.func.name
+            if (
+                cls.is_min_max_call(arg)
+                and arg.func.name == node.func.name
+                # Nesting is useful for finding the maximum in a matrix.
+                # Allow: max(max([[1, 2, 3], [4, 5, 6]]))
+                # Meaning, redunant call only if parent max call has more than 1 arg.
+                and len(arg.parent.args) > 1
+            )
         ]
 
     @only_required_for_messages("nested-min-max")

--- a/tests/functional/n/nested_min_max.py
+++ b/tests/functional/n/nested_min_max.py
@@ -56,7 +56,7 @@ max(3, max(list(range(4))))  # [nested-min-max]
 max(3, *list(range(4)))
 
 # Nesting is useful for finding the maximum in a matrix
-# No message if extrenal call has exactly 1 argument
+# No message if external call has exactly 1 argument
 matrix = [[1, 2, 3], [4, 5, 6]]
 max(max(matrix))
 max(max(max(matrix)))

--- a/tests/functional/n/nested_min_max.py
+++ b/tests/functional/n/nested_min_max.py
@@ -54,3 +54,11 @@ max(3, *[5] + list(range(4)))
 
 max(3, max(list(range(4))))  # [nested-min-max]
 max(3, *list(range(4)))
+
+# Nesting is useful for finding the maximum in a matrix
+# No message if extrenal call has exactly 1 argument
+matrix = [[1, 2, 3], [4, 5, 6]]
+max(max(matrix))
+max(max(max(matrix)))
+max(3, max(max(matrix)))  # [nested-min-max]
+max(max(3, max(matrix)))  # [nested-min-max]

--- a/tests/functional/n/nested_min_max.txt
+++ b/tests/functional/n/nested_min_max.txt
@@ -16,3 +16,5 @@ nested-min-max:46:0:46:25::Do not use nested call of 'max'; it's possible to do 
 nested-min-max:49:0:49:45::Do not use nested call of 'max'; it's possible to do 'max(3, *[5] + [i for i in range(4) if i])' instead:INFERENCE
 nested-min-max:52:0:52:33::Do not use nested call of 'max'; it's possible to do 'max(3, *[5] + list(range(4)))' instead:INFERENCE
 nested-min-max:55:0:55:27::Do not use nested call of 'max'; it's possible to do 'max(3, *list(range(4)))' instead:INFERENCE
+nested-min-max:63:0:63:24::Do not use nested call of 'max'; it's possible to do 'max(3, max(matrix))' instead:INFERENCE
+nested-min-max:64:4:64:23::Do not use nested call of 'max'; it's possible to do 'max(3, *matrix)' instead:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Nesting is useful for finding the maximum in a matrix.
Therefore, pylint now allows nesting of the form:
```
max(max([[1, 2, 3], [4, 5, 6]]))
```

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9307