### PR TITLE
Fix false positive in `use-yield-from` when using `yield` return

### DIFF
--- a/doc/whatsnew/fragments/9696.false_positive
+++ b/doc/whatsnew/fragments/9696.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``use-yield-from`` when using the return value from the ``yield`` atom.
+
+Closes #9696

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -57,3 +57,13 @@ async def async_for_yield(agen):
 async def async_yield(agen):
     for item in agen:
         yield item
+
+
+# If the return from `yield` is used inline, don't suggest delegation.
+
+def yield_use_send():
+    for item in (1, 2, 3):
+        _ = yield item
+    total = 0
+    for item in (1, 2, 3):
+        total += yield item


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

If the return value from `yield` is inspected inline, such as by (augmented) assignment, changing the looped `yield` to `yield from` is very likely to change the semantics of the generator, since there is an implicit use of `generator.send`.

The type-hint component of #9696 feels (to me) like it would be suitable to suppress with a local lint suppression rather than complex type inference within pylint; it's a pretty unusual construction.

Closes #9696
