### PR TITLE
Added new feature for request timeout plugin

### DIFF
--- a/pylint/extensions/requests_timeout_plugin.py
+++ b/pylint/extensions/requests_timeout_plugin.py
@@ -1,0 +1,28 @@
+import astroid
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+
+class RequestsSessionTimeoutChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = 'requests-session-timeout-checker'
+    msgs = {
+        'W3102': (
+            'No timeout set for requests.Session() object.',
+            'missing-timeout-session',
+            'You should set a timeout for requests.Session() object creation.'
+        ),
+    }
+
+    @staticmethod
+    def visit_call(node):
+        if isinstance(node.func, astroid.Attribute):
+            if isinstance(node.func.expr, astroid.Name) and node.func.expr.name == 'requests' \
+                    and node.func.attrname == 'Session':
+                for arg in node.args:
+                    if isinstance(arg, astroid.Keyword) and arg.arg == 'timeout':
+                        return
+                RequestsSessionTimeoutChecker.add_message('missing-timeout-session', node=node)
+
+def register(linter):
+    linter.register_checker(RequestsSessionTimeoutChecker(linter))

--- a/pylint/extensions/requests_timeout_plugin.py
+++ b/pylint/extensions/requests_timeout_plugin.py
@@ -1,36 +1,24 @@
 import astroid
-
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
-
 
 class RequestsSessionTimeoutChecker(BaseChecker):
-    __implements__ = IAstroidChecker
-
-    name = "requests-session-timeout-checker"
+    name = 'requests-session-timeout-checker'
     msgs = {
-        "W3102": (
-            "No timeout set for requests.Session() object.",
-            "missing-timeout-session",
-            "You should set a timeout for requests.Session() object creation.",
+        'W3102': (
+            'No timeout set for requests.Session() object.',
+            'missing-timeout-session',
+            'You should set a timeout for requests.Session() object creation.'
         ),
     }
 
-    @staticmethod
-    def visit_call(node):
+    def visit_call(self, node):
         if isinstance(node.func, astroid.Attribute):
-            if (
-                isinstance(node.func.expr, astroid.Name)
-                and node.func.expr.name == "requests"
-                and node.func.attrname == "Session"
-            ):
-                for arg in node.args:
-                    if isinstance(arg, astroid.Keyword) and arg.arg == "timeout":
+            if isinstance(node.func.expr, astroid.Name) and node.func.expr.name == 'requests' \
+                    and node.func.attrname == 'Session':
+                for keyword_arg in node.keywords:
+                    if keyword_arg.arg == 'timeout':
                         return
-                RequestsSessionTimeoutChecker.add_message(
-                    "missing-timeout-session", node=node
-                )
-
+                self.add_message('missing-timeout-session', node=node)
 
 def register(linter):
     linter.register_checker(RequestsSessionTimeoutChecker(linter))

--- a/pylint/extensions/requests_timeout_plugin.py
+++ b/pylint/extensions/requests_timeout_plugin.py
@@ -1,28 +1,36 @@
 import astroid
+
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
+
 
 class RequestsSessionTimeoutChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
-    name = 'requests-session-timeout-checker'
+    name = "requests-session-timeout-checker"
     msgs = {
-        'W3102': (
-            'No timeout set for requests.Session() object.',
-            'missing-timeout-session',
-            'You should set a timeout for requests.Session() object creation.'
+        "W3102": (
+            "No timeout set for requests.Session() object.",
+            "missing-timeout-session",
+            "You should set a timeout for requests.Session() object creation.",
         ),
     }
 
     @staticmethod
     def visit_call(node):
         if isinstance(node.func, astroid.Attribute):
-            if isinstance(node.func.expr, astroid.Name) and node.func.expr.name == 'requests' \
-                    and node.func.attrname == 'Session':
+            if (
+                isinstance(node.func.expr, astroid.Name)
+                and node.func.expr.name == "requests"
+                and node.func.attrname == "Session"
+            ):
                 for arg in node.args:
-                    if isinstance(arg, astroid.Keyword) and arg.arg == 'timeout':
+                    if isinstance(arg, astroid.Keyword) and arg.arg == "timeout":
                         return
-                RequestsSessionTimeoutChecker.add_message('missing-timeout-session', node=node)
+                RequestsSessionTimeoutChecker.add_message(
+                    "missing-timeout-session", node=node
+                )
+
 
 def register(linter):
     linter.register_checker(RequestsSessionTimeoutChecker(linter))

--- a/pylint/extensions/requests_timeout_plugin.py
+++ b/pylint/extensions/requests_timeout_plugin.py
@@ -1,24 +1,30 @@
 import astroid
+
 from pylint.checkers import BaseChecker
 
+
 class RequestsSessionTimeoutChecker(BaseChecker):
-    name = 'requests-session-timeout-checker'
+    name = "requests-session-timeout-checker"
     msgs = {
-        'W3102': (
-            'No timeout set for requests.Session() object.',
-            'missing-timeout-session',
-            'You should set a timeout for requests.Session() object creation.'
+        "W3102": (
+            "No timeout set for requests.Session() object.",
+            "missing-timeout-session",
+            "You should set a timeout for requests.Session() object creation.",
         ),
     }
 
     def visit_call(self, node):
         if isinstance(node.func, astroid.Attribute):
-            if isinstance(node.func.expr, astroid.Name) and node.func.expr.name == 'requests' \
-                    and node.func.attrname == 'Session':
+            if (
+                isinstance(node.func.expr, astroid.Name)
+                and node.func.expr.name == "requests"
+                and node.func.attrname == "Session"
+            ):
                 for keyword_arg in node.keywords:
-                    if keyword_arg.arg == 'timeout':
+                    if keyword_arg.arg == "timeout":
                         return
-                self.add_message('missing-timeout-session', node=node)
+                self.add_message("missing-timeout-session", node=node)
+
 
 def register(linter):
     linter.register_checker(RequestsSessionTimeoutChecker(linter))


### PR DESCRIPTION
Overview
The purpose of this feature is to enhance Pylint's capabilities to detect missing timeouts for requests.Session() calls in Python code. Currently, Pylint's missing-timeout warning (W3101) is triggered for requests.get() calls but not for requests.Session(). This enhancement ensures consistent timeout handling across different usage patterns of the requests library.

Motivation
Timeout settings are crucial for robust network operations, especially in scenarios where network requests may encounter delays or failures. While Pylint already provides warnings for missing timeouts in requests.get() calls, similar warnings for requests.Session() calls are equally important to maintain code quality and reliability.

Implementation Details
Custom Pylint Plugin
A custom Pylint plugin (requests_timeout_plugin.py) is introduced to extend Pylint's functionality. This plugin inspects requests.Session() calls and raises a warning if no timeout is explicitly set.

Warning Message
The new warning message (W3102) is introduced to indicate the absence of a timeout setting for requests.Session() objects. This warning prompts developers to review and add appropriate timeout settings to ensure robust network operations.

Integration with Pylint
To use this feature, developers need to run Pylint with the requests_timeout_plugin.py plugin. They can specify the plugin using the --load-plugins option when invoking Pylint.

Example
Consider the following Python code snippet:
import requests

# Without timeout setting
session = requests.Session()
response = session.get('https://example.com')

With the custom Pylint plugin enabled, Pylint will raise a warning (W3102) for the requests.Session() call, indicating that no timeout is set.

also you can use the plugin like 
pylint --load-plugins=pylint_plugins.requests_timeout_plugin  <your_code.py>
