### PR TITLE
Release branch 3.2.3

### DIFF
--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -14,6 +14,29 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.2.3?
+---------------------------
+Release date: 2024-06-06
+
+
+False Positives Fixed
+---------------------
+
+- Classes with only an Ellipsis (``...``) in their body do not trigger 'multiple-statements'
+  anymore if they are inlined (in accordance with black's 2024 style).
+
+  Closes #9398 (`#9398 <https://github.com/pylint-dev/pylint/issues/9398>`_)
+
+- Fix a false positive for ``redefined-outer-name`` when there is a name defined in an exception-handling block which shares the same name as a local variable that has been defined in a function body.
+
+  Closes #9671 (`#9671 <https://github.com/pylint-dev/pylint/issues/9671>`_)
+
+- Fix a false positive for ``use-yield-from`` when using the return value from the ``yield`` atom.
+
+  Closes #9696 (`#9696 <https://github.com/pylint-dev/pylint/issues/9696>`_)
+
+
+
 What's new in Pylint 3.2.2?
 ---------------------------
 Release date: 2024-05-20

--- a/doc/whatsnew/fragments/9398.false_positive
+++ b/doc/whatsnew/fragments/9398.false_positive
@@ -1,4 +1,0 @@
-Classes with only an Ellipsis (``...``) in their body do not trigger 'multiple-statements'
-anymore if they are inlined (in accordance with black's 2024 style).
-
-Closes #9398

--- a/doc/whatsnew/fragments/9671.false_positive
+++ b/doc/whatsnew/fragments/9671.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``redefined-outer-name`` when there is a name defined in an exception-handling block which shares the same name as a local variable that has been defined in a function body.
-
-Closes #9671

--- a/doc/whatsnew/fragments/9696.false_positive
+++ b/doc/whatsnew/fragments/9696.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``use-yield-from`` when using the return value from the ``yield`` atom.
-
-Closes #9696

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -87,8 +87,8 @@ load-plugins=
 # Pickle collected data for later comparisons.
 persistent=yes
 
-# Resolve imports to .pyi stubs if available. May reduce no-member messages
-# and increase not-an-iterable messages.
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
 prefer-stubs=no
 
 # Minimum Python version to use for version dependent checks. Will default to

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -77,9 +77,9 @@ limit-inference-results = 100
 # Pickle collected data for later comparisons.
 persistent = true
 
-# Resolve imports to .pyi stubs if available. May reduce no-member messages
-# and increase not-an-iterable messages.
-prefer-stubs = false
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+# prefer-stubs =
 
 # Minimum Python version to use for version dependent checks. Will default to the
 # version used to run pylint.

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.2.2"
+__version__ = "3.2.3"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.2.2"
+current = "3.2.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.2.2"
+version = "3.2.3"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.2/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.2.3?
---------------------------
Release date: 2024-06-06


False Positives Fixed
---------------------

- Classes with only an Ellipsis (``...``) in their body do not trigger 'multiple-statements'
  anymore if they are inlined (in accordance with black's 2024 style).

  Closes #9398 

- Fix a false positive for ``redefined-outer-name`` when there is a name defined in an exception-handling block which shares the same name as a local variable that has been defined in a function body.

  Closes #9671 

- Fix a false positive for ``use-yield-from`` when using the return value from the ``yield`` atom.

  Closes #9696 