### PR TITLE
Recognize new-style attrs decorators in too-few-public-methods check

### DIFF
--- a/doc/whatsnew/fragments/9345.false_positive
+++ b/doc/whatsnew/fragments/9345.false_positive
@@ -1,0 +1,4 @@
+Treat `attrs.define` and `attrs.frozen` as dataclass decorators in
+`too-few-public-methods` check.
+
+Closes #9345

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -92,6 +92,8 @@ MSGS: dict[
 SPECIAL_OBJ = re.compile("^_{2}[a-z]+_{2}$")
 DATACLASSES_DECORATORS = frozenset({"dataclass", "attrs"})
 DATACLASS_IMPORT = "dataclasses"
+ATTRS_DECORATORS = frozenset({"define", "frozen"})
+ATTRS_IMPORT = "attrs"
 TYPING_NAMEDTUPLE = "typing.NamedTuple"
 TYPING_TYPEDDICT = "typing.TypedDict"
 TYPING_EXTENSIONS_TYPEDDICT = "typing_extensions.TypedDict"
@@ -212,6 +214,10 @@ def _is_exempt_from_public_methods(node: astroid.ClassDef) -> bool:
         if name in DATACLASSES_DECORATORS and (
             root_locals.intersection(DATACLASSES_DECORATORS)
             or DATACLASS_IMPORT in root_locals
+        ):
+            return True
+        if name in ATTRS_DECORATORS and (
+            root_locals.intersection(ATTRS_DECORATORS) or ATTRS_IMPORT in root_locals
         ):
             return True
     return False

--- a/tests/functional/t/too/too_few_public_methods_37.py
+++ b/tests/functional/t/too/too_few_public_methods_37.py
@@ -8,6 +8,9 @@ import dataclasses
 import typing
 from dataclasses import dataclass
 
+import attrs  # pylint: disable=import-error
+from attrs import define, frozen  # pylint: disable=import-error
+
 
 @dataclasses.dataclass
 class ScheduledTxSearchModel:
@@ -40,3 +43,27 @@ class Point:
     def to_array(self):
         """Convert to a NumPy array `np.array((x, y, z))`."""
         return self.attr1
+
+
+@define
+class AttrsBarePoint:
+    x: float
+    y: float
+
+
+@frozen
+class AttrsBareFrozenPoint:
+    x: float
+    y: float
+
+
+@attrs.define
+class AttrsQualifiedPoint:
+    x: float
+    y: float
+
+
+@attrs.frozen
+class AttrsQualifiedFrozenPoint:
+    x: float
+    y: float


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [X] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [X] Write comprehensive commit messages and/or a good description of what the PR does.
- [X] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [X] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Beginning with attrs 21.1.0, the recommended way to use attrs is through `import attrs` and using `attrs.define`/`attrs.frozen`, not `import attr` and `attr.s` or `attr.attrs`. Pylint does understand `attr.attrs` (#2988), but new-style uses of attrs are not understood to be data class decorators.

Modify `_is_exempt_from_public_methods` to recognize `attrs.define` and `attrs.frozen` in a similar way as is currently done with `dataclasses.dataclass`.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9345
