### PR TITLE
Don't emit deprecate-typing-alias for changes until 3.13

### DIFF
--- a/doc/whatsnew/fragments/9708.false_positive
+++ b/doc/whatsnew/fragments/9708.false_positive
@@ -1,0 +1,3 @@
+Don't emit ``deprecated-typing-alias`` warning for ``typing.Generator``, ``typing.AsyncGenerator``, ``typing.ContextManager``, and ``typing.AsyncContextManger`` until ``py-version`` is set to ``3.13`` or higher.
+
+Refs #9708

--- a/tests/functional/ext/typing/typing_consider_using_alias.py
+++ b/tests/functional/ext/typing/typing_consider_using_alias.py
@@ -26,7 +26,7 @@ var4: typing.OrderedDict[str, int]  # [consider-using-alias]
 var5: typing.Awaitable[None]  # [consider-using-alias]
 var6: typing.Iterable[int]  # [consider-using-alias]
 var7: typing.Hashable  # [consider-using-alias]
-var8: typing.ContextManager[str]  # [consider-using-alias]
+var8: typing.ContextManager[str]  # only deprecated with 3.13
 var9: typing.Pattern[str]  # [consider-using-alias]
 var10: typing.re.Match[str]  # [consider-using-alias]
 var11: list[int]

--- a/tests/functional/ext/typing/typing_consider_using_alias.txt
+++ b/tests/functional/ext/typing/typing_consider_using_alias.txt
@@ -4,7 +4,6 @@ consider-using-alias:25:6:25:24::'typing.OrderedDict' will be deprecated with PY
 consider-using-alias:26:6:26:22::'typing.Awaitable' will be deprecated with PY39, consider using 'collections.abc.Awaitable' instead:INFERENCE
 consider-using-alias:27:6:27:21::'typing.Iterable' will be deprecated with PY39, consider using 'collections.abc.Iterable' instead:INFERENCE
 consider-using-alias:28:6:28:21::'typing.Hashable' will be deprecated with PY39, consider using 'collections.abc.Hashable' instead:INFERENCE
-consider-using-alias:29:6:29:27::'typing.ContextManager' will be deprecated with PY39, consider using 'contextlib.AbstractContextManager' instead:INFERENCE
 consider-using-alias:30:6:30:20::'typing.Pattern' will be deprecated with PY39, consider using 're.Pattern' instead:INFERENCE
 consider-using-alias:31:7:31:22::'typing.Match' will be deprecated with PY39, consider using 're.Match' instead:INFERENCE
 consider-using-alias:40:9:40:13::'typing.List' will be deprecated with PY39, consider using 'list' instead:INFERENCE

--- a/tests/functional/ext/typing/typing_consider_using_alias_without_future.py
+++ b/tests/functional/ext/typing/typing_consider_using_alias_without_future.py
@@ -24,7 +24,7 @@ var4: typing.OrderedDict[str, int]  # [consider-using-alias]
 var5: typing.Awaitable[None]  # [consider-using-alias]
 var6: typing.Iterable[int]  # [consider-using-alias]
 var7: typing.Hashable  # [consider-using-alias]
-var8: typing.ContextManager[str]  # [consider-using-alias]
+var8: typing.ContextManager[str]  # only deprecated with 3.13
 var9: typing.Pattern[str]  # [consider-using-alias]
 var10: typing.re.Match[str]  # [consider-using-alias]
 var11: list[int]

--- a/tests/functional/ext/typing/typing_consider_using_alias_without_future.txt
+++ b/tests/functional/ext/typing/typing_consider_using_alias_without_future.txt
@@ -4,7 +4,6 @@ consider-using-alias:23:6:23:24::'typing.OrderedDict' will be deprecated with PY
 consider-using-alias:24:6:24:22::'typing.Awaitable' will be deprecated with PY39, consider using 'collections.abc.Awaitable' instead. Add 'from __future__ import annotations' as well:INFERENCE
 consider-using-alias:25:6:25:21::'typing.Iterable' will be deprecated with PY39, consider using 'collections.abc.Iterable' instead. Add 'from __future__ import annotations' as well:INFERENCE
 consider-using-alias:26:6:26:21::'typing.Hashable' will be deprecated with PY39, consider using 'collections.abc.Hashable' instead:INFERENCE
-consider-using-alias:27:6:27:27::'typing.ContextManager' will be deprecated with PY39, consider using 'contextlib.AbstractContextManager' instead. Add 'from __future__ import annotations' as well:INFERENCE
 consider-using-alias:28:6:28:20::'typing.Pattern' will be deprecated with PY39, consider using 're.Pattern' instead. Add 'from __future__ import annotations' as well:INFERENCE
 consider-using-alias:29:7:29:22::'typing.Match' will be deprecated with PY39, consider using 're.Match' instead. Add 'from __future__ import annotations' as well:INFERENCE
 consider-using-alias:38:9:38:13::'typing.List' will be deprecated with PY39, consider using 'list' instead:INFERENCE

--- a/tests/functional/ext/typing/typing_deprecated_alias.py
+++ b/tests/functional/ext/typing/typing_deprecated_alias.py
@@ -2,7 +2,7 @@
 
 'py-version' needs to be set to >= '3.9'.
 """
-# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unsubscriptable-object,unnecessary-direct-lambda-call
+# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unsubscriptable-object,unnecessary-direct-lambda-call,wrong-import-position
 import collections
 import collections.abc
 import typing
@@ -17,7 +17,7 @@ var4: typing.OrderedDict[str, int]  # [deprecated-typing-alias]
 var5: typing.Awaitable[None]  # [deprecated-typing-alias]
 var6: typing.Iterable[int]  # [deprecated-typing-alias]
 var7: typing.Hashable  # [deprecated-typing-alias]
-var8: typing.ContextManager[str]  # [deprecated-typing-alias]
+var8: typing.ContextManager[str]  # only deprecated with 3.13
 var9: typing.Pattern[str]  # [deprecated-typing-alias]
 var10: typing.re.Match[str]  # [deprecated-typing-alias]
 var11: list[int]
@@ -64,3 +64,11 @@ class CustomTypedDict2(TypedDict):
 @dataclass
 class CustomDataClass:
     my_var: List[int]  # [deprecated-typing-alias]
+
+
+import typing_extensions
+
+var40: typing_extensions.AsyncContextManager[int]
+var41: typing_extensions.ContextManager[str]
+var42: typing_extensions.AsyncGenerator[int]
+var43: typing_extensions.Generator[str]

--- a/tests/functional/ext/typing/typing_deprecated_alias.txt
+++ b/tests/functional/ext/typing/typing_deprecated_alias.txt
@@ -4,7 +4,6 @@ deprecated-typing-alias:16:6:16:24::'typing.OrderedDict' is deprecated, use 'col
 deprecated-typing-alias:17:6:17:22::'typing.Awaitable' is deprecated, use 'collections.abc.Awaitable' instead:INFERENCE
 deprecated-typing-alias:18:6:18:21::'typing.Iterable' is deprecated, use 'collections.abc.Iterable' instead:INFERENCE
 deprecated-typing-alias:19:6:19:21::'typing.Hashable' is deprecated, use 'collections.abc.Hashable' instead:INFERENCE
-deprecated-typing-alias:20:6:20:27::'typing.ContextManager' is deprecated, use 'contextlib.AbstractContextManager' instead:INFERENCE
 deprecated-typing-alias:21:6:21:20::'typing.Pattern' is deprecated, use 're.Pattern' instead:INFERENCE
 deprecated-typing-alias:22:7:22:22::'typing.Match' is deprecated, use 're.Match' instead:INFERENCE
 deprecated-typing-alias:28:9:28:12::'typing.Set' is deprecated, use 'set' instead:INFERENCE

--- a/tests/functional/ext/typing/typing_deprecated_alias_py313.py
+++ b/tests/functional/ext/typing/typing_deprecated_alias_py313.py
@@ -1,0 +1,17 @@
+"""Test pylint.extension.typing - deprecated-typing-alias
+
+'py-version' needs to be set to >= '3.13'.
+"""
+# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unsubscriptable-object,unnecessary-direct-lambda-call
+import typing
+import typing_extensions
+
+var1: typing.AsyncContextManager[int]  # [deprecated-typing-alias]
+var2: typing.ContextManager[str]  # [deprecated-typing-alias]
+var3: typing.AsyncGenerator[int]  # [deprecated-typing-alias]
+var4: typing.Generator[str]  # [deprecated-typing-alias]
+
+var5: typing_extensions.AsyncContextManager[int]  # [deprecated-typing-alias]
+var6: typing_extensions.ContextManager[str]  # [deprecated-typing-alias]
+var7: typing_extensions.AsyncGenerator[int]  # [deprecated-typing-alias]
+var8: typing_extensions.Generator[str]  # [deprecated-typing-alias]

--- a/tests/functional/ext/typing/typing_deprecated_alias_py313.rc
+++ b/tests/functional/ext/typing/typing_deprecated_alias_py313.rc
@@ -1,0 +1,8 @@
+[main]
+py-version=3.13
+load-plugins=pylint.extensions.typing
+
+[testoptions]
+min_pyver=3.9
+
+[typing]

--- a/tests/functional/ext/typing/typing_deprecated_alias_py313.txt
+++ b/tests/functional/ext/typing/typing_deprecated_alias_py313.txt
@@ -1,0 +1,8 @@
+deprecated-typing-alias:9:6:9:32::'typing.AsyncContextManager' is deprecated, use 'contextlib.AbstractAsyncContextManager' instead:INFERENCE
+deprecated-typing-alias:10:6:10:27::'typing.ContextManager' is deprecated, use 'contextlib.AbstractContextManager' instead:INFERENCE
+deprecated-typing-alias:11:6:11:27::'typing.AsyncGenerator' is deprecated, use 'collections.abc.AsyncGenerator' instead:INFERENCE
+deprecated-typing-alias:12:6:12:22::'typing.Generator' is deprecated, use 'collections.abc.Generator' instead:INFERENCE
+deprecated-typing-alias:14:6:14:43::'typing.AsyncContextManager' is deprecated, use 'contextlib.AbstractAsyncContextManager' instead:INFERENCE
+deprecated-typing-alias:15:6:15:38::'typing.ContextManager' is deprecated, use 'contextlib.AbstractContextManager' instead:INFERENCE
+deprecated-typing-alias:16:6:16:38::'typing.AsyncGenerator' is deprecated, use 'collections.abc.AsyncGenerator' instead:INFERENCE
+deprecated-typing-alias:17:6:17:33::'typing.Generator' is deprecated, use 'collections.abc.Generator' instead:INFERENCE


### PR DESCRIPTION
## Description
For Python 3.13, the type definitions for `typing.Generator`, `typing.AsyncGenerator`, `typing.ContextManager`, and `typing.AsyncContextManager` changed to allow default TypeVars. This is backported to `typing_extensions`. However, as it's a stub only change and `typing_extensions` just delegates to `typing`, we need to exclude these names from the `deprecated-typing-alias` check until `py-version` is set to `3.13` or higher to not emit false positives.
