### PR TITLE
Fix primer compare step (again)

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -95,8 +95,8 @@ jobs:
           . venv/bin/activate
           python tests/primer/__main__.py compare \
           --commit=${{ github.event.workflow_run.head_sha }} \
-          --base-file=primer_output_main_${{ env.DEFAULT_PYTHON }}_BATCHIDX.txt \
-          --new-file=primer_output_pr_${{ env.DEFAULT_PYTHON }}_BATCHIDX.txt \
+          --base-file=output_${{ env.DEFAULT_PYTHON }}_main_BATCHIDX.txt \
+          --new-file=output_${{ env.DEFAULT_PYTHON }}_pr_BATCHIDX.txt \
           --batches=4
       - name: Post comment
         id: post-comment


### PR DESCRIPTION
Follow-up to 4329e05.

The last PR too eagerly monkeyed with this order of terms in the file name when all it needed to do was get the python version from the correct place. The zip files and txt files aren't created with the same names.

Here's an `ls` command dumping out the result:
```sh
output_3.12_main_batch0.txt
output_3.12_main_batch1.txt
output_3.12_main_batch2.txt
output_3.12_main_batch3.txt
output_3.12_pr_batch0.txt
output_3.12_pr_batch1.txt
output_3.12_pr_batch2.txt
output_3.12_pr_batch3.txt
pr_number.txt
pr_number.zip
primer_output_main_3.12_batch0.zip
primer_output_main_3.12_batch1.zip
primer_output_main_3.12_batch2.zip
primer_output_main_3.12_batch3.zip
primer_output_pr_3.12_batch0.zip
primer_output_pr_3.12_batch1.zip
primer_output_pr_3.12_batch2.zip
primer_output_pr_3.12_batch3.zip
```

Last one, @DanielNoord! Happy new year!