### PR TITLE
Bump pylint to 3.2.5, update changelog

### DIFF
--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -14,6 +14,21 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.2.5?
+---------------------------
+Release date: 2024-06-28
+
+
+Other Bug Fixes
+---------------
+
+- Fixed a false positive ``unreachable-code`` when using ``typing.Any`` as return type in python
+  3.8, the ``typing.NoReturn`` are not taken into account anymore for python 3.8 however.
+
+  Closes #9751 (`#9751 <https://github.com/pylint-dev/pylint/issues/9751>`_)
+
+
+
 What's new in Pylint 3.2.4?
 ---------------------------
 Release date: 2024-06-26

--- a/doc/whatsnew/fragments/9751.bugfix
+++ b/doc/whatsnew/fragments/9751.bugfix
@@ -1,4 +1,0 @@
-Fixed a false positive ``unreachable-code`` when using ``typing.Any`` as return type in python
-3.8, the ``typing.NoReturn`` are not taken into account anymore for python 3.8 however.
-
-Closes #9751

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.2.4"
+__version__ = "3.2.5"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.2.4"
+current = "3.2.5"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.2.4"
+version = "3.2.5"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.2/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.2.5?
---------------------------
Release date: 2024-06-28


Other Bug Fixes
---------------

- Fixed a false positive ``unreachable-code`` when using ``typing.Any`` as return type in python
  3.8, the ``typing.NoReturn`` are not taken into account anymore for python 3.8 however.

  Closes #9751