### PR TITLE
Bump pylint to 3.2.4, update changelog

### DIFF
--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -14,6 +14,41 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.2.4?
+---------------------------
+Release date: 2024-06-24
+
+
+False Positives Fixed
+---------------------
+
+- Prevent emitting ``possibly-used-before-assignment`` when relying on names
+  only potentially not defined in conditional blocks guarded by functions
+  annotated with ``typing.Never`` or ``typing.NoReturn``.
+
+  Closes #9674 (`#9674 <https://github.com/pylint-dev/pylint/issues/9674>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fixed a crash when the lineno of a variable used as an annotation wasn't available for ``undefined-variable``.
+
+  Closes #8866 (`#8866 <https://github.com/pylint-dev/pylint/issues/8866>`_)
+
+- Fixed a crash when the ``start`` value in an ``enumerate`` was non-constant and impossible to infer
+  (like in``enumerate(apples, start=int(random_apple_index)``) for ``unnecessary-list-index-lookup``.
+
+  Closes #9078 (`#9078 <https://github.com/pylint-dev/pylint/issues/9078>`_)
+
+- Fixed a crash in ``symilar`` when the ``-d`` or ``-i`` short option were not properly recognized.
+  It's still impossible to do ``-d=1`` (you must do ``-d 1``).
+
+  Closes #9343 (`#9343 <https://github.com/pylint-dev/pylint/issues/9343>`_)
+
+
+
 What's new in Pylint 3.2.3?
 ---------------------------
 Release date: 2024-06-06

--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -16,7 +16,7 @@ Summary -- Release highlights
 
 What's new in Pylint 3.2.4?
 ---------------------------
-Release date: 2024-06-24
+Release date: 2024-06-25
 
 
 False Positives Fixed

--- a/doc/whatsnew/fragments/8866.bugfix
+++ b/doc/whatsnew/fragments/8866.bugfix
@@ -1,3 +1,0 @@
-Fixed a crash when the lineno of a variable used as an annotation wasn't available for ``undefined-variable``.
-
-Closes #8866

--- a/doc/whatsnew/fragments/9078.bugfix
+++ b/doc/whatsnew/fragments/9078.bugfix
@@ -1,4 +1,0 @@
-Fixed a crash when the ``start`` value in an ``enumerate`` was non-constant and impossible to infer
-(like in``enumerate(apples, start=int(random_apple_index)``) for ``unnecessary-list-index-lookup``.
-
-Closes #9078

--- a/doc/whatsnew/fragments/9343.bugfix
+++ b/doc/whatsnew/fragments/9343.bugfix
@@ -1,4 +1,0 @@
-Fixed a crash in ``symilar`` when the ``-d`` or ``-i`` short option were not properly recognized.
-It's still impossible to do ``-d=1`` (you must do ``-d 1``).
-
-Closes #9343

--- a/doc/whatsnew/fragments/9674.false_positive
+++ b/doc/whatsnew/fragments/9674.false_positive
@@ -1,5 +1,0 @@
-Prevent emitting ``possibly-used-before-assignment`` when relying on names
-only potentially not defined in conditional blocks guarded by functions
-annotated with ``typing.Never`` or ``typing.NoReturn``.
-
-Closes #9674

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.2.3"
+__version__ = "3.2.4"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.2.3"
+current = "3.2.4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.2.3"
+version = "3.2.4"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.2/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.2.4?
---------------------------
Release date: 2024-06-25


False Positives Fixed
---------------------

- Prevent emitting ``possibly-used-before-assignment`` when relying on names
  only potentially not defined in conditional blocks guarded by functions
  annotated with ``typing.Never`` or ``typing.NoReturn``.

  Closes #9674 



Other Bug Fixes
---------------

- Fixed a crash when the lineno of a variable used as an annotation wasn't available for ``undefined-variable``.

  Closes #8866

- Fixed a crash when the ``start`` value in an ``enumerate`` was non-constant and impossible to infer
  (like in``enumerate(apples, start=int(random_apple_index)``) for ``unnecessary-list-index-lookup``.

  Closes #9078

- Fixed a crash in ``symilar`` when the ``-d`` or ``-i`` short option were not properly recognized.
  It's still impossible to do ``-d=1`` (you must do ``-d 1``).

  Closes #9343 