### PR TITLE
Bump pylint to 3.2.2, update changelog

### DIFF
--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -14,6 +14,25 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.2.2?
+---------------------------
+Release date: 2024-05-20
+
+
+False Positives Fixed
+---------------------
+
+- Fix multiple false positives for generic class syntax added in Python 3.12 (PEP 695).
+
+  Closes #9406 (`#9406 <https://github.com/pylint-dev/pylint/issues/9406>`_)
+
+- Exclude context manager without cleanup from
+  ``contextmanager-generator-missing-cleanup`` checks.
+
+  Closes #9625 (`#9625 <https://github.com/pylint-dev/pylint/issues/9625>`_)
+
+
+
 What's new in Pylint 3.2.1?
 ---------------------------
 Release date: 2024-05-18

--- a/doc/whatsnew/fragments/9406.false_positive
+++ b/doc/whatsnew/fragments/9406.false_positive
@@ -1,3 +1,0 @@
-Fix multiple false positives for generic class syntax added in Python 3.12 (PEP 695).
-
-Closes #9406

--- a/doc/whatsnew/fragments/9625.false_positive
+++ b/doc/whatsnew/fragments/9625.false_positive
@@ -1,4 +1,0 @@
-Exclude context manager without cleanup from
-``contextmanager-generator-missing-cleanup`` checks.
-
-Closes #9625

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.2.1"
+current = "3.2.2"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.2.1"
+version = "3.2.2"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.2/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.2.2?
---------------------------
Release date: 2024-05-20


False Positives Fixed
---------------------

- Fix multiple false positives for generic class syntax added in Python 3.12 (PEP 695).

  Closes #9406

- Exclude context manager without cleanup from
  ``contextmanager-generator-missing-cleanup`` checks.

  Closes #9625