### PR TITLE
Release branch 3.1.0

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -156,6 +156,8 @@ contributors:
   * Added new extension which detects comparing integers to zero,
   * Added new useless-return checker,
   * Added new try-except-raise checker
+- theirix <theirix@gmail.com>
+- crazybolillo <antonio@zoftko.com>
 - Téo Bouvard <teobouvard@gmail.com>
 - Stavros Ntentos <133706+stdedos@users.noreply.github.com>
 - Nicolas Boulenguez <nicolas@debian.org>
@@ -172,7 +174,6 @@ contributors:
 - Andreas Freimuth <andreas.freimuth@united-bits.de>: fix indentation checking with tabs
 - Alexandru Coman <fcoman@bitdefender.com>
 - jpkotta <jpkotta@gmail.com>
-- crazybolillo <antonio@zoftko.com>
 - Takahide Nojima <nozzy123nozzy@gmail.com>
 - Taewon D. Kim <kimt33@mcmaster.ca>
 - Sneaky Pete <sneakypete81@gmail.com>
@@ -249,6 +250,7 @@ contributors:
 - omarandlorraine <64254276+omarandlorraine@users.noreply.github.com>
 - craig-sh <craig-sh@users.noreply.github.com>
 - bernie gray <bfgray3@users.noreply.github.com>
+- azinneck0485 <123660683+azinneck0485@users.noreply.github.com>
 - Wes Turner <westurner@google.com> (Google): added new check 'inconsistent-quotes'
 - Tyler Thieding <tyler@thieding.com>
 - Tobias Hernstig <30827238+thernstig@users.noreply.github.com>
@@ -364,12 +366,14 @@ contributors:
 - Yann Dirson <ydirson@free.fr>
 - Yang Yang <y4n9squared@gmail.com>
 - Xi Shen <davidshen84@gmail.com>
+- Winston H <56998716+winstxnhdw@users.noreply.github.com>
 - Will Shanks <wsha@posteo.net>
 - Viorel Știrbu <viorels@gmail.com>: intern-builtin warning.
 - VictorT <victor.taix@gmail.com>
 - Victor Jiajunsu <16359131+jiajunsu@users.noreply.github.com>
 - ViRuSTriNiTy <cradle-of-mail@gmx.de>
 - Val Lorentz <progval+github@progval.net>
+- Udi Fuchs <udifuchs@gmail.com>
 - Trevor Bekolay <tbekolay@gmail.com>
   * Added --list-msgs-enabled command
 - Tomer Chachamu <tomer.chachamu@gmail.com>: simplifiable-if-expression
@@ -394,11 +398,13 @@ contributors:
 - Sigurd Spieckermann <2206639+sisp@users.noreply.github.com>
 - Shiv Venkatasubrahmanyam <shvenkat@users.noreply.github.com>
 - Sebastian Müller <mueller.seb@posteo.de>
+- Sayyed Faisal Ali <80758388+C0DE-SLAYER@users.noreply.github.com>
 - Sasha Bagan <pnlbagan@gmail.com>
 - Sardorbek Imomaliev <sardorbek.imomaliev@gmail.com>
 - Santiago Castro <bryant@montevideo.com.uy>
 - Samuel Freilich <sfreilich@google.com> (sfreilich)
 - Sam Vermeiren <88253337+PaaEl@users.noreply.github.com>
+- Ryan Ozawa <ryan.ozawa21@gmail.com>
 - Ryan McGuire <ryan@enigmacurry.com>
 - Ry4an Brase <ry4an-hg@ry4an.org>
 - Ruro <ruro.ruro@ya.ru>
@@ -435,22 +441,28 @@ contributors:
 - Neowizard <Neowizard@users.noreply.github.com>
 - Ned Batchelder <ned@nedbatchelder.com>
 - Natalie Serebryakova <natalie.serebryakova@Natalies-MacBook-Pro.local>
+- Naglis Jonaitis <827324+naglis@users.noreply.github.com>
 - Moody <mooodyhunter@outlook.com>
 - Mitchell Young <mitchelly@gmail.com>: minor adjustment to docparams
 - Mitar <mitar.github@tnode.com>
+- Ming Lyu <CareF.Lm@gmail.com>
 - Mikhail f. Shiryaev <mr.felixoid@gmail.com>
 - Mike Fiedler <miketheman@gmail.com> (miketheman)
 - Mike Bryant <leachim@leachim.info>
+- Mike Bernard <mdbernard@pm.me>
 - Michka Popoff <michkapopoff@gmail.com>
 - Michal Vasilek <michal@vasilek.cz>
 - Michael Scott Cuthbert <cuthbert@mit.edu>
 - Michael Kefeder <oss@multiwave.ch>
+- Michael K <michael-k@users.noreply.github.com>
 - Michael Hudson-Doyle <michael.hudson@canonical.com>
 - Michael Giuffrida <mgiuffrida@users.noreply.github.com>
 - Melvin Hazeleger <31448155+melvio@users.noreply.github.com>
+- Meltem Kenis <meltem.kenis@plentific.com>
 - Mehdi Drissi <mdrissi@hmc.edu>
 - Matěj Grabovský <mgrabovs@redhat.com>
 - Matthijs Blom <19817960+MatthijsBlom@users.noreply.github.com>
+- Matej Spiller Muys <matej.spiller-muys@bitstamp.net>
 - Matej Marušák <marusak.matej@gmail.com>
 - Markus Siebenhaar <41283549+siehar@users.noreply.github.com>
 - Marco Edward Gorelli <marcogorelli@protonmail.com>: Documented Jupyter integration
@@ -529,6 +541,7 @@ contributors:
 - Dr. Nick <das-intensity@users.noreply.github.com>
 - Don Jayamanne <don.jayamanne@yahoo.com>
 - Dmytro Kyrychuk <dmytro.kyrychuck@gmail.com>
+- Dionisio E Alonso <baco@users.noreply.github.com>
 - DetachHead <57028336+DetachHead@users.noreply.github.com>
 - Denis Laxalde <denis.laxalde@logilab.fr>
 - David Lawson <dmrlawson@gmail.com>
@@ -547,6 +560,7 @@ contributors:
 - Cubicpath <Cubicpath@protonmail.com>
 - Craig Citro <craigcitro@gmail.com>
 - Cosmo <cosmo@cosmo.red>
+- Clément Schreiner <clement@mux.me>
 - Clément Pit-Claudel <cpitclaudel@users.noreply.github.com>
 - Christopher Zurcher <zurcher@users.noreply.github.com>
 - Christian Clauss <cclauss@me.com>
@@ -580,6 +594,7 @@ contributors:
 - Andrew Howe <howeaj@users.noreply.github.com>
 - Andres Perez Hortal <andresperezcba@gmail.com>
 - Andre Hora <andrehora@users.noreply.github.com>
+- Aman Salwan <121633121+AmanSal1@users.noreply.github.com>
 - Alok Singh <8325708+alok@users.noreply.github.com>
 - Allan Chandler <95424144+allanc65@users.noreply.github.com> (allanc65)
   * Fixed issue 5452, false positive missing-param-doc for multi-line Google-style params

--- a/doc/development_guide/contributor_guide/release.rst
+++ b/doc/development_guide/contributor_guide/release.rst
@@ -64,7 +64,7 @@ For example:
    close ``2.4.0``, create ``2.4.1`` and ``2.6.0``)
 -  Hide and deactivate all the patch releases for the previous minor
    release on
-   `readthedoc <https://readthedocs.org/projects/pylint/versions/>`__,
+   `readthedocs <https://readthedocs.org/projects/pylint/versions/>`__,
    except the last one. (For example: hide ``v2.4.0``, ``v2.4.1``,
    ``v2.4.2`` and keep only ``v2.4.3``)
 

--- a/doc/whatsnew/3/3.1/index.rst
+++ b/doc/whatsnew/3/3.1/index.rst
@@ -7,10 +7,116 @@
    :maxdepth: 2
 
 :Release:3.1
-:Date: TBA
+:Date: 2024-02-25
 
 Summary -- Release highlights
 =============================
 
+Two new checks--``use-yield-from``, ``deprecated-attribute``--
+and a smattering of bug fixes.
 
 .. towncrier release notes start
+
+What's new in Pylint 3.1.0?
+---------------------------
+Release date: 2024-02-25
+
+
+New Features
+------------
+
+- Skip ``consider-using-join`` check for non-empty separators if an ``suggest-join-with-non-empty-separator`` option is set to ``no``.
+
+  Closes #8701 (`#8701 <https://github.com/pylint-dev/pylint/issues/8701>`_)
+
+- Discover ``.pyi`` files when linting.
+
+  These can be ignored with the ``ignore-patterns`` setting.
+
+  Closes #9097 (`#9097 <https://github.com/pylint-dev/pylint/issues/9097>`_)
+
+- Check ``TypeAlias`` and ``TypeVar`` (PEP 695) nodes for ``invalid-name``.
+
+  Refs #9196 (`#9196 <https://github.com/pylint-dev/pylint/issues/9196>`_)
+
+- Support for resolving external toml files named pylintrc.toml and .pylintrc.toml.
+
+  Closes #9228 (`#9228 <https://github.com/pylint-dev/pylint/issues/9228>`_)
+
+- Check for `.clear`, `.discard`, `.pop` and `remove` methods being called on a set while it is being iterated over.
+
+  Closes #9334 (`#9334 <https://github.com/pylint-dev/pylint/issues/9334>`_)
+
+
+
+New Checks
+----------
+
+- New message `use-yield-from` added to the refactoring checker. This message is emitted when yielding from a loop can be replaced by `yield from`.
+
+  Closes #9229. (`#9229 <https://github.com/pylint-dev/pylint/issues/9229>`_)
+
+- Added a ``deprecated-attribute`` message to check deprecated attributes in the stdlib.
+
+  Closes #8855 (`#8855 <https://github.com/pylint-dev/pylint/issues/8855>`_)
+
+
+False Positives Fixed
+---------------------
+
+- Fixed false positive for ``inherit-non-class`` for generic Protocols.
+
+  Closes #9106 (`#9106 <https://github.com/pylint-dev/pylint/issues/9106>`_)
+
+- Exempt ``TypedDict`` from ``typing_extensions`` from ``too-many-ancestor`` checks.
+
+  Refs #9167 (`#9167 <https://github.com/pylint-dev/pylint/issues/9167>`_)
+
+
+
+False Negatives Fixed
+---------------------
+
+- Extend broad-exception-raised and broad-exception-caught to except*.
+
+  Closes #8827 (`#8827 <https://github.com/pylint-dev/pylint/issues/8827>`_)
+
+- Fix a false-negative for unnecessary if blocks using a different than expected ordering of arguments.
+
+  Closes #8947. (`#8947 <https://github.com/pylint-dev/pylint/issues/8947>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Improve the message provided for wrong-import-order check.  Instead of the import statement ("import x"), the message now specifies the import that is out of order and which imports should come after it.  As reported in the issue, this is particularly helpful if there are multiple imports on a single line that do not follow the PEP8 convention.
+
+  The message will report imports as follows:
+  For "import X", it will report "(standard/third party/first party/local) import X"
+  For "import X.Y" and "from X import Y", it will report "(standard/third party/first party/local) import X.Y"
+  The import category is specified to provide explanation as to why pylint has issued the message and guidence to the developer on how to fix the problem.
+
+  Closes #8808 (`#8808 <https://github.com/pylint-dev/pylint/issues/8808>`_)
+
+
+
+Other Changes
+-------------
+
+- Print how many files were checked in verbose mode.
+
+  Closes #8935 (`#8935 <https://github.com/pylint-dev/pylint/issues/8935>`_)
+
+- Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.
+
+  Closes #9100 (`#9100 <https://github.com/pylint-dev/pylint/issues/9100>`_)
+
+
+
+Internal Changes
+----------------
+
+- Update astroid version to 3.1.0.
+
+  Refs #9457 (`#9457 <https://github.com/pylint-dev/pylint/issues/9457>`_)

--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -1,0 +1,16 @@
+
+***************************
+ What's New in Pylint 3.2
+***************************
+
+.. toctree::
+   :maxdepth: 2
+
+:Release:3.2
+:Date: TBA
+
+Summary -- Release highlights
+=============================
+
+
+.. towncrier release notes start

--- a/doc/whatsnew/3/index.rst
+++ b/doc/whatsnew/3/index.rst
@@ -6,5 +6,6 @@ This is the full list of change in pylint 3.x minors, by categories.
 .. toctree::
    :maxdepth: 2
 
+   3.2/index
    3.1/index
    3.0/index

--- a/doc/whatsnew/fragments/8701.feature
+++ b/doc/whatsnew/fragments/8701.feature
@@ -1,3 +1,0 @@
-Skip ``consider-using-join`` check for non-empty separators if an ``suggest-join-with-non-empty-separator`` option is set to ``no``.
-
-Closes #8701

--- a/doc/whatsnew/fragments/8808.bugfix
+++ b/doc/whatsnew/fragments/8808.bugfix
@@ -1,8 +1,0 @@
-Improve the message provided for wrong-import-order check.  Instead of the import statement ("import x"), the message now specifies the import that is out of order and which imports should come after it.  As reported in the issue, this is particularly helpful if there are multiple imports on a single line that do not follow the PEP8 convention.
-
-The message will report imports as follows:
-For "import X", it will report "(standard/third party/first party/local) import X"
-For "import X.Y" and "from X import Y", it will report "(standard/third party/first party/local) import X.Y"
-The import category is specified to provide explanation as to why pylint has issued the message and guidence to the developer on how to fix the problem.
-
-Closes #8808

--- a/doc/whatsnew/fragments/8827.false_negative
+++ b/doc/whatsnew/fragments/8827.false_negative
@@ -1,3 +1,0 @@
-Extend broad-exception-raised and broad-exception-caught to except*.
-
-Closes #8827

--- a/doc/whatsnew/fragments/8855.new_check
+++ b/doc/whatsnew/fragments/8855.new_check
@@ -1,3 +1,0 @@
-Added a ``deprecated-attribute`` message to check deprecated attributes in the stdlib.
-
-Closes #8855

--- a/doc/whatsnew/fragments/8935.other
+++ b/doc/whatsnew/fragments/8935.other
@@ -1,3 +1,0 @@
-Print how many files were checked in verbose mode.
-
-Closes #8935

--- a/doc/whatsnew/fragments/8947.false_negative
+++ b/doc/whatsnew/fragments/8947.false_negative
@@ -1,3 +1,0 @@
-Fix a false-negative for unnecessary if blocks using a different than expected ordering of arguments.
-
-Closes #8947.

--- a/doc/whatsnew/fragments/9097.feature
+++ b/doc/whatsnew/fragments/9097.feature
@@ -1,5 +1,0 @@
-Discover ``.pyi`` files when linting.
-
-These can be ignored with the ``ignore-patterns`` setting.
-
-Closes #9097

--- a/doc/whatsnew/fragments/9100.other
+++ b/doc/whatsnew/fragments/9100.other
@@ -1,3 +1,0 @@
-Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.
-
-Closes #9100

--- a/doc/whatsnew/fragments/9106.false_positive
+++ b/doc/whatsnew/fragments/9106.false_positive
@@ -1,3 +1,0 @@
-Fixed false positive for ``inherit-non-class`` for generic Protocols.
-
-Closes #9106

--- a/doc/whatsnew/fragments/9167.false_positive
+++ b/doc/whatsnew/fragments/9167.false_positive
@@ -1,3 +1,0 @@
-Exempt ``TypedDict`` from ``typing_extensions`` from ``too-many-ancestor`` checks.
-
-Refs #9167

--- a/doc/whatsnew/fragments/9196.feature
+++ b/doc/whatsnew/fragments/9196.feature
@@ -1,3 +1,0 @@
-Check ``TypeAlias`` and ``TypeVar`` (PEP 695) nodes for ``invalid-name``.
-
-Refs #9196

--- a/doc/whatsnew/fragments/9228.feature
+++ b/doc/whatsnew/fragments/9228.feature
@@ -1,3 +1,0 @@
-Support for resolving external toml files named pylintrc.toml and .pylintrc.toml.
-
-Closes #9228

--- a/doc/whatsnew/fragments/9229.feature
+++ b/doc/whatsnew/fragments/9229.feature
@@ -1,3 +1,0 @@
-New message `use-yield-from` added to the refactoring checker. This message is emitted when yielding from a loop can be replaced by `yield from`.
-
-Closes #9229.

--- a/doc/whatsnew/fragments/9334.feature
+++ b/doc/whatsnew/fragments/9334.feature
@@ -1,3 +1,0 @@
-Check for `.clear`, `.discard`, `.pop` and `remove` methods being called on a set while it is being iterated over.
-
-Closes #9334

--- a/doc/whatsnew/fragments/9457.internal
+++ b/doc/whatsnew/fragments/9457.internal
@@ -1,3 +1,0 @@
-Update astroid version to 3.1.0.
-
-Refs #9457

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -468,6 +468,11 @@ max-nested-blocks=5
 # printed.
 never-returning-functions=sys.exit,argparse.parse_error
 
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
 
 [REPORTS]
 

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -394,6 +394,10 @@ max-nested-blocks = 5
 # considered as an explicit return statement and no message will be printed.
 never-returning-functions = ["sys.exit", "argparse.parse_error"]
 
+# Let 'consider-using-join' be raised when the separator to join on would be non-
+# empty (resulting in expected fixes of the type: ``"- " + " - ".join(items)``)
+suggest-join-with-non-empty-separator = true
+
 [tool.pylint.reports]
 # Python expression which should return a score less than or equal to 10. You
 # have access to the variables 'fatal', 'error', 'warning', 'refactor',

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.1.0-dev0"
+__version__ = "3.1.0"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.1.0"
+__version__ = "3.2.0-dev0"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.1.0-dev0"
+current = "3.1.0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.1.0"
+current = "3.2.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,7 +1,7 @@
 [tool.towncrier]
-version = "3.1.0"
+version = "3.2.0"
 directory = "doc/whatsnew/fragments"
-filename = "doc/whatsnew/3/3.1/index.rst"
+filename = "doc/whatsnew/3/3.2/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"
 issue_format = "`#{issue} <https://github.com/pylint-dev/pylint/issues/{issue}>`_"
 wrap = false  # doesn't wrap links correctly if beginning with indentation


### PR DESCRIPTION
What's new in Pylint 3.1.0?
---------------------------
Release date: 2024-02-25


New Features
------------

- Skip ``consider-using-join`` check for non-empty separators if an ``suggest-join-with-non-empty-separator`` option is set to ``no``.

  Closes #8701 

- Discover ``.pyi`` files when linting.

  These can be ignored with the ``ignore-patterns`` setting.

  Closes #9097 

- Check ``TypeAlias`` and ``TypeVar`` (PEP 695) nodes for ``invalid-name``.

  Refs #9196 

- Support for resolving external toml files named pylintrc.toml and .pylintrc.toml.

  Closes #9228 

- Check for `.clear`, `.discard`, `.pop` and `remove` methods being called on a set while it is being iterated over.

  Closes #9334 



New Checks
----------

- New message `use-yield-from` added to the refactoring checker. This message is emitted when yielding from a loop can be replaced by `yield from`.

  Closes #9229. 

- Added a ``deprecated-attribute`` message to check deprecated attributes in the stdlib.

  Closes #8855 


False Positives Fixed
---------------------

- Fixed false positive for ``inherit-non-class`` for generic Protocols.

  Closes #9106

- Exempt ``TypedDict`` from ``typing_extensions`` from ``too-many-ancestor`` checks.

  Refs #9167 



False Negatives Fixed
---------------------

- Extend broad-exception-raised and broad-exception-caught to except*.

  Closes #8827 

- Fix a false-negative for unnecessary if blocks using a different than expected ordering of arguments.

  Closes #8947. 



Other Bug Fixes
---------------

- Improve the message provided for wrong-import-order check.  Instead of the import statement ("import x"), the message now specifies the import that is out of order and which imports should come after it.  As reported in the issue, this is particularly helpful if there are multiple imports on a single line that do not follow the PEP8 convention.

  The message will report imports as follows:
  For "import X", it will report "(standard/third party/first party/local) import X"
  For "import X.Y" and "from X import Y", it will report "(standard/third party/first party/local) import X.Y"
  The import category is specified to provide explanation as to why pylint has issued the message and guidence to the developer on how to fix the problem.

  Closes #8808 



Other Changes
-------------

- Print how many files were checked in verbose mode.

  Closes #8935 

- Fix a crash when an enum class which is also decorated with a ``dataclasses.dataclass`` decorator is defined.

  Closes #9100 



Internal Changes
----------------

- Update astroid version to 3.1.0.

  Refs #9457 
