### PR TITLE
Add `tox.ini` to the default discovered config files (right after setup.cfg)

### DIFF
--- a/doc/whatsnew/fragments/9727.bugfix
+++ b/doc/whatsnew/fragments/9727.bugfix
@@ -1,3 +1,5 @@
 Fix a bug where a ``tox.ini`` file with pylint configuration was ignored and it exists in the current directory.
 
+``.cfg`` and ``.ini`` files containing a ``Pylint`` configuration may now use a section named ``[pylint]``. This enhancement impacts the scenario where these file types are used as defaults when they are present and have not been explicitly referred to, using the ``--rcfile`` option.
+
 Closes #9727

--- a/doc/whatsnew/fragments/9727.bugfix
+++ b/doc/whatsnew/fragments/9727.bugfix
@@ -1,0 +1,3 @@
+Fix a bug where a ``tox.ini`` file with pylint configuration was ignored and it exists in the current directory.
+
+Closes #9727

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -61,7 +61,10 @@ def _cfg_has_config(path: Path | str) -> bool:
         parser.read(path, encoding="utf-8")
     except configparser.Error:
         return False
-    return any(section.startswith("pylint.") for section in parser.sections())
+    return any(
+        section == "pylint" or section.startswith("pylint.")
+        for section in parser.sections()
+    )
 
 
 def _yield_default_files() -> Iterator[Path]:

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -22,7 +22,8 @@ RC_NAMES = (
     Path(".pylintrc.toml"),
 )
 PYPROJECT_NAME = Path("pyproject.toml")
-CONFIG_NAMES = (*RC_NAMES, PYPROJECT_NAME, Path("setup.cfg"))
+TOX_NAME = Path("tox.ini")
+CONFIG_NAMES = (*RC_NAMES, PYPROJECT_NAME, Path("setup.cfg"), TOX_NAME)
 
 
 def _find_pyproject() -> Path:
@@ -71,7 +72,7 @@ def _yield_default_files() -> Iterator[Path]:
             if config_name.is_file():
                 if config_name.suffix == ".toml" and not _toml_has_config(config_name):
                     continue
-                if config_name.suffix == ".cfg" and not _cfg_has_config(config_name):
+                if config_name.suffix in (".cfg", ".ini") and not _cfg_has_config(config_name):
                     continue
 
                 yield config_name.resolve()

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -72,7 +72,9 @@ def _yield_default_files() -> Iterator[Path]:
             if config_name.is_file():
                 if config_name.suffix == ".toml" and not _toml_has_config(config_name):
                     continue
-                if config_name.suffix in (".cfg", ".ini") and not _cfg_has_config(config_name):
+                if config_name.suffix in (".cfg", ".ini") and not _cfg_has_config(
+                    config_name
+                ):
                     continue
 
                 yield config_name.resolve()

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -74,9 +74,10 @@ def _yield_default_files() -> Iterator[Path]:
             if config_name.is_file():
                 if config_name.suffix == ".toml" and not _toml_has_config(config_name):
                     continue
-                if config_name.suffix in {".cfg", ".ini"} and not _cfg_or_ini_has_config(
-                    config_name
-                ):
+                if config_name.suffix in {
+                    ".cfg",
+                    ".ini",
+                } and not _cfg_or_ini_has_config(config_name):
                     continue
 
                 yield config_name.resolve()

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -22,8 +22,7 @@ RC_NAMES = (
     Path(".pylintrc.toml"),
 )
 PYPROJECT_NAME = Path("pyproject.toml")
-TOX_NAME = Path("tox.ini")
-CONFIG_NAMES = (*RC_NAMES, PYPROJECT_NAME, Path("setup.cfg"), TOX_NAME)
+CONFIG_NAMES = (*RC_NAMES, PYPROJECT_NAME, Path("setup.cfg"), Path("tox.ini"))
 
 
 def _find_pyproject() -> Path:

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -55,7 +55,7 @@ def _toml_has_config(path: Path | str) -> bool:
     return "pylint" in content.get("tool", [])
 
 
-def _cfg_has_config(path: Path | str) -> bool:
+def _cfg_or_ini_has_config(path: Path | str) -> bool:
     parser = configparser.ConfigParser()
     try:
         parser.read(path, encoding="utf-8")
@@ -74,7 +74,7 @@ def _yield_default_files() -> Iterator[Path]:
             if config_name.is_file():
                 if config_name.suffix == ".toml" and not _toml_has_config(config_name):
                     continue
-                if config_name.suffix in {".cfg", ".ini"} and not _cfg_has_config(
+                if config_name.suffix in {".cfg", ".ini"} and not _cfg_or_ini_has_config(
                     config_name
                 ):
                     continue

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -72,7 +72,7 @@ def _yield_default_files() -> Iterator[Path]:
             if config_name.is_file():
                 if config_name.suffix == ".toml" and not _toml_has_config(config_name):
                     continue
-                if config_name.suffix in (".cfg", ".ini") and not _cfg_has_config(
+                if config_name.suffix in {".cfg", ".ini"} and not _cfg_has_config(
                     config_name
                 ):
                     continue

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -310,7 +310,7 @@ disable = logging-not-lazy,logging-format-interpolation
 def test_has_config(content: str, expected: bool, tmp_path: Path) -> None:
     """Test that a .cfg file or .ini file has a pylint config."""
     for file_name in ("fake.cfg", "tox.ini"):
-        fake_conf = tmp_path / file_name 
+        fake_conf = tmp_path / file_name
         with open(fake_conf, "w", encoding="utf8") as f:
             f.write(content)
         assert _cfg_has_config(fake_conf) == expected

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -307,12 +307,17 @@ disable = logging-not-lazy,logging-format-interpolation
         ],
     ],
 )
-def test_cfg_has_config(content: str, expected: bool, tmp_path: Path) -> None:
-    """Test that a cfg file has a pylint config."""
+def test_has_config(content: str, expected: bool, tmp_path: Path) -> None:
+    """Test that a .cfg file or .ini file has a pylint config."""
     fake_cfg = tmp_path / "fake.cfg"
     with open(fake_cfg, "w", encoding="utf8") as f:
         f.write(content)
     assert _cfg_has_config(fake_cfg) == expected
+
+    fake_ini = tmp_path / "tox.ini"
+    with open(fake_ini, "w", encoding="utf8") as f:
+        f.write(content)
+    assert _cfg_has_config(fake_ini) == expected
 
 
 def test_non_existent_home() -> None:

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -309,10 +309,11 @@ disable = logging-not-lazy,logging-format-interpolation
 )
 def test_has_config(content: str, expected: bool, tmp_path: Path) -> None:
     """Test that a .cfg file or .ini file has a pylint config."""
-    fake_cfg = tmp_path / "fake.cfg"
-    with open(fake_cfg, "w", encoding="utf8") as f:
-        f.write(content)
-    assert _cfg_has_config(fake_cfg) == expected
+    for file_name in ("fake.cfg", "tox.ini"):
+        fake_conf = tmp_path / file_name 
+        with open(fake_conf, "w", encoding="utf8") as f:
+            f.write(content)
+        assert _cfg_has_config(fake_conf) == expected
 
     fake_ini = tmp_path / "tox.ini"
     with open(fake_ini, "w", encoding="utf8") as f:

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -315,11 +315,6 @@ def test_has_config(content: str, expected: bool, tmp_path: Path) -> None:
             f.write(content)
         assert _cfg_has_config(fake_conf) == expected
 
-    fake_ini = tmp_path / "tox.ini"
-    with open(fake_ini, "w", encoding="utf8") as f:
-        f.write(content)
-    assert _cfg_has_config(fake_ini) == expected
-
 
 def test_non_existent_home() -> None:
     """Test that we handle a non-existent home directory.

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -18,7 +18,7 @@ import pytest
 from pytest import CaptureFixture
 
 from pylint import config, testutils
-from pylint.config.find_default_config_files import _cfg_has_config, _toml_has_config
+from pylint.config.find_default_config_files import _cfg_or_ini_has_config, _toml_has_config
 from pylint.lint.run import Run
 
 
@@ -313,7 +313,7 @@ def test_has_config(content: str, expected: bool, tmp_path: Path) -> None:
         fake_conf = tmp_path / file_name
         with open(fake_conf, "w", encoding="utf8") as f:
             f.write(content)
-        assert _cfg_has_config(fake_conf) == expected
+        assert _cfg_or_ini_has_config(fake_conf) == expected
 
 
 def test_non_existent_home() -> None:

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -18,7 +18,10 @@ import pytest
 from pytest import CaptureFixture
 
 from pylint import config, testutils
-from pylint.config.find_default_config_files import _cfg_or_ini_has_config, _toml_has_config
+from pylint.config.find_default_config_files import (
+    _cfg_or_ini_has_config,
+    _toml_has_config,
+)
 from pylint.lint.run import Run
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fix a bug where a ``tox.ini`` file with pylint configuration was ignored and it exists in the current directory.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9727
