### PR TITLE
Add ignored modules to Astroid module deny list

### DIFF
--- a/.pyenchant_pylint_custom_dict.txt
+++ b/.pyenchant_pylint_custom_dict.txt
@@ -300,6 +300,7 @@ spammy
 sqlalchemy
 src
 starargs
+stateful
 staticmethod
 stderr
 stdin

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -120,7 +120,7 @@ Standard Checkers
 
 --ignored-modules
 """""""""""""""""
-*List of module names for which member attributes should not be checked (useful for modules/projects where namespaces are manipulated during runtime and thus existing member attributes cannot be deduced by static analysis). It supports qualified module names, as well as Unix pattern matching.*
+*List of module names for which member attributes should not be checked and will not be imported (useful for modules/projects where namespaces are manipulated during runtime and thus existing member attributes cannot be deduced by static analysis). It supports qualified module names, as well as Unix pattern matching.*
 
 **Default:**  ``()``
 

--- a/doc/whatsnew/fragments/9442.other
+++ b/doc/whatsnew/fragments/9442.other
@@ -1,0 +1,5 @@
+Ignored modules are now not checked at all, instead of being checked and then
+ignored. This should speed up the analysis of large codebases which have
+ignored modules.
+
+Closes #9442 (`#9442 <https://github.com/pylint-dev/pylint/issues/9442>`_)

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -59,10 +59,11 @@ ignore-paths=
 # Emacs file locks
 ignore-patterns=^\.#
 
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well
+# as Unix pattern matching.
 ignored-modules=
 
 # Python code to execute, usually for sys.path manipulation such as

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -49,10 +49,11 @@ ignore = ["CVS"]
 # file locks
 ignore-patterns = ["^\\.#"]
 
-# List of module names for which member attributes should not be checked (useful
-# for modules/projects where namespaces are manipulated during runtime and thus
-# existing member attributes cannot be deduced by static analysis). It supports
-# qualified module names, as well as Unix pattern matching.
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well
+# as Unix pattern matching.
 # ignored-modules =
 
 # Python code to execute, usually for sys.path manipulation such as

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -384,7 +384,8 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "type": "csv",
                 "metavar": "<module names>",
                 "help": "List of module names for which member attributes "
-                "should not be checked (useful for modules/projects "
+                "should not be checked and will not be imported "
+                "(useful for modules/projects "
                 "where namespaces are manipulated during runtime and "
                 "thus existing member attributes cannot be "
                 "deduced by static analysis). It supports qualified "

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1073,6 +1073,7 @@ class PyLinter(
         MANAGER.always_load_extensions = self.config.unsafe_load_any_extension
         MANAGER.max_inferable_values = self.config.limit_inference_results
         MANAGER.extension_package_whitelist.update(self.config.extension_pkg_allow_list)
+        MANAGER.module_denylist.update(self.config.ignored_modules)
         if self.config.extension_pkg_whitelist:
             MANAGER.extension_package_whitelist.update(
                 self.config.extension_pkg_whitelist

--- a/pylintrc
+++ b/pylintrc
@@ -342,10 +342,11 @@ property-classes=abc.abstractproperty
 # members is set to 'yes'
 mixin-class-rgx=.*MixIn
 
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well
+# as Unix pattern matching.
 ignored-modules=
 
 # List of class names for which member attributes should not be checked (useful

--- a/tests/lint/test_pylinter.py
+++ b/tests/lint/test_pylinter.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from pytest import CaptureFixture
 
-from pylint.lint.pylinter import PyLinter
+from pylint.lint.pylinter import MANAGER, PyLinter
 from pylint.utils import FileState
 
 
@@ -48,3 +48,14 @@ def test_crash_during_linting(
         assert len(files) == 1
         assert "pylint-crash-20" in str(files[0])
         assert any(m.symbol == "astroid-error" for m in linter.reporter.messages)
+
+
+def test_open_pylinter_denied_modules(linter: PyLinter) -> None:
+    """Test PyLinter open() adds ignored modules to Astroid manager deny list."""
+    MANAGER.module_denylist = {"mod1"}
+    try:
+        linter.config.ignored_modules = ["mod2", "mod3"]
+        linter.open()
+        assert MANAGER.module_denylist == {"mod1", "mod2", "mod3"}
+    finally:
+        MANAGER.module_denylist = set()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -7,13 +7,16 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from _pytest.config import Config
 
 from pylint import testutils
 from pylint.constants import PY312_PLUS
+from pylint.lint.pylinter import MANAGER
 from pylint.testutils import UPDATE_FILE, UPDATE_OPTION
 from pylint.testutils.functional import (
     FunctionalTestFile,
@@ -21,6 +24,9 @@ from pylint.testutils.functional import (
     get_functional_test_files_from_directory,
 )
 from pylint.utils import HAS_ISORT_5
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
 
 FUNCTIONAL_DIR = Path(__file__).parent.resolve() / "functional"
 
@@ -40,6 +46,14 @@ TEST_WITH_EXPECTED_DEPRECATION = [
 ]
 
 
+@pytest.fixture
+def revert_stateful_config_changes(linter: PyLinter) -> Iterator[PyLinter]:
+    yield linter
+    # Revert any stateful configuration changes.
+    MANAGER.brain["module_denylist"] = set()
+
+
+@pytest.mark.usefixtures("revert_stateful_config_changes")
 @pytest.mark.parametrize("test_file", TESTS, ids=TESTS_NAMES)
 def test_functional(test_file: FunctionalTestFile, pytestconfig: Config) -> None:
     __tracebackhide__ = True  # pylint: disable=unused-variable


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description
Adds ignored modules to the Astroid deny list so they may be truly ignored as they will now not be imported at all.
<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Depends on Astroid change pylint-dev/astroid#2399

Closes #9442 
