### PR TITLE
improve readability

### DIFF
--- a/pylint/extensions/private_import.py
+++ b/pylint/extensions/private_import.py
@@ -156,12 +156,8 @@ class PrivateImportChecker(BaseChecker):
                     elif isinstance(assign_parent, nodes.Assign):
                         name_assignments.append(assign_parent)
 
-                if isinstance(usage_node, nodes.FunctionDef):
+                if isinstance(usage_node, (nodes.FunctionDef, nodes.LocalsDictNodeNG)):
                     self._populate_type_annotations_function(
-                        usage_node, all_used_type_annotations
-                    )
-                if isinstance(usage_node, nodes.LocalsDictNodeNG):
-                    self._populate_type_annotations(
                         usage_node, all_used_type_annotations
                     )
             if private_name is not None:


### PR DESCRIPTION
From the docs:

    A tuple, as in isinstance(x, (A, B, ...)), may be given as the target to check against. This is equivalent to isinstance(x, A) or isinstance(x, B) or ... etc.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ✓ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [✓  ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |

| ✓   | :hammer: Refactoring   |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #XXXX

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #XXXX
