### PR TITLE
Fix "function never returning" computation

### DIFF
--- a/doc/whatsnew/fragments/7565.false_positive
+++ b/doc/whatsnew/fragments/7565.false_positive
@@ -1,0 +1,3 @@
+Fix computation of never-returning function: `Never` is handled in addition to `NoReturn`, and priority is given to the explicit `--never-returning-functions` option.
+
+Closes #7565.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2054,17 +2054,21 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         Returns:
             bool: True if the function never returns, False otherwise.
         """
-        if isinstance(node, (nodes.FunctionDef, astroid.BoundMethod)) and node.returns:
-            return (
-                isinstance(node.returns, nodes.Attribute)
-                and node.returns.attrname == "NoReturn"
-                or isinstance(node.returns, nodes.Name)
-                and node.returns.name == "NoReturn"
-            )
         try:
-            return node.qname() in self._never_returning_functions
+            if node.qname() in self._never_returning_functions:
+                return True
         except (TypeError, AttributeError):
-            return False
+            pass
+        return (
+            isinstance(node, (nodes.FunctionDef, astroid.BoundMethod))
+            and node.returns
+            and (
+                isinstance(node.returns, nodes.Attribute)
+                and node.returns.attrname in {"NoReturn", "Never"}
+                or isinstance(node.returns, nodes.Name)
+                and node.returns.name in {"NoReturn", "Never"}
+            )
+        )
 
     def _check_return_at_the_end(self, node: nodes.FunctionDef) -> None:
         """Check for presence of a *single* return statement at the end of a

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.py
@@ -3,6 +3,7 @@
 
 import sys
 import typing
+import typing_extensions
 
 def parser_error(msg) -> typing.NoReturn:  # pylint: disable=unused-argument
     sys.exit(1)
@@ -11,7 +12,7 @@ def parser_error_nortype(msg):  # pylint: disable=unused-argument
     sys.exit(2)
 
 
-from typing import NoReturn  # pylint: disable=wrong-import-position
+from typing import NoReturn  # pylint: disable=wrong-import-position,wrong-import-order
 
 def parser_error_name(msg) -> NoReturn:  # pylint: disable=unused-argument
     sys.exit(3)
@@ -95,3 +96,22 @@ class ClassUnderTest:
             return n
         except ValueError:
             self._falsely_no_return_method()
+
+# https://github.com/pylint-dev/pylint/issues/7565
+def never_is_handled_like_noreturn(arg: typing.Union[int, str]) -> int:
+    if isinstance(arg, int):
+        return 1
+    if isinstance(arg, str):
+        return 2
+    typing_extensions.assert_never(arg)
+
+
+def declared_to_not_return() -> None:
+    return
+
+def config_takes_precedence_over_inference(arg: typing.Union[int, str]) -> int:
+    if isinstance(arg, int):
+        return 1
+    if isinstance(arg, str):
+        return 2
+    declared_to_not_return()

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.rc
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.rc
@@ -1,2 +1,2 @@
 [REFACTORING]
-never-returning-functions=sys.exit,sys.getdefaultencoding
+never-returning-functions=sys.exit,sys.getdefaultencoding,inconsistent_returns_noreturn.declared_to_not_return

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.txt
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.txt
@@ -1,2 +1,2 @@
-inconsistent-return-statements:32:0:32:25:bug_pylint_4122_wrong:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
-inconsistent-return-statements:77:4:77:29:ClassUnderTest.bug_pylint_8747_wrong:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
+inconsistent-return-statements:33:0:33:25:bug_pylint_4122_wrong:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
+inconsistent-return-statements:78:4:78:29:ClassUnderTest.bug_pylint_8747_wrong:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED


### PR DESCRIPTION
This fixes 2 bugs in the computation:
* `Never` is handled in addition to `NoReturn`.
* Give priority to the explicit `--never-returning-functions` option.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #7565
