### PR TITLE
Enable `possibly-used-before-assignment` and fix a few of them

### DIFF
--- a/pylint/checkers/__init__.py
+++ b/pylint/checkers/__init__.py
@@ -110,6 +110,7 @@ def table_lines_from_stats(
                 ("error", "NC"),
             ]
 
+    # pylint: disable=possibly-used-before-assignment
     for index, value in enumerate(new):
         new_value = value[1]
         old_value = old[index][1]

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -222,6 +222,7 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
                     error_detected = True
                     op = op_1
                 if error_detected:
+                    # pylint: disable=possibly-used-before-assignment
                     original = f"{op_1.as_string()} {op_2} {op_3.as_string()}"
                     suggestion = (
                         op.as_string()

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -209,20 +209,17 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
                 continue
             op_1 = all_ops[ops_idx]
             op_3 = all_ops[ops_idx + 2]
-            error_detected = False
             if self.linter.is_message_enabled(
                 "use-implicit-booleaness-not-comparison-to-zero"
             ):
+                op = None
                 # 0 ?? X
                 if _is_constant_zero(op_1):
-                    error_detected = True
                     op = op_3
                 # X ?? 0
                 elif _is_constant_zero(op_3):
-                    error_detected = True
                     op = op_1
-                if error_detected:
-                    # pylint: disable=possibly-used-before-assignment
+                if op is not None:
                     original = f"{op_1.as_string()} {op_2} {op_3.as_string()}"
                     suggestion = (
                         op.as_string()
@@ -235,20 +232,17 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
                         node=node,
                         confidence=HIGH,
                     )
-                    error_detected = False
             if self.linter.is_message_enabled(
                 "use-implicit-booleaness-not-comparison-to-str"
             ):
-                node_name = ""
+                node_name = None
                 # x ?? ""
                 if utils.is_empty_str_literal(op_1):
-                    error_detected = True
                     node_name = op_3.as_string()
                 # '' ?? X
                 elif utils.is_empty_str_literal(op_3):
-                    error_detected = True
                     node_name = op_1.as_string()
-                if error_detected:
+                if node_name is not None:
                     suggestion = (
                         f"not {node_name}" if op_2 in {"==", "is"} else node_name
                     )

--- a/pylint/checkers/similar.py
+++ b/pylint/checkers/similar.py
@@ -596,6 +596,7 @@ def stripped_lines(
            the line
     :return: the collection of line/line number/line type tuples
     """
+    # pylint: disable=possibly-used-before-assignment
     if ignore_imports or ignore_signatures:
         tree = astroid.parse("".join(lines))
     if ignore_imports:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -2135,6 +2135,7 @@ accessed. Python regular expressions are accepted.",
             msg = "unsupported-delete-operation"
 
         if isinstance(node.value, nodes.SetComp):
+            # pylint: disable-next=possibly-used-before-assignment
             self.add_message(msg, args=node.value.as_string(), node=node.value)
             return
 

--- a/pylint/testutils/_primer/primer.py
+++ b/pylint/testutils/_primer/primer.py
@@ -105,6 +105,7 @@ class Primer:
             command_class = RunCommand
         elif self.config.command == "compare":
             command_class = CompareCommand
+        # pylint: disable-next=possibly-used-before-assignment
         self.command = command_class(self.primer_directory, self.packages, self.config)
 
     def run(self) -> None:

--- a/pylintrc
+++ b/pylintrc
@@ -109,7 +109,6 @@ disable=
     # We anticipate #3512 where it will become optional
     fixme,
     consider-using-assignment-expr,
-    possibly-used-before-assignment,
 
 
 [REPORTS]

--- a/tests/message/unittest_message.py
+++ b/tests/message/unittest_message.py
@@ -53,6 +53,7 @@ def test_new_message(message_definitions: ValuesView[MessageDefinition]) -> None
     expected = (
         "2:5:6: E1234: Duplicate keyword argument %r in %s call (duplicate-keyword-arg)"
     )
+    # pylint: disable=possibly-used-before-assignment
     e1234 = build_message(e1234_message_definition, e1234_location_values)
     w1234 = build_message(w1234_message_definition, w1234_location_values)
     assert e1234.location == e1234_location_values

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -603,6 +603,7 @@ class TestCheckParallel:
                     files=file_infos,
                 )
                 stats_check_parallel = linter.stats
+        # pylint: disable=possibly-used-before-assignment
         assert str(stats_single_proc.by_msg) == str(
             stats_check_parallel.by_msg
         ), "Single-proc and check_parallel() should return the same thing"


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ x ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ x ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ x ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ x ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ x ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Original: #9644

Enables `possibly-used-before-assignment` for the pylint codebase, fixes the errors in two files, and locally disables the rest.
The disabled errors can probably be fixed but would need extra code coverage.

<!-- If this PR references an issue without fixing it: -->

Refs #9637
