### PR TITLE
Add a test case for ``too-complex`` in match case, for discussion

### DIFF
--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -91,6 +91,9 @@ class PathGraphingAstVisitor(Mccabe_PathGraphingAstVisitor):  # type: ignore[mis
 
     visitAsyncFunctionDef = visitFunctionDef
 
+    # def visitMatchCase(self, node: MatchCase) -> None:
+    #     self._append_node(node)
+
     def visitSimpleStatement(self, node: _StatementNodes) -> None:
         self._append_node(node)
 

--- a/tests/functional/ext/mccabe/mccabe.py
+++ b/tests/functional/ext/mccabe/mccabe.py
@@ -214,3 +214,16 @@ def method3(self):  # [too-complex]
     finally:
         pass
     return True
+
+def match_case_complexity(self, avg):  # [too-complex]
+    """McCabe rating: 3
+    See https://github.com/astral-sh/ruff/issues/11421
+    """
+    match avg:
+        case avg if avg < .3:
+            avg_grade = "F"
+        case avg if avg < .7:
+            avg_grade = "E+"
+        case _:
+            raise ValueError(f"Unexpected average: {avg}")
+    return avg_grade

--- a/tests/functional/ext/mccabe/mccabe.txt
+++ b/tests/functional/ext/mccabe/mccabe.txt
@@ -13,3 +13,4 @@ too-complex:142:4:142:15:MyClass1.method2:'method2' is too complex. The McCabe r
 too-many-branches:142:4:142:15:MyClass1.method2:Too many branches (19/12):UNDEFINED
 too-complex:198:0:204:15::This 'for' is too complex. The McCabe rating is 4:HIGH
 too-complex:207:0:207:11:method3:'method3' is too complex. The McCabe rating is 3:HIGH
+too-complex:218:0:218:25:match_case_complexity:'match_case_complexity' is too complex. The McCabe rating is 3:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

See https://github.com/astral-sh/ruff/issues/11421 for initial reasoning behind this. I think we should modify the way we compute match case. But not sure if we should add a new visit method in pylint or add a ``get_children`` method for match case in astroid so we ends up not having to modify anything on the pylint side (and would benefit from it elsewhere too ?).
