### PR TITLE
Catch ValueError - generator already executing

### DIFF
--- a/.pyenchant_pylint_custom_dict.txt
+++ b/.pyenchant_pylint_custom_dict.txt
@@ -361,6 +361,7 @@ unicode
 Uninferable
 uninferable
 unittest
+unraisablehook
 untriggered
 # prefix for string
 ur

--- a/doc/whatsnew/fragments/9138.bugfix
+++ b/doc/whatsnew/fragments/9138.bugfix
@@ -1,0 +1,4 @@
+Catch incorrect ValueError ``"generator already executing"`` for Python 3.12.0 - 3.12.2.
+This is fixed upstream in Python 3.12.3.
+
+Closes #9138

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -95,4 +95,25 @@ def modify_sys_path() -> None:
         sys.path.pop(1)
 
 
+def _catch_valueerror(unraisable: sys.UnraisableHookArgs) -> None:
+    """Overwrite sys.unraisablehook to catch incorrect ValueError.
+
+    Python 3.12 introduced changes that sometimes cause astroid to emit ValueErrors
+    with 'generator already executing'. Fixed in Python 3.12.3 and 3.13.
+
+    https://github.com/pylint-dev/pylint/issues/9138
+    """
+    if (
+        isinstance(unraisable.exc_value, ValueError)
+        and unraisable.exc_value.args[0] == "generator already executing"
+    ):
+        return
+
+    sys.__unraisablehook__(unraisable)
+
+
+if (3, 12, 0) <= sys.version_info[:3] < (3, 12, 3):
+    sys.unraisablehook = _catch_valueerror
+
+
 version = __version__

--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -95,7 +95,7 @@ def modify_sys_path() -> None:
         sys.path.pop(1)
 
 
-def _catch_valueerror(unraisable: sys.UnraisableHookArgs) -> None:
+def _catch_valueerror(unraisable: sys.UnraisableHookArgs) -> None:  # pragma: no cover
     """Overwrite sys.unraisablehook to catch incorrect ValueError.
 
     Python 3.12 introduced changes that sometimes cause astroid to emit ValueErrors


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Overwrite `sys.unraisablehook` to catch `ValueError` - `"generator already executing"` messages for Python 3.12.0 - 3.12.2 only. This is fixed upstream in both `3.12.3` and `3.13a2+`.

Closes #9138 
