### PR TITLE
Fixed typo in W0212

### DIFF
--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -328,7 +328,7 @@ Classes checker Messages
   interface or in an overridden method.
 :protected-access (W0212): *Access to a protected member %s of a client class*
   Used when a protected member (i.e. class member with a name beginning with an
-  underscore) is access outside the class or a descendant of the class where
+  underscore) is accessed outside the class or a descendant of the class where
   it's defined.
 :attribute-defined-outside-init (W0201): *Attribute %r defined outside __init__*
   Used when an instance attribute is defined outside the __init__ method.

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -523,7 +523,7 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "Access to a protected member %s of a client class",  # E0214
         "protected-access",
         "Used when a protected member (i.e. class member with a name "
-        "beginning with an underscore) is access outside the class or a "
+        "beginning with an underscore) is accessed outside the class or a "
         "descendant of the class where it's defined.",
     ),
     "W0213": (


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [X] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [X] Write comprehensive commit messages and/or a good description of what the PR does.
- [X] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [X] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Fixed typo in the description of message W0212: "access" -> "accessed".