### PR TITLE
Revert "Remove `--min_pyver_end_position`"

### DIFF
--- a/doc/development_guide/contributor_guide/tests/writing_test.rst
+++ b/doc/development_guide/contributor_guide/tests/writing_test.rst
@@ -61,6 +61,7 @@ test runner. The following options are currently supported:
 
 - "min_pyver": Minimal python version required to run the test
 - "max_pyver": Python version from which the test won't be run. If the last supported version is 3.9 this setting should be set to 3.10.
+- "min_pyver_end_position": Minimal python version required to check the end_line and end_column attributes of the message
 - "requires": Packages required to be installed locally to run the test
 - "except_implementations": List of python implementations on which the test should not run
 - "exclude_platforms": List of operating systems on which the test should not run

--- a/doc/whatsnew/fragments/9774.other
+++ b/doc/whatsnew/fragments/9774.other
@@ -1,6 +1,4 @@
 Remove support for launching pylint with Python 3.8.
 Code that supports Python 3.8 can still be linted with the ``--py-version=3.8`` setting.
 
-``--min_pyver_end_position`` in the functional test runner is no longer relevant and is removed.
-
 Refs #9774

--- a/pylint/testutils/functional/test_file.py
+++ b/pylint/testutils/functional/test_file.py
@@ -22,6 +22,7 @@ class NoFileError(Exception):
 class TestFileOptions(TypedDict):
     min_pyver: tuple[int, ...]
     max_pyver: tuple[int, ...]
+    min_pyver_end_position: tuple[int, ...]
     requires: list[str]
     except_implementations: list[str]
     exclude_platforms: list[str]
@@ -32,6 +33,7 @@ class TestFileOptions(TypedDict):
 POSSIBLE_TEST_OPTIONS = {
     "min_pyver",
     "max_pyver",
+    "min_pyver_end_position",
     "requires",
     "except_implementations",
     "exclude_platforms",
@@ -45,6 +47,7 @@ class FunctionalTestFile:
     _CONVERTERS: dict[str, Callable[[str], tuple[int, ...] | list[str]]] = {
         "min_pyver": parse_python_version,
         "max_pyver": parse_python_version,
+        "min_pyver_end_position": parse_python_version,
         "requires": lambda s: [i.strip() for i in s.split(",")],
         "except_implementations": lambda s: [i.strip() for i in s.split(",")],
         "exclude_platforms": lambda s: [i.strip() for i in s.split(",")],
@@ -58,6 +61,7 @@ class FunctionalTestFile:
         self.options: TestFileOptions = {
             "min_pyver": (2, 5),
             "max_pyver": (4, 0),
+            "min_pyver_end_position": (3, 8),
             "requires": [],
             "except_implementations": [],
             "exclude_platforms": [],

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -80,6 +80,9 @@ class LintModuleTest:
             "--max_pyver", type=parse_python_version, default=(4, 0)
         )
         self._linter._arg_parser.add_argument(
+            "--min_pyver_end_position", type=parse_python_version, default=(3, 8)
+        )
+        self._linter._arg_parser.add_argument(
             "--requires", type=lambda s: [i.strip() for i in s.split(",")], default=[]
         )
         self._linter._arg_parser.add_argument(

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -11,15 +11,13 @@ import sys
 from collections import Counter
 from io import StringIO
 from pathlib import Path
-from typing import Counter as CounterType
-from typing import TextIO, Tuple
+from typing import TextIO
 
 import pytest
 from _pytest.config import Config
 
 from pylint import checkers
 from pylint.config.config_initialization import _config_initialization
-from pylint.constants import IS_PYPY
 from pylint.lint import PyLinter
 from pylint.message.message import Message
 from pylint.testutils.constants import _EXPECTED_RE, _OPERATORS, UPDATE_OPTION
@@ -33,7 +31,7 @@ from pylint.testutils.functional.test_file import (
 from pylint.testutils.output_line import OutputLine
 from pylint.testutils.reporter_for_tests import FunctionalTestReporter
 
-MessageCounter = CounterType[Tuple[int, str]]
+MessageCounter = Counter[tuple[int, str]]
 
 PYLINTRC = Path(__file__).parent / "testing_pylintrc"
 
@@ -108,9 +106,6 @@ class LintModuleTest:
         self._check_end_position = (
             sys.version_info >= self._linter.config.min_pyver_end_position
         )
-        # TODO: PY3.9: PyPy supports end_lineno from 3.9 and above
-        if self._check_end_position and IS_PYPY:
-            self._check_end_position = sys.version_info >= (3, 9)  # pragma: no cover
 
         self._config = config
 

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -44,8 +44,8 @@ class OutputLine(NamedTuple):
     def from_msg(cls, msg: Message, check_endline: bool = True) -> OutputLine:
         """Create an OutputLine from a Pylint Message."""
         column = cls._get_column(msg.column)
-        end_line = cls._get_py38_none_value(msg.end_line, check_endline)
-        end_column = cls._get_py38_none_value(msg.end_column, check_endline)
+        end_line = cls._get_end_line_and_end_col(msg.end_line, check_endline)
+        end_column = cls._get_end_line_and_end_col(msg.end_column, check_endline)
         return cls(
             msg.symbol,
             msg.line,
@@ -63,7 +63,7 @@ class OutputLine(NamedTuple):
         return int(column)
 
     @staticmethod
-    def _get_py38_none_value(value: _T, check_endline: bool) -> _T | None:
+    def _get_end_line_and_end_col(value: _T, check_endline: bool) -> _T | None:
         """Used to make end_line and end_column None as indicated by our version
         compared to `min_pyver_end_position`.
         """
@@ -84,10 +84,10 @@ class OutputLine(NamedTuple):
             line = int(row[1])
             column = cls._get_column(row[2])
             end_line = cls._value_to_optional_int(
-                cls._get_py38_none_value(row[3], check_endline)
+                cls._get_end_line_and_end_col(row[3], check_endline)
             )
             end_column = cls._value_to_optional_int(
-                cls._get_py38_none_value(row[4], check_endline)
+                cls._get_end_line_and_end_col(row[4], check_endline)
             )
             # symbol, line, column, end_line, end_column, node, msg, confidences
             assert len(row) == 8

--- a/tests/testutils/test_output_line.py
+++ b/tests/testutils/test_output_line.py
@@ -70,13 +70,33 @@ def test_output_line_from_message(message: _MessageCallable) -> None:
     assert output_line.msg == "msg"
     assert output_line.confidence == "HIGH"
 
+    output_line_with_end = OutputLine.from_msg(message(), True)
+    assert output_line_with_end.symbol == "missing-docstring"
+    assert output_line_with_end.lineno == 1
+    assert output_line_with_end.column == 2
+    assert output_line_with_end.end_lineno == 1
+    assert output_line_with_end.end_column == 3
+    assert output_line_with_end.object == "obj"
+    assert output_line_with_end.msg == "msg"
+    assert output_line_with_end.confidence == "HIGH"
+
+    output_line_without_end = OutputLine.from_msg(message(), False)
+    assert output_line_without_end.symbol == "missing-docstring"
+    assert output_line_without_end.lineno == 1
+    assert output_line_without_end.column == 2
+    assert output_line_without_end.end_lineno is None
+    assert output_line_without_end.end_column is None
+    assert output_line_without_end.object == "obj"
+    assert output_line_without_end.msg == "msg"
+    assert output_line_without_end.confidence == "HIGH"
+
 
 @pytest.mark.parametrize("confidence", [HIGH, INFERENCE])
 def test_output_line_to_csv(confidence: Confidence, message: _MessageCallable) -> None:
     """Test that the OutputLine NamedTuple is instantiated correctly with from_msg
     and then converted to csv.
     """
-    output_line = OutputLine.from_msg(message(confidence))
+    output_line = OutputLine.from_msg(message(confidence), True)
     csv = output_line.to_csv()
     assert csv == (
         "missing-docstring",
@@ -84,6 +104,19 @@ def test_output_line_to_csv(confidence: Confidence, message: _MessageCallable) -
         "2",
         "1",
         "3",
+        "obj",
+        "msg",
+        confidence.name,
+    )
+
+    output_line_without_end = OutputLine.from_msg(message(confidence), False)
+    csv = output_line_without_end.to_csv()
+    assert csv == (
+        "missing-docstring",
+        "1",
+        "2",
+        "None",
+        "None",
         "obj",
         "msg",
         confidence.name,
@@ -102,6 +135,28 @@ def test_output_line_from_csv() -> None:
         lineno=1,
         column=2,
         end_lineno=1,
+        end_column=None,
+        object="obj",
+        msg="msg",
+        confidence="HIGH",
+    )
+    output_line_with_end = OutputLine.from_csv(proper_csv, True)
+    assert output_line_with_end == OutputLine(
+        symbol="missing-docstring",
+        lineno=1,
+        column=2,
+        end_lineno=1,
+        end_column=None,
+        object="obj",
+        msg="msg",
+        confidence="HIGH",
+    )
+    output_line_without_end = OutputLine.from_csv(proper_csv, False)
+    assert output_line_without_end == OutputLine(
+        symbol="missing-docstring",
+        lineno=1,
+        column=2,
+        end_lineno=None,
         end_column=None,
         object="obj",
         msg="msg",


### PR DESCRIPTION
This reverts commit 4b45192113654c9403c288824bff1ff01c29e061 and 833762fd6f3326d61b897ffa2dab6086b8c8edc4..

See https://github.com/pylint-dev/pylint/pull/9774#discussion_r1671215907.