### PR TITLE
[Backport maintenance/3.2.x] Bump astroid to 3.2.4 (#9816)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.2.3,<=3.3.0-dev0",
+    "astroid>=3.2.4,<=3.3.0-dev0",
     "isort>=4.2.5,<6,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.2.3  # Pinned to a specific version for tests
+astroid==3.2.4  # Pinned to a specific version for tests
 typing-extensions~=4.11
 py~=1.11.0
 pytest~=7.4


### PR DESCRIPTION
(cherry picked from commit c9c768e2fb56b9af3b0a5a25f0515bfd8cd0938b)