### PR TITLE
Fix the whitespacing in the optional checker note

### DIFF
--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -334,7 +334,7 @@ def _generate_single_message_body(message: MessageData) -> str:
         body += f"""
 .. note::
   This message is emitted by the optional :ref:`'{message.checker}'<{message.checker_module_name}>`
-   checker which requires the ``{message.checker_module_name}`` plugin to be loaded.
+  checker, which requires the ``{message.checker_module_name}`` plugin to be loaded.
 
 """
     return body


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Closes #9372 

See https://pylint--9400.org.readthedocs.build/en/9400/user_guide/messages/refactor/no-self-use.html

