### PR TITLE
📝 Integrate `sphinxcontrib-towncrier`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,3 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    pre_build:
-      - towncrier build --yes --date TBA

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import sys
 from datetime import datetime
+from pathlib import Path
 
 # Pylint documentation build configuration file, created by
 # sphinx-quickstart on Thu Apr  4 20:31:25 2013.
@@ -32,6 +33,18 @@ from pylint.__pkginfo__ import numversion
 
 # pylint: enable=wrong-import-position
 
+# -- Path setup --------------------------------------------------------------
+
+PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
+IS_RELEASE_ON_RTD = (
+    os.getenv('READTHEDOCS', 'False') == 'True'
+    and os.environ['READTHEDOCS_VERSION_TYPE'] == 'tag'
+)
+if IS_RELEASE_ON_RTD:
+    tags: set[str]
+    # pylint: disable-next=used-before-assignment
+    tags.add('is_release')  # noqa: F821
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -47,6 +60,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx_reredirects",
+    "sphinxcontrib.towncrier.ext",
 ]
 
 
@@ -305,3 +319,11 @@ autosectionlabel_maxdepth = 2
 linkcheck_ignore = [
     "https://github.com/pylint-dev/pylint/blob/main/pylint/extensions/.*"
 ]
+
+# -- Options for towncrier_draft extension -----------------------------------
+
+# or: 'sphinx-version', 'sphinx-release'
+towncrier_draft_autoversion_mode = 'draft'
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = PROJECT_ROOT_DIR
+towncrier_draft_config_path = 'towncrier.toml'  # relative to cwd

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==7.2.6
 sphinx-reredirects<1
-towncrier~=23.11
+sphinxcontrib-towncrier ~= 0.4.0a0
 furo==2024.1.29
 -e .

--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -13,4 +13,18 @@ Summary -- Release highlights
 =============================
 
 
-.. towncrier release notes start
+.. only:: not is_release
+
+   *To be included in the next release*
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+   .. towncrier-draft-entries:: |release| :sub:`/UNRELEASED DRAFT/`
+
+   Released versions
+   ^^^^^^^^^^^^^^^^^
+
+   .. towncrier release notes start
+
+.. only:: is_release
+
+   .. towncrier release notes start


### PR DESCRIPTION
This plugin embeds displaying a changelog draft right into the Sphinx ecosystem, removing the need to separately run the `towncrier --draft` command externally.
It works with native Sphinx build runs universally, meaning that the result is the same and embedded for local runs, and is not only set up on RTD in a disconnected manner.

*DISCLAIMER:* I authored this Sphinx extension.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

I just saw the changelog draft hack and figured I'd try plugging in my thing. Evidently, the docs structure is a bit different compared to what I'm used to so I'm just experimenting with the integration for now and want to preview how it goes.
I wasn't sure about a change note. I can write it later if needed. Recently I started using more granular Towncrier fragments in my projects, introducing sections targeting the contributors and downstreams (e.g. https://docs.aiohttp.org/en/stable/changes.html#contributor-facing-changes). I'd use one of those if they existed, but since they don't, perhaps an `internal` note would fit. Let me know!

With the above in mind, I'm opening this PR in the draft status and may change it to review-ready later.