### PR TITLE
Fix a false positive for ``redefined-outer-name``

### DIFF
--- a/doc/whatsnew/fragments/9671.false_positive
+++ b/doc/whatsnew/fragments/9671.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``redefined-outer-name`` when there is a name defined in an exception-handling block which shares the same name as a local variable that has been defined in a function body.
+
+Closes #9671

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1519,9 +1519,16 @@ class VariablesChecker(BaseChecker):
                 ):
                     continue
 
-                line = definition.fromlineno
-                if line > stmt.lineno:
+                # Suppress emitting the message if the outer name is in the
+                # scope of an exception assignment.
+                # For example: the `e` in `except ValueError as e`
+                global_node = globs[name][0]
+                if isinstance(global_node, nodes.AssignName) and isinstance(
+                    global_node.parent, nodes.ExceptHandler
+                ):
                     continue
+
+                line = definition.fromlineno
                 if not self._is_name_ignored(stmt, name):
                     self.add_message(
                         "redefined-outer-name", args=(name, line), node=stmt

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1520,6 +1520,8 @@ class VariablesChecker(BaseChecker):
                     continue
 
                 line = definition.fromlineno
+                if line > stmt.lineno:
+                    continue
                 if not self._is_name_ignored(stmt, name):
                     self.add_message(
                         "redefined-outer-name", args=(name, line), node=stmt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
-# pylint: disable=redefined-outer-name
-
 from __future__ import annotations
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
+# pylint: disable=redefined-outer-name
+
 from __future__ import annotations
 
 import os

--- a/tests/functional/r/redefined/redefined_except_handler.py
+++ b/tests/functional/r/redefined/redefined_except_handler.py
@@ -73,7 +73,7 @@ def func():
 
 
 # https://github.com/pylint-dev/pylint/issues/9671
-def function_before():
+def function_before_exception():
     """The local variable `e` should not trigger `redefined-outer-name`
        when `e` is also defined in the subsequent exception handling block.
     """
@@ -86,10 +86,9 @@ except ValueError as e:
     print(e)
 
 
-def function_after():
-    """function defined after exception handler at module level
-       The local variable `e` should not trigger `redefined-outer-name`
-       when `e` is also defined in the subsequent exception handling block.
+def function_after_exception():
+    """The local variable `e` should not trigger `redefined-outer-name`
+       when `e` is also defined in the preceding exception handling block.
     """
     e = 42
     return e

--- a/tests/functional/r/redefined/redefined_except_handler.py
+++ b/tests/functional/r/redefined/redefined_except_handler.py
@@ -70,3 +70,18 @@ def func():
     # pylint:disable-next=invalid-name, unused-variable
     except IOError as CustomException:  # [redefined-outer-name]
         pass
+
+
+def function_before():
+    """https://github.com/pylint-dev/pylint/issues/9671
+
+       The local variable `e` should not trigger `redefined-outer-name`
+       when `e` is also defined in the subsequent exception handling block.
+    """
+    e = 42
+    return e
+
+try:
+    raise ValueError('outer')
+except ValueError as e:
+    print(e)

--- a/tests/functional/r/redefined/redefined_except_handler.py
+++ b/tests/functional/r/redefined/redefined_except_handler.py
@@ -72,10 +72,9 @@ def func():
         pass
 
 
+# https://github.com/pylint-dev/pylint/issues/9671
 def function_before():
-    """https://github.com/pylint-dev/pylint/issues/9671
-
-       The local variable `e` should not trigger `redefined-outer-name`
+    """The local variable `e` should not trigger `redefined-outer-name`
        when `e` is also defined in the subsequent exception handling block.
     """
     e = 42
@@ -85,3 +84,12 @@ try:
     raise ValueError('outer')
 except ValueError as e:
     print(e)
+
+
+def function_after():
+    """function defined after exception handler at module level
+       The local variable `e` should not trigger `redefined-outer-name`
+       when `e` is also defined in the subsequent exception handling block.
+    """
+    e = 42
+    return e


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fix a false positive for ``redefined-outer-name`` when there is a name defined in an exception-handling block which shares the same name as a local variable that has been defined in a function body.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9671
