### PR TITLE
📝 Fix RST mdash typos @ 3.1 changelog summary

### DIFF
--- a/doc/whatsnew/3/3.1/index.rst
+++ b/doc/whatsnew/3/3.1/index.rst
@@ -12,7 +12,7 @@
 Summary -- Release highlights
 =============================
 
-Two new checks--``use-yield-from``, ``deprecated-attribute``--
+Two new checks -- ``use-yield-from``, ``deprecated-attribute`` --
 and a smattering of bug fixes.
 
 .. towncrier release notes start


### PR DESCRIPTION
Missing whitespaces confuse RST parsers and they fail to recognize that em dashes don't need to remain double hyphens.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |