### PR TITLE
Add GitHub reporter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,8 +77,7 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        args:
-          ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I", "--output-format=github"]
+        args: ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I"]
         exclude: tests(/\w*)*/functional/|tests/input|tests(/\w*)*data/|doc/
       # We define an additional manual step to allow running pylint with a spelling
       # checker in CI.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,8 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        args: ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I"]
+        args:
+          ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I", "--output-format=github"]
         exclude: tests(/\w*)*/functional/|tests/input|tests(/\w*)*data/|doc/
       # We define an additional manual step to allow running pylint with a spelling
       # checker in CI.
@@ -87,7 +88,15 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        args: ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I", "--spelling-dict=en"]
+        args:
+          [
+            "-rn",
+            "-sn",
+            "--rcfile=pylintrc",
+            "--fail-on=I",
+            "--spelling-dict=en",
+            "--output-format=github",
+          ]
         exclude: tests(/\w*)*/functional/|tests/input|tests(/\w*)*data/|doc/
         stages: [manual]
       - id: sphinx-generated-doc

--- a/doc/whatsnew/fragments/9443.feature
+++ b/doc/whatsnew/fragments/9443.feature
@@ -1,4 +1,4 @@
-A new `github` reporter has been added. This reporter automatically annotates code on GitHub's user interface
-with the messages found during linting. Use it with `pylint --output-format=github`.
+A new `github` reporter has been added. This reporter  returns the output of `pylint` in a format that
+Github can use to automatically annotate code. Use it with `pylint --output-format=github` on your Github Workflows.
 
 Closes #9443.

--- a/doc/whatsnew/fragments/9443.feature
+++ b/doc/whatsnew/fragments/9443.feature
@@ -1,0 +1,4 @@
+A new `github` reporter has been added. This reporter automatically annotates code on GitHub's user interface
+with the messages found during linting. Use it with `pylint --output-format=github`.
+
+Closes #9443.

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -276,7 +276,7 @@ class GithubReporter(TextReporter):
         for key in ("end_line", "end_column"):
             self_dict[key] = self_dict[key] or ""
 
-        self_dict["category"] = self.category_map.get(msg.msg_id[:1]) or "error"
+        self_dict["category"] = self.category_map.get(msg.C) or "error"
         self.writeln(self._fixed_template.format(**self_dict))
 
 

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -255,9 +255,35 @@ class ColorizedTextReporter(TextReporter):
         self.write_message(msg)
 
 
+class GithubReporter(TextReporter):
+    """Report messages in GitHub's special format to annotate code in its user
+    interface.
+    """
+
+    name = "github"
+    line_format = "::{category} file={path},line={line},endline={end_line},col={column},title={msg_id}::{msg}"
+    category_map = {
+        "F": "error",
+        "E": "error",
+        "W": "warning",
+        "C": "notice",
+        "R": "notice",
+        "I": "notice",
+    }
+
+    def write_message(self, msg: Message) -> None:
+        self_dict = asdict(msg)
+        for key in ("end_line", "end_column"):
+            self_dict[key] = self_dict[key] or ""
+
+        self_dict["category"] = self.category_map.get(msg.msg_id[:1]) or "error"
+        self.writeln(self._fixed_template.format(**self_dict))
+
+
 def register(linter: PyLinter) -> None:
     linter.register_reporter(TextReporter)
     linter.register_reporter(NoHeaderReporter)
     linter.register_reporter(ParseableTextReporter)
     linter.register_reporter(VSTextReporter)
     linter.register_reporter(ColorizedTextReporter)
+    linter.register_reporter(GithubReporter)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -33,7 +33,7 @@ from pylint.lint.pylinter import PyLinter
 from pylint.message import Message
 from pylint.reporters import BaseReporter
 from pylint.reporters.json_reporter import JSON2Reporter
-from pylint.reporters.text import ColorizedTextReporter, TextReporter
+from pylint.reporters.text import ColorizedTextReporter, GithubReporter, TextReporter
 from pylint.testutils._run import _add_rcfile_default_pylintrc
 from pylint.testutils._run import _Run as Run
 from pylint.testutils.utils import (
@@ -189,6 +189,7 @@ class TestRunTC:
             TextReporter(StringIO()),
             ColorizedTextReporter(StringIO()),
             JSON2Reporter(StringIO()),
+            GithubReporter(StringIO()),
         ]
         self._runtest(
             [join(HERE, "functional", "a", "arguments.py")],


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
A new `github` reporter has been added. This reporter automatically annotates code on GitHub's UI with the messages found during linting.

Closes #9443.
