### PR TITLE
Bump pylint to 3.2.6, update changelog

### DIFF
--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -14,6 +14,51 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.2.6?
+---------------------------
+Release date: 2024-07-21
+
+
+False Positives Fixed
+---------------------
+
+- Quiet false positives for `unexpected-keyword-arg` when pylint cannot
+  determine which of two or more dynamically defined classes is being instantiated.
+
+  Closes #9672 (`#9672 <https://github.com/pylint-dev/pylint/issues/9672>`_)
+
+- Fix a false positive for ``missing-param-doc`` where a method which is decorated with ``typing.overload`` was expected to have a docstring specifying its parameters.
+
+  Closes #9739 (`#9739 <https://github.com/pylint-dev/pylint/issues/9739>`_)
+
+- Fix a regression that raised ``invalid-name`` on class attributes merely
+  overriding invalid names from an ancestor.
+
+  Closes #9765 (`#9765 <https://github.com/pylint-dev/pylint/issues/9765>`_)
+
+- Treat `assert_never()` the same way when imported from `typing_extensions`.
+
+  Closes #9780 (`#9780 <https://github.com/pylint-dev/pylint/issues/9780>`_)
+
+- Fix a false positive for `consider-using-min-max-builtin` when the assignment target is an attribute.
+
+  Refs #9800 (`#9800 <https://github.com/pylint-dev/pylint/issues/9800>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fix an `AssertionError` arising from properties that return partial functions.
+
+  Closes #9214 (`#9214 <https://github.com/pylint-dev/pylint/issues/9214>`_)
+
+- Fix a crash when a subclass extends ``__slots__``.
+
+  Closes #9814 (`#9814 <https://github.com/pylint-dev/pylint/issues/9814>`_)
+
+
+
 What's new in Pylint 3.2.5?
 ---------------------------
 Release date: 2024-06-28

--- a/doc/whatsnew/fragments/9214.bugfix
+++ b/doc/whatsnew/fragments/9214.bugfix
@@ -1,3 +1,0 @@
-Fix an `AssertionError` arising from properties that return partial functions.
-
-Closes #9214

--- a/doc/whatsnew/fragments/9672.false_positive
+++ b/doc/whatsnew/fragments/9672.false_positive
@@ -1,4 +1,0 @@
-Quiet false positives for `unexpected-keyword-arg` when pylint cannot
-determine which of two or more dynamically defined classes are being instantiated.
-
-Closes #9672

--- a/doc/whatsnew/fragments/9739.false_positive
+++ b/doc/whatsnew/fragments/9739.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``missing-param-doc`` where a method which is decorated with ``typing.overload`` was expected to have a docstring specifying its parameters.
-
-Closes #9739

--- a/doc/whatsnew/fragments/9765.false_positive
+++ b/doc/whatsnew/fragments/9765.false_positive
@@ -1,4 +1,0 @@
-Fix a regression that raised ``invalid-name`` on class attributes merely
-overriding invalid names from an ancestor.
-
-Closes #9765

--- a/doc/whatsnew/fragments/9780.false_positive
+++ b/doc/whatsnew/fragments/9780.false_positive
@@ -1,3 +1,0 @@
-Treat `assert_never()` the same way when imported from `typing_extensions`.
-
-Closes #9780

--- a/doc/whatsnew/fragments/9800.false_negative
+++ b/doc/whatsnew/fragments/9800.false_negative
@@ -1,3 +1,0 @@
-Fix a false positive for `consider-using-min-max-builtin` when the assignment target is an attribute.
-
-Refs #9800

--- a/doc/whatsnew/fragments/9814.bugfix
+++ b/doc/whatsnew/fragments/9814.bugfix
@@ -1,3 +1,0 @@
-Fix a crash when a subclass extends ``__slots__``.
-
-Closes #9814

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.2.5"
+__version__ = "3.2.6"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.2.5"
+current = "3.2.6"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.2.5"
+version = "3.2.6"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.2/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.2.6?
---------------------------
Release date: 2024-07-21


False Positives Fixed
---------------------

- Quiet false positives for `unexpected-keyword-arg` when pylint cannot
  determine which of two or more dynamically defined classes is being instantiated.

  Closes #9672

- Fix a false positive for ``missing-param-doc`` where a method which is decorated with ``typing.overload`` was expected to have a docstring specifying its parameters.

  Closes #9739

- Fix a regression that raised ``invalid-name`` on class attributes merely
  overriding invalid names from an ancestor.

  Closes #9765

- Treat `assert_never()` the same way when imported from `typing_extensions`.

  Closes #9780

- Fix a false positive for `consider-using-min-max-builtin` when the assignment target is an attribute.

  Refs #9800



Other Bug Fixes
---------------

- Fix an `AssertionError` arising from properties that return partial functions.

  Closes #9214

- Fix a crash when a subclass extends ``__slots__``.

  Closes #9814