### PR TITLE
Fix useless-return false negatives

### DIFF
--- a/doc/whatsnew/fragments/9449.false_negative
+++ b/doc/whatsnew/fragments/9449.false_negative
@@ -1,0 +1,3 @@
+If and Try nodes are now checked for useless return statements as well.
+
+Closes #9449.

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -686,7 +686,6 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                     isinstance(prev, nodes.ImportFrom) and prev.modname == "__future__"
                 ):
                     self.add_message("misplaced-future", node=node)
-            return
 
     def _check_same_line_imports(self, node: nodes.ImportFrom) -> None:
         # Detect duplicate imports on the same line.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2078,12 +2078,18 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         Per its implementation and PEP8 we can have a "return None" at the end
         of the function body if there are other return statements before that!
         """
-        if len(self._return_nodes[node.name]) > 1:
+        if len(self._return_nodes[node.name]) != 1:
             return
-        if len(node.body) <= 1:
+        if not node.body:
             return
 
         last = node.body[-1]
+        if isinstance(last, nodes.Return) and len(node.body) == 1:
+            return
+
+        while isinstance(last, (nodes.If, nodes.Try, nodes.ExceptHandler)):
+            last = last.last_child()
+
         if isinstance(last, nodes.Return):
             # e.g. "return"
             if last.value is None:

--- a/tests/functional/i/inconsistent/inconsistent_returns.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns.py
@@ -1,5 +1,5 @@
 #pylint: disable=missing-docstring, no-else-return, no-else-break, invalid-name, unused-variable, superfluous-parens, try-except-raise
-#pylint: disable=disallowed-name,too-few-public-methods,no-member,useless-else-on-loop
+#pylint: disable=disallowed-name,too-few-public-methods,no-member,useless-else-on-loop,useless-return
 """Testing inconsistent returns"""
 import math
 import sys

--- a/tests/functional/u/used/used_before_assignment_else_return.py
+++ b/tests/functional/u/used/used_before_assignment_else_return.py
@@ -1,5 +1,5 @@
 """If the else block returns, it is generally safe to rely on assignments in the except."""
-# pylint: disable=missing-function-docstring, invalid-name
+# pylint: disable=missing-function-docstring, invalid-name, useless-return
 import sys
 
 def valid():

--- a/tests/functional/u/useless/useless_return.py
+++ b/tests/functional/u/useless/useless_return.py
@@ -41,3 +41,32 @@ def function5(parameter):  # [useless-return]
         parameter.do()
     except RuntimeError:
         return
+
+
+def code_after_return(param):
+    try:
+        param.kaboom()
+    except RuntimeError:
+        param.other()
+        return
+
+    param.something_else()
+    param.state = "good"
+
+
+def code_after_else(obj):
+    if obj.k:
+        pass
+    else:
+        return
+
+    obj.do()
+
+
+def return_in_loop(obj):
+    for _ in range(10):
+        obj.do()
+        if obj.k:
+            return
+
+    return

--- a/tests/functional/u/useless/useless_return.py
+++ b/tests/functional/u/useless/useless_return.py
@@ -13,3 +13,31 @@ class SomeClass:
     # These are not emitted
     def item_at(self):
         return None
+
+
+def function2(parameter):  # [useless-return]
+    if parameter:
+        pass
+    return
+
+
+def function3(parameter):  # [useless-return]
+    if parameter:
+        pass
+    else:
+        return
+
+
+def function4(parameter):  # [useless-return]
+    try:
+        parameter.do()
+    except RuntimeError:
+        parameter.other()
+        return
+
+
+def function5(parameter):  # [useless-return]
+    try:
+        parameter.do()
+    except RuntimeError:
+        return

--- a/tests/functional/u/useless/useless_return.txt
+++ b/tests/functional/u/useless/useless_return.txt
@@ -1,2 +1,6 @@
 useless-return:4:0:4:10:myfunc:Useless return at end of function or method:UNDEFINED
 useless-return:9:4:9:16:SomeClass.mymethod:Useless return at end of function or method:UNDEFINED
+useless-return:18:0:18:13:function2:Useless return at end of function or method:UNDEFINED
+useless-return:24:0:24:13:function3:Useless return at end of function or method:UNDEFINED
+useless-return:31:0:31:13:function4:Useless return at end of function or method:UNDEFINED
+useless-return:39:0:39:13:function5:Useless return at end of function or method:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Returns inside try or if/else conditions were not being detected as useless. Said nodes are now checked for return statements to ensure their last component is not a useless return as well.

Closes #9449.
