### PR TITLE
[primer] Allow primer comment job to recreate venv

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -44,7 +44,6 @@ jobs:
         uses: actions/cache@v4.0.0
         with:
           path: venv
-          fail-on-cache-miss: true
           key:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
If five days elapse without a commit on main, the artifacts created by the last primer / main job are still around, and can be used by the compare job, but the compare job will fail because the venv it needs will likely have been evicted in the meantime because we cache so much and are constantly running low on space.

The solve here is to just let the compare job recreate the venv. I tested by rerunning the primer / main job, and without even waiting for it to finish, I could [rerun this failing primer / comment job](https://github.com/pylint-dev/pylint/actions/runs/7855219897/job/21437376819), and it succeeded.


Refs https://github.com/pylint-dev/pylint/pull/9419#issuecomment-1937019507