### PR TITLE
[Backport maintenance/3.2.x] Fix a crash when a subclass extends `__slots__` (#9817)

### DIFF
--- a/doc/whatsnew/fragments/9814.bugfix
+++ b/doc/whatsnew/fragments/9814.bugfix
@@ -1,0 +1,3 @@
+Fix a crash when a subclass extends ``__slots__``.
+
+Closes #9814

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1486,7 +1486,11 @@ a metaclass class method.",
         if "__slots__" not in node.locals:
             return
 
-        for slots in node.ilookup("__slots__"):
+        try:
+            inferred_slots = tuple(node.ilookup("__slots__"))
+        except astroid.InferenceError:
+            return
+        for slots in inferred_slots:
             # check if __slots__ is a valid type
             if isinstance(slots, util.UninferableBase):
                 continue

--- a/tests/functional/s/slots_checks.py
+++ b/tests/functional/s/slots_checks.py
@@ -128,3 +128,17 @@ class Parent:
 
 class ChildNotAffectedByValueInSlot(Parent):
     __slots__ = ('first', )
+
+
+# https://github.com/pylint-dev/pylint/issues/9814
+class SlotsManipulationTest:
+    __slots__ = ["a", "b", "c"]
+
+
+class TestChild(SlotsManipulationTest):
+    __slots__ += ["d", "e", "f"]  # pylint: disable=undefined-variable
+
+
+t = TestChild()
+
+print(t.__slots__)


### PR DESCRIPTION
(cherry picked from commit 8e18fc012a5fcbd6cfe2b719e35ecd995da9f4bf)