### PR TITLE
[primer] Only prime pandas.core

### DIFF
--- a/tests/primer/packages_to_prime.json
+++ b/tests/primer/packages_to_prime.json
@@ -34,7 +34,7 @@
   },
   "pandas": {
     "branch": "main",
-    "directories": ["pandas"],
+    "directories": ["pandas/core"],
     "pylint_additional_args": ["--ignore-patterns=\"test_"],
     "url": "https://github.com/pandas-dev/pandas"
   },


### PR DESCRIPTION
Thousands of messages are going in/out of the baseline on every PR, adding noise and friction to the contribution experience, and hiding other legitimate feedback due to comment length limitations. Make a start toward reducing this.