### PR TITLE
📝 Fix release RST fields @ 3.1/3.2 changelogs

### DIFF
--- a/doc/whatsnew/3/3.1/index.rst
+++ b/doc/whatsnew/3/3.1/index.rst
@@ -6,7 +6,7 @@
 .. toctree::
    :maxdepth: 2
 
-:Release:3.1
+:Release: 3.1
 :Date: 2024-02-25
 
 Summary -- Release highlights

--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -6,7 +6,7 @@
 .. toctree::
    :maxdepth: 2
 
-:Release:3.2
+:Release: 3.2
 :Date: TBA
 
 Summary -- Release highlights


### PR DESCRIPTION
These are lacking a whitespace so the RST parser doesn't recognize them as fields.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |