### PR TITLE
Fix `invalid-name` regression for class attributes in subclasses

### DIFF
--- a/doc/whatsnew/fragments/9765.false_positive
+++ b/doc/whatsnew/fragments/9765.false_positive
@@ -1,0 +1,4 @@
+Fix a regression that raised ``invalid-name`` on class attributes merely
+overriding invalid names from an ancestor.
+
+Closes #9765

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -491,7 +491,9 @@ class NameChecker(_BasicChecker):
                         self._check_name("variable", node.name, node)
 
         # Check names defined in class scopes
-        elif isinstance(frame, nodes.ClassDef):
+        elif isinstance(frame, nodes.ClassDef) and not any(
+            frame.local_attr_ancestors(node.name)
+        ):
             if utils.is_enum_member(node) or utils.is_assign_name_annotated_with(
                 node, "Final"
             ):

--- a/tests/functional/i/invalid/invalid_name.py
+++ b/tests/functional/i/invalid/invalid_name.py
@@ -102,3 +102,10 @@ class FooBar:
         """Invalid-name will still be raised for other arguments."""
         self.foo_bar = fooBar
         self.foo_bar2 = fooBar2
+
+    def tearDown(self): ...  # pylint: disable=invalid-name
+
+
+class FooBarSubclass(FooBar):
+    tearDown = FooBar.tearDown
+    tearDownNotInAncestor = None  # [invalid-name]

--- a/tests/functional/i/invalid/invalid_name.rc
+++ b/tests/functional/i/invalid/invalid_name.rc
@@ -1,0 +1,2 @@
+[MAIN]
+class-attribute-naming-style=snake_case

--- a/tests/functional/i/invalid/invalid_name.txt
+++ b/tests/functional/i/invalid/invalid_name.txt
@@ -6,3 +6,4 @@ invalid-name:66:0:66:68:a_very_very_very_long_function_name_WithCamelCase_to_mak
 invalid-name:74:23:74:29:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
 invalid-name:80:8:80:14:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
 invalid-name:100:8:100:15:FooBar.test_disable_mixed:"Argument name ""fooBar2"" doesn't conform to snake_case naming style":HIGH
+invalid-name:111:4:111:25:FooBarSubclass:"Class attribute name ""tearDownNotInAncestor"" doesn't conform to snake_case naming style":HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description
Fixes #9765