### PR TITLE
Update astroid to 3.2.2

### DIFF
--- a/doc/whatsnew/fragments/9406.false_positive
+++ b/doc/whatsnew/fragments/9406.false_positive
@@ -1,0 +1,3 @@
+Fix multiple false positives for generic class syntax added in Python 3.12 (PEP 695).
+
+Closes #9406

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.2.1,<=3.3.0-dev0",
+    "astroid>=3.2.2,<=3.3.0-dev0",
     "isort>=4.2.5,<6,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.2.1  # Pinned to a specific version for tests
+astroid==3.2.2  # Pinned to a specific version for tests
 typing-extensions~=4.11
 py~=1.11.0
 pytest~=7.4

--- a/tests/functional/g/generic_class_syntax.py
+++ b/tests/functional/g/generic_class_syntax.py
@@ -1,0 +1,38 @@
+# pylint: disable=missing-docstring,too-few-public-methods
+from typing import Generic, TypeVar
+
+_T = TypeVar("_T")
+
+
+class Entity(Generic[_T]):
+    last_update: int | None = None
+
+    def __init__(self, data: _T) -> None:
+        self.data = data
+
+
+class Sensor(Entity[int]):
+    def __init__(self, data: int) -> None:
+        super().__init__(data)
+
+    def async_update(self) -> None:
+        self.data = 2
+
+        if self.last_update is None:
+            pass
+        self.last_update = 2
+
+
+class Switch(Entity[int]):
+    def __init__(self, data: int) -> None:
+        Entity.__init__(self, data)
+
+
+class Parent(Generic[_T]):
+    def __init__(self):
+        self.update_interval = 0
+
+
+class Child(Parent[_T]):
+    def func(self):
+        self.update_interval = None

--- a/tests/functional/g/generic_class_syntax.py
+++ b/tests/functional/g/generic_class_syntax.py
@@ -1,11 +1,11 @@
 # pylint: disable=missing-docstring,too-few-public-methods
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Optional
 
 _T = TypeVar("_T")
 
 
 class Entity(Generic[_T]):
-    last_update: int | None = None
+    last_update: Optional[int] = None
 
     def __init__(self, data: _T) -> None:
         self.data = data

--- a/tests/functional/g/generic_class_syntax_py312.py
+++ b/tests/functional/g/generic_class_syntax_py312.py
@@ -1,0 +1,33 @@
+# pylint: disable=missing-docstring,too-few-public-methods
+class Entity[_T: float]:
+    last_update: int | None = None
+
+    def __init__(self, data: _T) -> None:  # [undefined-variable]  # false-positive
+        self.data = data
+
+
+class Sensor(Entity[int]):
+    def __init__(self, data: int) -> None:
+        super().__init__(data)
+
+    def async_update(self) -> None:
+        self.data = 2
+
+        if self.last_update is None:
+            pass
+        self.last_update = 2
+
+
+class Switch(Entity[int]):
+    def __init__(self, data: int) -> None:
+        Entity.__init__(self, data)
+
+
+class Parent[_T]:
+    def __init__(self):
+        self.update_interval = 0
+
+
+class Child[_T](Parent[_T]):  # [undefined-variable]  # false-positive
+    def func(self):
+        self.update_interval = None

--- a/tests/functional/g/generic_class_syntax_py312.rc
+++ b/tests/functional/g/generic_class_syntax_py312.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/g/generic_class_syntax_py312.txt
+++ b/tests/functional/g/generic_class_syntax_py312.txt
@@ -1,0 +1,2 @@
+undefined-variable:5:29:5:31:Entity.__init__:Undefined variable '_T':UNDEFINED
+undefined-variable:31:23:31:25:Child:Undefined variable '_T':UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Update astroid to `3.2.2` to fix multiple false positives with generic class syntax added in Python 3.12 (PEP 695).
This included
- useless-parent-delegation
- attribute-defined-outside-init
- access-member-before-definition
- non-parent-init-called
- unsubscriptable-object

It does `not` address the `undefined-variable` issue.
- #9335

--
https://github.com/pylint-dev/astroid/releases/tag/v3.2.2

Closes #9406