### PR TITLE
New message `use-yield-from`

### DIFF
--- a/doc/data/messages/u/use-yield-from/bad.py
+++ b/doc/data/messages/u/use-yield-from/bad.py
@@ -1,3 +1,3 @@
 def bad_yield_from(generator):
     for item in generator:
-        yield item
+        yield item  # [use-yield-from]

--- a/doc/data/messages/u/use-yield-from/bad.py
+++ b/doc/data/messages/u/use-yield-from/bad.py
@@ -1,0 +1,3 @@
+def bad_yield_from(generator):
+    for item in generator:
+        yield item

--- a/doc/data/messages/u/use-yield-from/bad.py
+++ b/doc/data/messages/u/use-yield-from/bad.py
@@ -1,3 +1,3 @@
 def bad_yield_from(generator):
-    for item in generator:
-        yield item  # [use-yield-from]
+    for item in generator:  # [use-yield-from]
+        yield item

--- a/doc/data/messages/u/use-yield-from/details.rst
+++ b/doc/data/messages/u/use-yield-from/details.rst
@@ -1,0 +1,14 @@
+:code:`yield from` can be thought of as removing the intermediary (your for loop) between the function caller and the
+requested generator. This enables the caller to directly communicate with the generator (e.g. :code:`send()`).
+This communication is not possible when manually yielding each element one by one in a loop.
+
+PEP 380 describes the possibility of adding optimizations specific to :code:`yield from`, as of the time of writing,
+it can't be confirmed that such optimizations have been implemented. The following snippet still shows that while
+probably negligible, a performance improvement can exist simply because of the removed overhead.
+
+.. code-block:: sh
+
+  $ python3 -m timeit "def yield_from(): yield from range(100)" "for _ in yield_from(): pass"
+  100000 loops, best of 5: 2.44 usec per loop
+  $ python3 -m timeit "def yield_loop():" "    for item in range(100): yield item" "for _ in yield_loop(): pass"
+  100000 loops, best of 5: 2.49 usec per loop

--- a/doc/data/messages/u/use-yield-from/details.rst
+++ b/doc/data/messages/u/use-yield-from/details.rst
@@ -1,10 +1,10 @@
 :code:`yield from` can be thought of as removing the intermediary (your for loop) between the function caller and the
-requested generator. This enables the caller to directly communicate with the generator (e.g. :code:`send()`).
+requested generator. This enables the caller to directly communicate with the generator (e.g. using :code:`send()`).
 This communication is not possible when manually yielding each element one by one in a loop.
 
-PEP 380 describes the possibility of adding optimizations specific to :code:`yield from`, as of the time of writing,
-it can't be confirmed that such optimizations have been implemented. The following snippet still shows that while
-probably negligible, a performance improvement can exist simply because of the removed overhead.
+PEP 380 describes the possibility of adding optimizations specific to :code:`yield from`. It looks like said
+implementations have not been implemented as of the time of writing. Even without said optimizations, the following
+snippets shows that :code:`yield from` is marginally faster.
 
 .. code-block:: sh
 

--- a/doc/data/messages/u/use-yield-from/details.rst
+++ b/doc/data/messages/u/use-yield-from/details.rst
@@ -2,9 +2,9 @@
 requested generator. This enables the caller to directly communicate with the generator (e.g. using :code:`send()`).
 This communication is not possible when manually yielding each element one by one in a loop.
 
-PEP 380 describes the possibility of adding optimizations specific to :code:`yield from`. It looks like said
-implementations have not been implemented as of the time of writing. Even without said optimizations, the following
-snippets shows that :code:`yield from` is marginally faster.
+PEP 380 describes the possibility of adding optimizations specific to :code:`yield from`. It looks like they
+have not been implemented as of the time of writing. Even without said optimizations, the following snippet shows
+that :code:`yield from` is marginally faster.
 
 .. code-block:: sh
 

--- a/doc/data/messages/u/use-yield-from/good.py
+++ b/doc/data/messages/u/use-yield-from/good.py
@@ -1,0 +1,2 @@
+def good_yield_from(generator):
+    yield from generator

--- a/doc/data/messages/u/use-yield-from/related.rst
+++ b/doc/data/messages/u/use-yield-from/related.rst
@@ -1,0 +1,1 @@
+- `PEP 380 <https://peps.python.org/pep-0380/>`_

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -908,7 +908,7 @@ Refactoring checker Messages
   set constructor. It is faster and simpler.
 :use-yield-from (R1737): *Use 'yield from' directly instead of yielding each element one by one*
   Yielding directly from the iterator is faster and arguably cleaner code than
-  yielding each element in the loop.
+  yielding each element one by one in the loop.
 :use-a-generator (R1729): *Use a generator instead '%s(%s)'*
   Comprehension inside of 'any', 'all', 'max', 'min' or 'sum' is unnecessary. A
   generator would be sufficient and faster.

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -797,9 +797,6 @@ Refactoring checker Messages
   Emitted when a boolean condition can be simplified to a constant value.
 :simplify-boolean-expression (R1709): *Boolean expression may be simplified to %s*
   Emitted when redundant pre-python 2.5 ternary syntax is used.
-:use-yield-from (R1737): *Consider directly using 'yield from' instead*
-  Emitted when yielding from a loop can be replaced by yielding from the
-  iterator directly.
 :consider-using-in (R1714): *Consider merging these comparisons with 'in' by using '%s %sin (%s)'. Use a set instead if elements are hashable.*
   To check if a variable is equal to one of many values, combine the values
   into a set or tuple and check if the variable is contained "in" it instead of
@@ -909,6 +906,9 @@ Refactoring checker Messages
 :unnecessary-comprehension (R1721): *Unnecessary use of a comprehension, use %s instead.*
   Instead of using an identity comprehension, consider using the list, dict or
   set constructor. It is faster and simpler.
+:use-yield-from (R1737): *Use 'yield from' directly instead of yielding each element one by one*
+  Yielding directly from the iterator is faster and arguably cleaner code than
+  yielding each element in the loop.
 :use-a-generator (R1729): *Use a generator instead '%s(%s)'*
   Comprehension inside of 'any', 'all', 'max', 'min' or 'sum' is unnecessary. A
   generator would be sufficient and faster.

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -797,6 +797,9 @@ Refactoring checker Messages
   Emitted when a boolean condition can be simplified to a constant value.
 :simplify-boolean-expression (R1709): *Boolean expression may be simplified to %s*
   Emitted when redundant pre-python 2.5 ternary syntax is used.
+:use-yield-from (R1737): *Consider directly using 'yield from' instead*
+  Emitted when yielding from a loop can be replaced by yield from the iterator
+  directly.
 :consider-using-in (R1714): *Consider merging these comparisons with 'in' by using '%s %sin (%s)'. Use a set instead if elements are hashable.*
   To check if a variable is equal to one of many values, combine the values
   into a set or tuple and check if the variable is contained "in" it instead of

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -798,8 +798,8 @@ Refactoring checker Messages
 :simplify-boolean-expression (R1709): *Boolean expression may be simplified to %s*
   Emitted when redundant pre-python 2.5 ternary syntax is used.
 :use-yield-from (R1737): *Consider directly using 'yield from' instead*
-  Emitted when yielding from a loop can be replaced by yield from the iterator
-  directly.
+  Emitted when yielding from a loop can be replaced by yielding from the
+  iterator directly.
 :consider-using-in (R1714): *Consider merging these comparisons with 'in' by using '%s %sin (%s)'. Use a set instead if elements are hashable.*
   To check if a variable is equal to one of many values, combine the values
   into a set or tuple and check if the variable is contained "in" it instead of

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -544,6 +544,7 @@ All messages in the refactor category:
    refactor/use-dict-literal
    refactor/use-list-literal
    refactor/use-set-for-membership
+   refactor/use-yield-from
    refactor/useless-object-inheritance
    refactor/useless-option-value
    refactor/useless-return

--- a/doc/whatsnew/fragments/9229.feature
+++ b/doc/whatsnew/fragments/9229.feature
@@ -1,0 +1,3 @@
+New message `use-yield-from` added to the refactoring checker. This message is emitted when yielding from a loop can be replaced by `yield from`.
+
+Closes #9229.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -486,7 +486,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         "R1737": (
             "Consider directly using 'yield from' instead",
             "use-yield-from",
-            "Emitted when yielding from a loop can be replaced by yield from.",
+            "Emitted when yielding from a loop can be replaced by yielding from the iterator directly.",
         ),
     }
     options = (

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1134,10 +1134,17 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             return
 
         parent = node.parent.parent
-        if not isinstance(parent, nodes.For) or len(parent.body) != 1:
+        if (
+            not isinstance(parent, nodes.For)
+            or isinstance(parent, nodes.AsyncFor)
+            or len(parent.body) != 1
+        ):
             return
 
         if parent.target.name != node.value.name:
+            return
+
+        if isinstance(node.frame(), nodes.AsyncFunctionDef):
             return
 
         self.add_message("use-yield-from", node.lineno, node, confidence=HIGH)

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -487,7 +487,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "Use 'yield from' directly instead of yielding each element one by one",
             "use-yield-from",
             "Yielding directly from the iterator is faster and arguably cleaner code than yielding each element "
-            "in the loop.",
+            "one by one in the loop.",
         ),
     }
     options = (

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1137,6 +1137,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         if not isinstance(parent, nodes.For) or len(parent.body) != 1:
             return
 
+        if parent.target.name != node.value.name:
+            return
+
         self.add_message("use-yield-from", node.lineno, node, confidence=HIGH)
 
     @staticmethod

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -484,9 +484,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             "The value can be accessed directly instead.",
         ),
         "R1737": (
-            "Consider directly using 'yield from' instead",
+            "Use 'yield from' directly instead of yielding each element one by one",
             "use-yield-from",
-            "Emitted when yielding from a loop can be replaced by yielding from the iterator directly.",
+            "Yielding directly from the iterator is faster and arguably cleaner code than yielding each element "
+            "in the loop.",
         ),
     }
     options = (
@@ -1147,7 +1148,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         if isinstance(node.frame(), nodes.AsyncFunctionDef):
             return
 
-        self.add_message("use-yield-from", node.lineno, node, confidence=HIGH)
+        self.add_message("use-yield-from", node=parent, confidence=HIGH)
 
     @staticmethod
     def _has_exit_in_scope(scope: nodes.LocalsDictNodeNG) -> bool:

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1144,7 +1144,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             elif isinstance(parent.iter, nodes.Call):
                 gen = f"{parent.iter.func.name}()"
 
-            self.add_message("use-yield-from", node.lineno, node, gen)
+            self.add_message("use-yield-from", node.lineno, node, gen, confidence=HIGH)
 
     @staticmethod
     def _has_exit_in_scope(scope: nodes.LocalsDictNodeNG) -> bool:

--- a/tests/functional/b/bad_reversed_sequence.py
+++ b/tests/functional/b/bad_reversed_sequence.py
@@ -1,6 +1,6 @@
 """ Checks that reversed() receive proper argument """
 # pylint: disable=missing-docstring
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods,use-yield-from
 from collections import deque, OrderedDict
 from enum import IntEnum
 

--- a/tests/functional/c/consider/consider_using_enumerate.py
+++ b/tests/functional/c/consider/consider_using_enumerate.py
@@ -1,6 +1,6 @@
 """Emit a message for iteration through range and len is encountered."""
 
-# pylint: disable=missing-docstring, import-error, unsubscriptable-object, too-few-public-methods, unnecessary-list-index-lookup
+# pylint: disable=missing-docstring, import-error, unsubscriptable-object, too-few-public-methods, unnecessary-list-index-lookup, use-yield-from
 
 def bad():
     iterable = [1, 2, 3]

--- a/tests/functional/ext/docparams/return/missing_return_doc_Sphinx.py
+++ b/tests/functional/ext/docparams/return/missing_return_doc_Sphinx.py
@@ -1,7 +1,7 @@
 """Tests for missing-return-doc and missing-return-type-doc for Sphinx style docstrings"""
 # pylint: disable=function-redefined, invalid-name, undefined-variable, missing-function-docstring
 # pylint: disable=unused-argument, disallowed-name, too-few-public-methods, missing-class-docstring
-# pylint: disable=unnecessary-pass
+# pylint: disable=unnecessary-pass, use-yield-from
 import abc
 
 

--- a/tests/functional/i/iterable_context_py36.py
+++ b/tests/functional/i/iterable_context_py36.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,too-few-public-methods,unused-variable,unnecessary-comprehension
+# pylint: disable=missing-docstring,too-few-public-methods,unused-variable,unnecessary-comprehension,use-yield-from
 import asyncio
 
 class AIter:

--- a/tests/functional/n/non/non_iterator_returned.py
+++ b/tests/functional/n/non/non_iterator_returned.py
@@ -1,6 +1,6 @@
 """Check non-iterators returned by __iter__ """
 
-# pylint: disable=too-few-public-methods, missing-docstring, consider-using-with, import-error
+# pylint: disable=too-few-public-methods, missing-docstring, consider-using-with, import-error, use-yield-from
 from uninferable import UNINFERABLE
 
 class FirstGoodIterator:

--- a/tests/functional/s/stop_iteration_inside_generator.py
+++ b/tests/functional/s/stop_iteration_inside_generator.py
@@ -2,7 +2,7 @@
 Test that no StopIteration is raised inside a generator
 """
 # pylint: disable=missing-docstring,invalid-name,import-error, try-except-raise, wrong-import-position
-# pylint: disable=not-callable,raise-missing-from,broad-exception-raised
+# pylint: disable=not-callable,raise-missing-from,broad-exception-raised,use-yield-from
 import asyncio
 
 class RebornStopIteration(StopIteration):

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring, multiple-statements, import-outside-toplevel
 # pylint: disable=too-few-public-methods, bare-except, broad-except
 # pylint: disable=using-constant-test, import-error, global-variable-not-assigned, unnecessary-comprehension
-# pylint: disable=unnecessary-lambda-assignment
+# pylint: disable=unnecessary-lambda-assignment, use-yield-from
 
 
 from typing import TYPE_CHECKING

--- a/tests/functional/u/unpacking/unpacking_non_sequence.py
+++ b/tests/functional/u/unpacking/unpacking_non_sequence.py
@@ -1,6 +1,6 @@
 """Check unpacking non-sequences in assignments. """
 
-# pylint: disable=too-few-public-methods, invalid-name, attribute-defined-outside-init, unused-variable
+# pylint: disable=too-few-public-methods, invalid-name, attribute-defined-outside-init, unused-variable, use-yield-from
 # pylint: disable=using-constant-test, missing-docstring, wrong-import-order,wrong-import-position,no-else-return
 from os import rename as nonseq_func
 from functional.u.unpacking.unpacking import nonseq

--- a/tests/functional/u/use/use_implicit_booleaness_not_len.py
+++ b/tests/functional/u/use/use_implicit_booleaness_not_len.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-few-public-methods,import-error, missing-docstring
+# pylint: disable=too-few-public-methods,import-error, missing-docstring, use-yield-from
 # pylint: disable=useless-super-delegation,wrong-import-position,invalid-name, wrong-import-order, condition-evals-to-constant
 
 if len('TEST'):  # [use-implicit-booleaness-not-len]

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -32,3 +32,8 @@ def yield_attr():
 def yield_attr_nested():
     for item in factory.kiwi.gen():
         yield item  # [use-yield-from]
+
+
+def yield_expr():
+    for item in [1, 2, 3]:
+        yield item  # [use-yield-from]

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring, import-error
 
+import factory
 from magic import shazam, turbogen
 
 
@@ -21,3 +22,13 @@ def good(generator):
 
 def yield_something():
     yield 5
+
+
+def yield_attr():
+    for item in factory.gen():
+        yield item  # [use-yield-from]
+
+
+def yield_attr_nested():
+    for item in factory.kiwi.gen():
+        yield item  # [use-yield-from]

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -5,13 +5,13 @@ from magic import shazam, turbogen
 yield 1
 
 def bad(generator):
-    for item in generator:
-        yield item  # [use-yield-from]
+    for item in generator:  # [use-yield-from]
+        yield item
 
 
 def out_of_names():
-    for item in turbogen():
-        yield item  # [use-yield-from]
+    for item in turbogen():  # [use-yield-from]
+        yield item
 
 
 def good(generator):
@@ -25,18 +25,18 @@ def yield_something():
 
 
 def yield_attr():
-    for item in factory.gen():
-        yield item  # [use-yield-from]
+    for item in factory.gen():  # [use-yield-from]
+        yield item
 
 
 def yield_attr_nested():
-    for item in factory.kiwi.gen():
-        yield item  # [use-yield-from]
+    for item in factory.kiwi.gen():  # [use-yield-from]
+        yield item
 
 
 def yield_expr():
-    for item in [1, 2, 3]:
-        yield item  # [use-yield-from]
+    for item in [1, 2, 3]:  # [use-yield-from]
+        yield item
 
 
 def for_else_yield(gen, something):

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -1,0 +1,23 @@
+# pylint: disable=missing-docstring, import-error
+
+from magic import shazam, turbogen
+
+
+def bad(generator):
+    for item in generator:
+        yield item  # [use-yield-from]
+
+
+def out_of_names():
+    for item in turbogen():
+        yield item  # [use-yield-from]
+
+
+def good(generator):
+    for item in generator:
+        shazam()
+        yield item
+
+
+def yield_something():
+    yield 5

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -45,3 +45,15 @@ def for_else_yield(gen, something):
             break
     else:
         yield something
+
+
+# yield from is not supported in async functions, so the following are fine
+
+async def async_for_yield(agen):
+    async for item in agen:
+        yield item
+
+
+async def async_yield(agen):
+    for item in agen:
+        yield item

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -1,8 +1,8 @@
-# pylint: disable=missing-docstring, import-error
-
+# pylint: disable=missing-docstring, import-error, yield-outside-function
 import factory
 from magic import shazam, turbogen
 
+yield 1
 
 def bad(generator):
     for item in generator:
@@ -37,3 +37,11 @@ def yield_attr_nested():
 def yield_expr():
     for item in [1, 2, 3]:
         yield item  # [use-yield-from]
+
+
+def for_else_yield(gen, something):
+    for item in gen():
+        if shazam(item):
+            break
+    else:
+        yield something

--- a/tests/functional/u/use/use_yield_from.txt
+++ b/tests/functional/u/use/use_yield_from.txt
@@ -1,5 +1,5 @@
-use-yield-from:9:8:9:18:bad:Consider directly using 'yield from' instead:HIGH
-use-yield-from:14:8:14:18:out_of_names:Consider directly using 'yield from' instead:HIGH
-use-yield-from:29:8:29:18:yield_attr:Consider directly using 'yield from' instead:HIGH
-use-yield-from:34:8:34:18:yield_attr_nested:Consider directly using 'yield from' instead:HIGH
-use-yield-from:39:8:39:18:yield_expr:Consider directly using 'yield from' instead:HIGH
+use-yield-from:8:4:9:18:bad:Use 'yield from' directly instead of yielding each element one by one:HIGH
+use-yield-from:13:4:14:18:out_of_names:Use 'yield from' directly instead of yielding each element one by one:HIGH
+use-yield-from:28:4:29:18:yield_attr:Use 'yield from' directly instead of yielding each element one by one:HIGH
+use-yield-from:33:4:34:18:yield_attr_nested:Use 'yield from' directly instead of yielding each element one by one:HIGH
+use-yield-from:38:4:39:18:yield_expr:Use 'yield from' directly instead of yielding each element one by one:HIGH

--- a/tests/functional/u/use/use_yield_from.txt
+++ b/tests/functional/u/use/use_yield_from.txt
@@ -1,4 +1,5 @@
-use-yield-from:9:8:9:18:bad:Consider directly using 'yield from generator' instead:HIGH
-use-yield-from:14:8:14:18:out_of_names:Consider directly using 'yield from turbogen()' instead:HIGH
-use-yield-from:29:8:29:18:yield_attr:Consider directly using 'yield from factory.gen()' instead:HIGH
-use-yield-from:34:8:34:18:yield_attr_nested:Consider directly using 'yield from factory.kiwi.gen()' instead:HIGH
+use-yield-from:9:8:9:18:bad:Consider directly using 'yield from' instead:HIGH
+use-yield-from:14:8:14:18:out_of_names:Consider directly using 'yield from' instead:HIGH
+use-yield-from:29:8:29:18:yield_attr:Consider directly using 'yield from' instead:HIGH
+use-yield-from:34:8:34:18:yield_attr_nested:Consider directly using 'yield from' instead:HIGH
+use-yield-from:39:8:39:18:yield_expr:Consider directly using 'yield from' instead:HIGH

--- a/tests/functional/u/use/use_yield_from.txt
+++ b/tests/functional/u/use/use_yield_from.txt
@@ -1,2 +1,4 @@
-use-yield-from:8:8:8:18:bad:Consider directly using 'yield from generator' instead:HIGH
-use-yield-from:13:8:13:18:out_of_names:Consider directly using 'yield from turbogen()' instead:HIGH
+use-yield-from:9:8:9:18:bad:Consider directly using 'yield from generator' instead:HIGH
+use-yield-from:14:8:14:18:out_of_names:Consider directly using 'yield from turbogen()' instead:HIGH
+use-yield-from:29:8:29:18:yield_attr:Consider directly using 'yield from factory.gen()' instead:HIGH
+use-yield-from:34:8:34:18:yield_attr_nested:Consider directly using 'yield from factory.kiwi.gen()' instead:HIGH

--- a/tests/functional/u/use/use_yield_from.txt
+++ b/tests/functional/u/use/use_yield_from.txt
@@ -1,0 +1,2 @@
+use-yield-from:8:8:8:18:bad:Consider directly using 'yield from generator' instead:UNDEFINED
+use-yield-from:13:8:13:18:out_of_names:Consider directly using 'yield from turbogen()' instead:UNDEFINED

--- a/tests/functional/u/use/use_yield_from.txt
+++ b/tests/functional/u/use/use_yield_from.txt
@@ -1,2 +1,2 @@
-use-yield-from:8:8:8:18:bad:Consider directly using 'yield from generator' instead:UNDEFINED
-use-yield-from:13:8:13:18:out_of_names:Consider directly using 'yield from turbogen()' instead:UNDEFINED
+use-yield-from:8:8:8:18:bad:Consider directly using 'yield from generator' instead:HIGH
+use-yield-from:13:8:13:18:out_of_names:Consider directly using 'yield from turbogen()' instead:HIGH

--- a/tests/functional/y/yield_assign.py
+++ b/tests/functional/y/yield_assign.py
@@ -1,3 +1,4 @@
+# pylint: disable=use-yield-from
 """https://www.logilab.org/ticket/8771"""
 
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
A new message has been added to suggest refactoring when yielding from a for loop can be replaced by 'yield from'. This message is only emitted when there are no other statements in the containing for loop.

Closes #9229.
