### PR TITLE
`too-few-function-args` redundant with `no-value-for-parameter`

### DIFF
--- a/doc/data/messages/t/too-few-function-args/bad.py
+++ b/doc/data/messages/t/too-few-function-args/bad.py
@@ -1,1 +1,0 @@
-isinstance("foo")  # [too-few-function-args]

--- a/doc/data/messages/t/too-few-function-args/details.rst
+++ b/doc/data/messages/t/too-few-function-args/details.rst
@@ -1,2 +1,0 @@
-As of 2024-08-13, #9847, ```too-few-function-args``` is only implemented for the
-```isinstance``` built-in function.

--- a/doc/data/messages/t/too-few-function-args/good.py
+++ b/doc/data/messages/t/too-few-function-args/good.py
@@ -1,1 +1,0 @@
-isinstance("foo", str)

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -1241,8 +1241,6 @@ Typecheck checker Messages
 :invalid-slice-step (E1144): *Slice step cannot be 0*
   Used when a slice step is 0 and the object doesn't implement a custom
   __getitem__ method.
-:too-few-function-args (E1145): *Too few positional arguments for %s call*
-  Used when a function or method call has fewer arguments than expected.
 :too-many-function-args (E1121): *Too many positional arguments for %s call*
   Used when a function call passes too many positional arguments.
 :unexpected-keyword-arg (E1123): *Unexpected keyword argument %r in %s call*

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -155,7 +155,6 @@ All messages in the error category:
    error/star-needs-assignment-target
    error/syntax-error
    error/too-few-format-args
-   error/too-few-function-args
    error/too-many-format-args
    error/too-many-function-args
    error/too-many-star-expressions

--- a/doc/whatsnew/fragments/9847.false_negative
+++ b/doc/whatsnew/fragments/9847.false_negative
@@ -1,6 +1,5 @@
-Fix a false negative when `isinstance` does not have exactly two arguments.
-Change now emits a `too-many-function-args` when there are too many arguments
-in the `isinstance` call or `no-value-for-parameter` when there are too few
-arguments in the `isinstance` call.
+Fix false negatives when `isinstance` does not have exactly two arguments.
+pylint now emits a `too-many-function-args` or `no-value-for-parameter`
+appropriately for `isinstance` calls.
 
 Closes #9847

--- a/doc/whatsnew/fragments/9847.false_negative
+++ b/doc/whatsnew/fragments/9847.false_negative
@@ -1,5 +1,6 @@
-Fix a false negative when `isinstance` has too many arguments.
-Change now emits a `too-many-function-args` output with behavior similar to other
-`too-many-function-args` calls.
+Fix a false negative when `isinstance` does not have exactly two arguments.
+Change now emits a `too-many-function-args` when there are too many arguments
+in the `isinstance` call or `no-value-for-parameter` when there are too few
+arguments in the `isinstance` call.
 
 Closes #9847

--- a/doc/whatsnew/fragments/9847.new_check
+++ b/doc/whatsnew/fragments/9847.new_check
@@ -1,5 +1,0 @@
-Add `too-few-function-args` for when fewer arguments than expected are provided for a
-function or method call.
-As of this PR, `too-few-function-args` only applies to the built-in function `isinstance`.
-
-Closes #9847

--- a/doc/whatsnew/fragments/9881.bugfix
+++ b/doc/whatsnew/fragments/9881.bugfix
@@ -1,3 +1,0 @@
-Remove `too-few-function-args` in favor of the incumbent message `no-value-for-parameter`.
-
-Closes #9881

--- a/doc/whatsnew/fragments/9881.bugfix
+++ b/doc/whatsnew/fragments/9881.bugfix
@@ -1,0 +1,3 @@
+Remove `too-few-function-args` in favor of the incumbent message `no-value-for-parameter`.
+
+Closes #9881

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -377,11 +377,6 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "Used when a slice step is 0 and the object doesn't implement "
         "a custom __getitem__ method.",
     ),
-    "E1145": (
-        "Too few positional arguments for %s call",
-        "too-few-function-args",
-        "Used when a function or method call has fewer arguments than expected.",
-    ),
     "W1113": (
         "Keyword argument before variable positional arguments list "
         "in the definition of %s function",
@@ -1434,12 +1429,17 @@ accessed. Python regular expressions are accepted.",
                 confidence=HIGH,
             )
         elif len(node.args) < 2:
-            self.add_message(
-                "too-few-function-args",
-                node=node,
-                args=(callable_name,),
-                confidence=HIGH,
-            )
+            # NOTE: Hard-coding the parameters for `isinstance` is fragile,
+            # but as noted elsewhere, built-in functions do not provide
+            # argument info, making this necessary for now.
+            parameters = ("'_obj'", "'__class_or_tuple'")
+            for parameter in parameters[len(node.args) :]:
+                self.add_message(
+                    "no-value-for-parameter",
+                    node=node,
+                    args=(parameter, callable_name),
+                    confidence=HIGH,
+                )
             return
 
         second_arg = node.args[1]

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -331,3 +331,5 @@ class Foo:
 
     func(42)
     a = func(42)
+
+isinstance(1) # [no-value-for-parameter]

--- a/tests/functional/a/arguments.txt
+++ b/tests/functional/a/arguments.txt
@@ -39,3 +39,4 @@ no-value-for-parameter:217:0:217:30::No value for argument 'second' in function 
 unexpected-keyword-arg:218:0:218:43::Unexpected keyword argument 'fourth' in function call:UNDEFINED
 redundant-keyword-arg:308:0:308:79::Argument 'banana' passed by position and keyword in function call:UNDEFINED
 no-value-for-parameter:318:0:318:16::No value for argument 'param1' in function call:UNDEFINED
+no-value-for-parameter:335:0:335:13::No value for argument '__class_or_tuple' in function call:HIGH

--- a/tests/functional/c/consider/consider_merging_isinstance.py
+++ b/tests/functional/c/consider/consider_merging_isinstance.py
@@ -23,8 +23,8 @@ def isinstances():
     result = isinstance(var[10], str) or isinstance(var[10], int) and var[8] * 14 or isinstance(var[10], float) and var[5] * 14.4 or isinstance(var[10], list)   # [consider-merging-isinstance]
     result = isinstance(var[11], int) or isinstance(var[11], int) or isinstance(var[11], float)   # [consider-merging-isinstance]
 
-    result = isinstance(var[20]) # [too-few-function-args]
-    result = isinstance() # [too-few-function-args]
+    result = isinstance(var[20]) # [no-value-for-parameter]
+    result = isinstance() # [no-value-for-parameter, no-value-for-parameter]
 
     # Combination merged and not merged
     result = isinstance(var[12], (int, float)) or isinstance(var[12], list)  # [consider-merging-isinstance]

--- a/tests/functional/c/consider/consider_merging_isinstance.txt
+++ b/tests/functional/c/consider/consider_merging_isinstance.txt
@@ -4,6 +4,7 @@ consider-merging-isinstance:19:13:19:73:isinstances:Consider merging these isins
 consider-merging-isinstance:22:13:22:127:isinstances:Consider merging these isinstance calls to isinstance(var[6], (float, int)):UNDEFINED
 consider-merging-isinstance:23:13:23:158:isinstances:Consider merging these isinstance calls to isinstance(var[10], (list, str)):UNDEFINED
 consider-merging-isinstance:24:13:24:95:isinstances:Consider merging these isinstance calls to isinstance(var[11], (float, int)):UNDEFINED
-too-few-function-args:26:13:26:32:isinstances:Too few positional arguments for function call:HIGH
-too-few-function-args:27:13:27:25:isinstances:Too few positional arguments for function call:HIGH
+no-value-for-parameter:26:13:26:32:isinstances:No value for argument '__class_or_tuple' in function call:HIGH
+no-value-for-parameter:27:13:27:25:isinstances:No value for argument '__class_or_tuple' in function call:HIGH
+no-value-for-parameter:27:13:27:25:isinstances:No value for argument '_obj' in function call:HIGH
 consider-merging-isinstance:30:13:30:75:isinstances:Consider merging these isinstance calls to isinstance(var[12], (float, int, list)):UNDEFINED

--- a/tests/functional/t/too/too_few_function_args.py
+++ b/tests/functional/t/too/too_few_function_args.py
@@ -1,3 +1,0 @@
-# pylint: disable=missing-docstring
-
-isinstance(1) # [too-few-function-args]

--- a/tests/functional/t/too/too_few_function_args.txt
+++ b/tests/functional/t/too/too_few_function_args.txt
@@ -1,1 +1,0 @@
-too-few-function-args:3:0:3:13::Too few positional arguments for function call:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [X] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [X] Write comprehensive commit messages and/or a good description of what the PR does.
- [X] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [X] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

The addition of a new message, `too-few-function-args`, in #9847, overlaps (fully) with an existing message `no-value-for-parameter`. Because the `too-few-function-args` was only implemented for `isinstance`, this PR only seeks to transfer those messages over to the existing message `no-value-for-parameter` with hard-coded argument names for `isinstance` because it's a built-in function.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9881
