### PR TITLE
Sync Sphinx version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,7 @@ repos:
       - id: rstcheck
         args: ["--report-level=warning"]
         files: ^(doc/(.*/)*.*\.rst)
-        additional_dependencies: [Sphinx==5.0.1]
+        additional_dependencies: [Sphinx==7.4.3]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.1
     hooks:


### PR DESCRIPTION
Prevents this error on Python 3.13:
```py
ExtensionError: Could not import extension sphinx.builders.epub3 (exception: No 
module named 'imghdr')
```

We were already pinning Sphinx in docs/requirements.txt:
https://github.com/pylint-dev/pylint/blob/60bd2307c220210b6dd6b739c382c6b3c45d75c4/doc/requirements.txt#L1