### PR TITLE
[Backport maintenance/3.2.x] Fix crash in refactoring checker when calling bound lambda

### DIFF
--- a/doc/whatsnew/fragments/9865.bugfix
+++ b/doc/whatsnew/fragments/9865.bugfix
@@ -1,0 +1,3 @@
+Fix crash in refactoring checker when calling a lambda bound as a method.
+
+Closes #9865

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2083,13 +2083,18 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         Returns:
             bool: True if the function never returns, False otherwise.
         """
-        if isinstance(node, (nodes.FunctionDef, astroid.BoundMethod)) and node.returns:
-            return (
-                isinstance(node.returns, nodes.Attribute)
-                and node.returns.attrname == "NoReturn"
-                or isinstance(node.returns, nodes.Name)
-                and node.returns.name == "NoReturn"
-            )
+        if isinstance(node, (nodes.FunctionDef, astroid.BoundMethod)):
+            try:
+                returns: nodes.NodeNG | None = node.returns
+            except AttributeError:
+                return False  # the BoundMethod proxy may be a lambda without a returns
+            if returns is not None:
+                return (
+                    isinstance(returns, nodes.Attribute)
+                    and returns.attrname == "NoReturn"
+                    or isinstance(returns, nodes.Name)
+                    and returns.name == "NoReturn"
+                )
         try:
             return node.qname() in self._never_returning_functions
         except (TypeError, AttributeError):

--- a/tests/functional/r/regression/regression_9865_calling_bound_lambda.py
+++ b/tests/functional/r/regression/regression_9865_calling_bound_lambda.py
@@ -1,0 +1,8 @@
+"""Regression for https://github.com/pylint-dev/pylint/issues/9865."""
+# pylint: disable=missing-docstring,too-few-public-methods,unnecessary-lambda-assignment
+class C:
+    eq = lambda self, y: self == y
+
+def test_lambda_method():
+    ret = C().eq(1)
+    return ret


### PR DESCRIPTION
Manual backport of b78deb6140799549ae5f2afc9cb5bc8c1afda5cc from #9866