### PR TITLE
tests: add testcase that shows that pyreverse will not extract the inheritance link for a flat folder as described in https://github.com/pylint-dev/pylint/issues/7686

### DIFF
--- a/pylint/testutils/pyreverse.py
+++ b/pylint/testutils/pyreverse.py
@@ -110,6 +110,35 @@ def get_functional_test_files(
     return test_files
 
 
+def get_functional_test_modules(
+    root_directory: Path,
+) -> list[FunctionalPyreverseTestfile]:
+    """Get all functional test files from the given directory."""
+    test_files = []
+    for path in root_directory.rglob("__init__.py"):
+        module_directory = path.parent
+        module_name = module_directory.name
+        config_file = module_directory / f"{module_name}.rc"
+        if config_file.exists():
+            test_files.append(
+                FunctionalPyreverseTestfile(
+                    source=module_directory, options=_read_config(config_file)
+                )
+            )
+        else:
+            test_files.append(
+                FunctionalPyreverseTestfile(
+                    source=module_directory,
+                    options={
+                        "source_roots": [],
+                        "output_formats": ["mmd"],
+                        "command_line_args": [],
+                    },
+                )
+            )
+    return test_files
+
+
 def _read_config(config_file: Path) -> TestFileOptions:
     config = configparser.ConfigParser()
     config.read(str(config_file))

--- a/tests/pyreverse/functional/class_diagrams/inheritance/complex_inheritance.mmd
+++ b/tests/pyreverse/functional/class_diagrams/inheritance/complex_inheritance.mmd
@@ -1,0 +1,11 @@
+classDiagram
+  class AbstractParent {
+  }
+  class Child {
+  }
+  class ConcreteChild {
+  }
+  class GenericParent {
+  }
+  Child --|> AbstractParent
+  ConcreteChild --|> GenericParent

--- a/tests/pyreverse/functional/class_diagrams/inheritance/complex_inheritance.py
+++ b/tests/pyreverse/functional/class_diagrams/inheritance/complex_inheritance.py
@@ -1,0 +1,24 @@
+from abc import ABC
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+
+@dataclass
+class AbstractParent(ABC):
+    """parent class"""
+
+
+@dataclass
+class Child(AbstractParent):
+    """child class"""
+
+
+GenericType = TypeVar("GenericType")
+
+
+class GenericParent(Generic[GenericType]):
+    """parent class"""
+
+
+class ConcreteChild(GenericParent[int]):
+    """child class"""

--- a/tests/pyreverse/functional/modules/complex_inheritance/child.py
+++ b/tests/pyreverse/functional/modules/complex_inheritance/child.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from parent import AbstractParent
+
+
+@dataclass
+class Child(AbstractParent):
+    """child class"""
+    pass

--- a/tests/pyreverse/functional/modules/complex_inheritance/complex_inheritance.mmd
+++ b/tests/pyreverse/functional/modules/complex_inheritance/complex_inheritance.mmd
@@ -1,0 +1,6 @@
+classDiagram
+  class Child {
+  }
+  class AbstractParent {
+  }
+  Child --|> AbstractParent

--- a/tests/pyreverse/functional/modules/complex_inheritance/complex_inheritance.rc
+++ b/tests/pyreverse/functional/modules/complex_inheritance/complex_inheritance.rc
@@ -1,0 +1,2 @@
+[testoptions]
+command_line_args=-ASmy

--- a/tests/pyreverse/functional/modules/complex_inheritance/parent.py
+++ b/tests/pyreverse/functional/modules/complex_inheritance/parent.py
@@ -1,0 +1,7 @@
+from abc import ABC
+from dataclasses import dataclass
+
+
+@dataclass
+class AbstractParent(ABC):
+    """parent class"""

--- a/tests/pyreverse/test_pyreverse_functional.py
+++ b/tests/pyreverse/test_pyreverse_functional.py
@@ -10,12 +10,18 @@ from pylint.pyreverse.main import Run
 from pylint.testutils.pyreverse import (
     FunctionalPyreverseTestfile,
     get_functional_test_files,
+    get_functional_test_modules,
 )
 
 FUNCTIONAL_DIR = Path(__file__).parent / "functional"
 CLASS_DIAGRAMS_DIR = FUNCTIONAL_DIR / "class_diagrams"
 CLASS_DIAGRAM_TESTS = get_functional_test_files(CLASS_DIAGRAMS_DIR)
 CLASS_DIAGRAM_TEST_IDS = [testfile.source.stem for testfile in CLASS_DIAGRAM_TESTS]
+MODULE_DIAGRAMS_DIR = FUNCTIONAL_DIR / "modules"
+MODULE_DIAGRAM_TESTS = get_functional_test_modules(MODULE_DIAGRAMS_DIR)
+MODULE_DIAGRAM_TEST_IDS = [
+    testmodule.source.name for testmodule in MODULE_DIAGRAM_TESTS
+]
 
 
 @pytest.mark.parametrize(
@@ -49,3 +55,36 @@ def test_class_diagrams(testfile: FunctionalPyreverseTestfile, tmp_path: Path) -
         assert testfile.source.with_suffix(f".{output_format}").read_text(
             encoding="utf8"
         ) == (tmp_path / f"classes.{output_format}").read_text(encoding="utf8")
+
+
+@pytest.mark.parametrize(
+    "testmodule",
+    MODULE_DIAGRAM_TESTS,
+    ids=MODULE_DIAGRAM_TEST_IDS,
+)
+def test_modules(testmodule: FunctionalPyreverseTestfile, tmp_path: Path) -> None:
+    input_path = testmodule.source
+    if testmodule.options["source_roots"]:
+        source_roots = ",".join(
+            [
+                os.path.realpath(
+                    os.path.expanduser(os.path.join(input_path, source_root))
+                )
+                for source_root in testmodule.options["source_roots"]
+            ]
+        )
+    else:
+        source_roots = ""
+    for output_format in testmodule.options["output_formats"]:
+        output_file = input_path / f"{input_path.name}.{output_format}"
+        with pytest.raises(SystemExit) as sys_exit:
+            args = ["-o", f"{output_format}", "-d", str(tmp_path)]
+            if source_roots:
+                args += ["--source-roots", source_roots]
+            args.extend(testmodule.options["command_line_args"])
+            args += [str(input_path)]
+            Run(args)
+        assert sys_exit.value.code == 0
+        assert output_file.read_text(encoding="utf8") == (
+            tmp_path / f"classes.{output_format}"
+        ).read_text(encoding="utf8")


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

As described in #7686, pyreverse does not extract the inheritance link for classes living in different files. In this PR I haved added the possibility to easily write testcases for pyreverse to generate a diagram for a complete directory / module. As far as I can tell this was not possible before just using the functional tests.

I also have a possible fix in mind for this issue, but am not sure, if I should add it in this PR or open another one. As @DudeNr33 suggested, I started with writing the test to reproduce the described issue.

Refs #7686 
