### PR TITLE
More concise 'fail-under' `>=` comparisons

### DIFF
--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -154,7 +154,7 @@ def _make_linter_options(linter: PyLinter) -> Options:
             "fail-under",
             {
                 "default": 10,
-                "type": "float",
+                "type": "string",
                 "metavar": "<score>",
                 "help": "Specify a score threshold under which the program will exit with error.",
             },

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -222,7 +222,18 @@ group are mutually exclusive.",
                 # So we use self.linter.msg_status if that is non-zero, otherwise we just return 1.
                 sys.exit(self.linter.msg_status or 1)
             elif score_value is not None:
-                if score_value >= linter.config.fail_under:
+                # Convert fail_under from str to a float
+                fail_under = float(linter.config.fail_under)
+                if "." not in linter.config.fail_under:
+                    # If there is no decimal place, do not round score to the same precision as the
+                    # fail_under comparison
+                    rounded_score_value = score_value
+                else:
+                    # Round the score to the number of decimal places given in the fail_under option
+                    decimal_places = len(linter.config.fail_under.split(".")[1])
+                    # Round the score to the number of decimal places
+                    rounded_score_value = round(score_value, decimal_places)
+                if rounded_score_value >= fail_under:
                     sys.exit(0)
                 else:
                     # We need to make sure we return a failing exit code in this case.


### PR DESCRIPTION

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

Change the handling of 'fail-under' from a float to a string. When fail-under's comparison is made, we can round the score to the same precision as the fail-under.

Example, if a project reports a score of 8.79, to fix all pylint warnings is a large task, so we add a CI task that ensures the score only increases on each pull request.

If I use:
```
pylint iterate --fail-under 8.79
```
The CI task will run and return a non-zero exit code. This is because the score is more precisely '8.78563061304178', and the comparison 
```
score_value >= linter.config.fail_under
```
is False. The documentation accurately describes the `>=` operator, but users can be left confused why the `--fail-under` only behaves some of the time (ie when the score rounds down in the reported score). 
The help string for --fail-under:

> Specify a score threshold under which the program will exit with error. (default: 10)

Here in this pull request, I set a local variable with a score rounded to the same number of decimal places as the user provided. If the user provides an integer (or if the default value is set), I do not round the score

