### PR TITLE
Avoid search paths for ImportChecker when possible

### DIFF
--- a/doc/whatsnew/fragments/9310.performance
+++ b/doc/whatsnew/fragments/9310.performance
@@ -1,0 +1,4 @@
+ImportChecker's logic has been modified to avoid context files when possible. This makes it possible
+to cache module searches on astroid and reduce execution times.
+
+Refs #9310.

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -1045,9 +1045,12 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         base = os.path.splitext(os.path.basename(module_file))[0]
 
         try:
-            importedmodname = astroid.modutils.get_module_part(
-                importedmodname, module_file
-            )
+            if isinstance(node, nodes.ImportFrom) and node.level:
+                importedmodname = astroid.modutils.get_module_part(
+                    importedmodname, module_file
+                )
+            else:
+                importedmodname = astroid.modutils.get_module_part(importedmodname)
         except ImportError:
             pass
 


### PR DESCRIPTION
If possible it is desirable to look for modules with no context file as it results in no search paths being given to astroid's find_spec(). This makes calls to it more uniform and opens up the possibility of effective caching.

Refs #9310.

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |