### PR TITLE
Bump pylint to 3.0.4, update changelog

### DIFF
--- a/doc/whatsnew/3/3.0/index.rst
+++ b/doc/whatsnew/3/3.0/index.rst
@@ -65,6 +65,46 @@ easier to parse and provides more info, here's a sample output.
 
 .. towncrier release notes start
 
+What's new in Pylint 3.0.4?
+---------------------------
+Release date: 2024-02-23
+
+
+False Positives Fixed
+---------------------
+
+- ``used-before-assignment`` is no longer emitted when using a name in a loop and
+  depending on an earlier name assignment in an ``except`` block paired with
+  ``else: continue``.
+
+  Closes #6804 (`#6804 <https://github.com/pylint-dev/pylint/issues/6804>`_)
+
+- Avoid false positives for ``no-member`` involving function
+  attributes supplied by decorators.
+
+  Closes #9246 (`#9246 <https://github.com/pylint-dev/pylint/issues/9246>`_)
+
+- Fixed false positive nested-min-max for nested lists.
+
+  Closes #9307 (`#9307 <https://github.com/pylint-dev/pylint/issues/9307>`_)
+
+- Fix false positive for ``used-before-assignment`` in a ``finally`` block
+  when assignments took place in both the ``try`` block and each exception handler.
+
+  Closes #9451 (`#9451 <https://github.com/pylint-dev/pylint/issues/9451>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Catch incorrect ValueError ``"generator already executing"`` for Python 3.12.0 - 3.12.2.
+  This is fixed upstream in Python 3.12.3.
+
+  Closes #9138 (`#9138 <https://github.com/pylint-dev/pylint/issues/9138>`_)
+
+
+
 What's new in Pylint 3.0.3?
 ---------------------------
 Release date: 2023-12-11

--- a/doc/whatsnew/fragments/6804.false_positive
+++ b/doc/whatsnew/fragments/6804.false_positive
@@ -1,5 +1,0 @@
-``used-before-assignment`` is no longer emitted when using a name in a loop and
-depending on an earlier name assignment in an ``except`` block paired with
-``else: continue``.
-
-Closes #6804

--- a/doc/whatsnew/fragments/9138.bugfix
+++ b/doc/whatsnew/fragments/9138.bugfix
@@ -1,4 +1,0 @@
-Catch incorrect ValueError ``"generator already executing"`` for Python 3.12.0 - 3.12.2.
-This is fixed upstream in Python 3.12.3.
-
-Closes #9138

--- a/doc/whatsnew/fragments/9246.false_positive
+++ b/doc/whatsnew/fragments/9246.false_positive
@@ -1,4 +1,0 @@
-Avoid false positives for ``no-member`` involving function
-attributes supplied by decorators.
-
-Closes #9246

--- a/doc/whatsnew/fragments/9307.false_positive
+++ b/doc/whatsnew/fragments/9307.false_positive
@@ -1,3 +1,0 @@
-Fixed false positive nested-min-max for nested lists.
-
-Closes #9307

--- a/doc/whatsnew/fragments/9451.false_positive
+++ b/doc/whatsnew/fragments/9451.false_positive
@@ -1,4 +1,0 @@
-Fix false positive for ``used-before-assignment`` in a ``finally`` block
-when assignments took place in both the ``try`` block and each exception handler.
-
-Closes #9451

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.0.3"
+__version__ = "3.0.4"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.0.3"
+current = "3.0.4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.0.3"
+version = "3.0.4"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.0/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.0.4?
---------------------------
Release date: 2024-02-23


False Positives Fixed
---------------------

- ``used-before-assignment`` is no longer emitted when using a name in a loop and
  depending on an earlier name assignment in an ``except`` block paired with
  ``else: continue``.

  Closes #6804

- Avoid false positives for ``no-member`` involving function
  attributes supplied by decorators.

  Closes #9246 

- Fixed false positive nested-min-max for nested lists.

  Closes #9307 

- Fix false positive for ``used-before-assignment`` in a ``finally`` block
  when assignments took place in both the ``try`` block and each exception handler.

  Closes #9451 



Other Bug Fixes
---------------

- Catch incorrect ValueError ``"generator already executing"`` for Python 3.12.0 - 3.12.2.
  This is fixed upstream in Python 3.12.3.

  Closes #9138 

