### PR TITLE
Fix crash in refactoring checker when calling bound lambda

### DIFF
--- a/doc/whatsnew/fragments/9865.bugfix
+++ b/doc/whatsnew/fragments/9865.bugfix
@@ -1,0 +1,3 @@
+Fix crash in refactoring checker when calling a lambda bound as a method.
+
+Closes #9865

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2089,15 +2089,17 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 return True
         except (TypeError, AttributeError):
             pass
+
+        try:
+            returns: nodes.NodeNG | None = node.returns
+        except AttributeError:
+            return False  # the BoundMethod proxy may be a lambda without a returns
+
         return (
-            isinstance(node, (nodes.FunctionDef, astroid.BoundMethod))
-            and node.returns
-            and (
-                isinstance(node.returns, nodes.Attribute)
-                and node.returns.attrname in {"NoReturn", "Never"}
-                or isinstance(node.returns, nodes.Name)
-                and node.returns.name in {"NoReturn", "Never"}
-            )
+            isinstance(returns, nodes.Attribute)
+            and returns.attrname in {"NoReturn", "Never"}
+            or isinstance(returns, nodes.Name)
+            and returns.name in {"NoReturn", "Never"}
         )
 
     def _check_return_at_the_end(self, node: nodes.FunctionDef) -> None:

--- a/tests/functional/r/regression/regression_9865_calling_bound_lambda.py
+++ b/tests/functional/r/regression/regression_9865_calling_bound_lambda.py
@@ -1,0 +1,8 @@
+"""Regression for https://github.com/pylint-dev/pylint/issues/9865."""
+# pylint: disable=missing-docstring,too-few-public-methods,unnecessary-lambda-assignment
+class C:
+    eq = lambda self, y: self == y
+
+def test_lambda_method():
+    ret = C().eq(1)
+    return ret


### PR DESCRIPTION
Fixes:
```
  File "sources/pylint/pylint/checkers/refactoring/refactoring_checker.py", line 2094, in _is_function_def_never_returning
    and node.returns
        ^^^^^^^^^^^^
  File "sources/pylint/.venv/lib/python3.11/site-packages/astroid/bases.py", line 138, in __getattr__
    return getattr(self._proxied, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Lambda' object has no attribute 'returns'
```

Crash is reproducible if you have something like this:

```python
class C:
    eq = lambda self, y: self == y
```

As a workaround, use a normal function instead of a lambda.

Closes #9865

## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

