### PR TITLE
Bump pylint to 3.1.1, update changelog

### DIFF
--- a/doc/whatsnew/3/3.1/index.rst
+++ b/doc/whatsnew/3/3.1/index.rst
@@ -17,6 +17,29 @@ and a smattering of bug fixes.
 
 .. towncrier release notes start
 
+What's new in Pylint 3.1.1?
+---------------------------
+Release date: 2024-05-13
+
+
+False Positives Fixed
+---------------------
+
+- Treat `attrs.define` and `attrs.frozen` as dataclass decorators in
+  `too-few-public-methods` check.
+
+  Closes #9345 (`#9345 <https://github.com/pylint-dev/pylint/issues/9345>`_)
+
+- Fix a false positive with ``singledispatchmethod-function`` when a method is decorated with both ``functools.singledispatchmethod`` and ``staticmethod``.
+
+  Closes #9531 (`#9531 <https://github.com/pylint-dev/pylint/issues/9531>`_)
+
+- Fix a false positive for ``consider-using-dict-items`` when iterating using ``keys()`` and then deleting an item using the key as a lookup.
+
+  Closes #9554 (`#9554 <https://github.com/pylint-dev/pylint/issues/9554>`_)
+
+
+
 What's new in Pylint 3.1.0?
 ---------------------------
 Release date: 2024-02-25

--- a/doc/whatsnew/fragments/9345.false_positive
+++ b/doc/whatsnew/fragments/9345.false_positive
@@ -1,4 +1,0 @@
-Treat `attrs.define` and `attrs.frozen` as dataclass decorators in
-`too-few-public-methods` check.
-
-Closes #9345

--- a/doc/whatsnew/fragments/9531.false_positive
+++ b/doc/whatsnew/fragments/9531.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive with ``singledispatchmethod-function`` when a method is decorated with both ``functools.singledispatchmethod`` and ``staticmethod``.
-
-Closes #9531

--- a/doc/whatsnew/fragments/9554.false_positive
+++ b/doc/whatsnew/fragments/9554.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``consider-using-dict-items`` when iterating using ``keys()`` and then deleting an item using the key as a lookup.
-
-Closes #9554

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.1.0"
+current = "3.1.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.1.0"
+version = "3.1.1"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.1/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.1.1?
---------------------------
Release date: 2024-05-13


False Positives Fixed
---------------------

- Treat `attrs.define` and `attrs.frozen` as dataclass decorators in
  `too-few-public-methods` check.

  Closes #9345

- Fix a false positive with ``singledispatchmethod-function`` when a method is decorated with both ``functools.singledispatchmethod`` and ``staticmethod``.

  Closes #9531

- Fix a false positive for ``consider-using-dict-items`` when iterating using ``keys()`` and then deleting an item using the key as a lookup.

  Closes #9554
