### PR TITLE
[possibly-used-before-assignment] Avoid FP for typing.NoReturn

### DIFF
--- a/doc/data/messages/p/possibly-used-before-assignment/details.rst
+++ b/doc/data/messages/p/possibly-used-before-assignment/details.rst
@@ -17,6 +17,11 @@ You can use ``assert_never`` to mark exhaustive choices:
     if suffix in "dmy":
         handle_date_suffix(suffix)
 
+Or, instead of `assert_never()`, you can call a function with a return
+annotation of `Never` or `NoReturn`. Unlike in the general case, where
+by design pylint ignores type annotations and does its own static analysis,
+here, pylint treats these special annotations like a disable comment.
+
 Pylint currently allows repeating the same test like this, even though this
 lets some error cases through, as pylint does not assess the intervening code:
 

--- a/doc/whatsnew/fragments/9674.false_positive
+++ b/doc/whatsnew/fragments/9674.false_positive
@@ -1,0 +1,5 @@
+Prevent emitting ``possibly-used-before-assignment`` when relying on names
+only potentially not defined in conditional blocks guarded by functions
+annotated with ``typing.Never`` or ``typing.NoReturn``.
+
+Closes #9674

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2630,7 +2630,7 @@ class VariablesChecker(BaseChecker):
                 else_stmt, (nodes.Return, nodes.Raise, nodes.Break, nodes.Continue)
             ):
                 return
-            # TODO: 4.0: Consider using RefactoringChecker._is_function_def_never_returning
+            # TODO: 4.0: Consider using utils.is_terminating_func
             if isinstance(else_stmt, nodes.Expr) and isinstance(
                 else_stmt.value, nodes.Call
             ):

--- a/tests/functional/u/used/used_before_assignment.py
+++ b/tests/functional/u/used/used_before_assignment.py
@@ -2,6 +2,7 @@
 # pylint: disable=consider-using-f-string, missing-function-docstring
 import datetime
 import sys
+from typing import NoReturn
 
 MSG = "hello %s" % MSG  # [used-before-assignment]
 
@@ -205,3 +206,19 @@ def inner_if_continues_outer_if_has_no_other_statements():
         else:
             order = None
         print(order)
+
+
+class PlatformChecks:
+    """https://github.com/pylint-dev/pylint/issues/9674"""
+    def skip(self, msg) -> NoReturn:
+        raise Exception(msg)  # pylint: disable=broad-exception-raised
+
+    def print_platform_specific_command(self):
+        if sys.platform == "linux":
+            cmd = "ls"
+        elif sys.platform == "win32":
+            cmd = "dir"
+        else:
+            self.skip("only runs on Linux/Windows")
+
+        print(cmd)

--- a/tests/functional/u/used/used_before_assignment.txt
+++ b/tests/functional/u/used/used_before_assignment.txt
@@ -1,15 +1,15 @@
-used-before-assignment:6:19:6:22::Using variable 'MSG' before assignment:HIGH
-used-before-assignment:8:20:8:24::Using variable 'MSG2' before assignment:HIGH
-used-before-assignment:11:4:11:9:outer:Using variable 'inner' before assignment:HIGH
-used-before-assignment:20:20:20:40:ClassWithProperty:Using variable 'redefine_time_import' before assignment:HIGH
-used-before-assignment:24:0:24:9::Using variable 'calculate' before assignment:HIGH
-used-before-assignment:32:10:32:14:redefine_time_import:Using variable 'time' before assignment:HIGH
-used-before-assignment:46:3:46:7::Using variable 'VAR2' before assignment:INFERENCE
-possibly-used-before-assignment:64:3:64:7::Possibly using variable 'VAR4' before assignment:INFERENCE
-possibly-used-before-assignment:74:3:74:7::Possibly using variable 'VAR5' before assignment:INFERENCE
-used-before-assignment:79:3:79:7::Using variable 'VAR6' before assignment:INFERENCE
-used-before-assignment:114:6:114:11::Using variable 'VAR10' before assignment:INFERENCE
-possibly-used-before-assignment:120:6:120:11::Possibly using variable 'VAR12' before assignment:CONTROL_FLOW
-used-before-assignment:151:10:151:14::Using variable 'SALE' before assignment:INFERENCE
-used-before-assignment:183:10:183:18::Using variable 'ALL_DONE' before assignment:INFERENCE
-used-before-assignment:194:6:194:24::Using variable 'NOT_ALWAYS_DEFINED' before assignment:INFERENCE
+used-before-assignment:7:19:7:22::Using variable 'MSG' before assignment:HIGH
+used-before-assignment:9:20:9:24::Using variable 'MSG2' before assignment:HIGH
+used-before-assignment:12:4:12:9:outer:Using variable 'inner' before assignment:HIGH
+used-before-assignment:21:20:21:40:ClassWithProperty:Using variable 'redefine_time_import' before assignment:HIGH
+used-before-assignment:25:0:25:9::Using variable 'calculate' before assignment:HIGH
+used-before-assignment:33:10:33:14:redefine_time_import:Using variable 'time' before assignment:HIGH
+used-before-assignment:47:3:47:7::Using variable 'VAR2' before assignment:INFERENCE
+possibly-used-before-assignment:65:3:65:7::Possibly using variable 'VAR4' before assignment:INFERENCE
+possibly-used-before-assignment:75:3:75:7::Possibly using variable 'VAR5' before assignment:INFERENCE
+used-before-assignment:80:3:80:7::Using variable 'VAR6' before assignment:INFERENCE
+used-before-assignment:115:6:115:11::Using variable 'VAR10' before assignment:INFERENCE
+possibly-used-before-assignment:121:6:121:11::Possibly using variable 'VAR12' before assignment:CONTROL_FLOW
+used-before-assignment:152:10:152:14::Using variable 'SALE' before assignment:INFERENCE
+used-before-assignment:184:10:184:18::Using variable 'ALL_DONE' before assignment:INFERENCE
+used-before-assignment:195:6:195:24::Using variable 'NOT_ALWAYS_DEFINED' before assignment:INFERENCE


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description
Closes #9674 for the general case, but not necessarily for pytest.skip due to the following:

```py
from astroid import extract_node
n = extract_node("""
... import pytest
... pytest.skip('foo')""")
>>> n.func.inferred()
[Uninferable]
```