### PR TITLE
Bump pylint to 3.2.7, update changelog

### DIFF
--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -14,6 +14,37 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.2.7?
+---------------------------
+Release date: 2024-08-31
+
+
+False Positives Fixed
+---------------------
+
+- Fixed a false positive `unreachable` for `NoReturn` coroutine functions.
+
+  Closes #9840. (`#9840 <https://github.com/pylint-dev/pylint/issues/9840>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fix crash in refactoring checker when calling a lambda bound as a method.
+
+  Closes #9865 (`#9865 <https://github.com/pylint-dev/pylint/issues/9865>`_)
+
+- Fix a crash in ``undefined-loop-variable`` when providing the ``iterable`` argument to ``enumerate()``.
+
+  Closes #9875 (`#9875 <https://github.com/pylint-dev/pylint/issues/9875>`_)
+
+- Fix to address indeterminacy of error message in case a module name is same as another in a separate namespace.
+
+  Refs #9883 (`#9883 <https://github.com/pylint-dev/pylint/issues/9883>`_)
+
+
+
 What's new in Pylint 3.2.6?
 ---------------------------
 Release date: 2024-07-21

--- a/doc/whatsnew/fragments/9840.false_positive
+++ b/doc/whatsnew/fragments/9840.false_positive
@@ -1,3 +1,0 @@
-Fixed a false positive `unreachable` for `NoReturn` coroutine functions.
-
-Closes #9840.

--- a/doc/whatsnew/fragments/9865.bugfix
+++ b/doc/whatsnew/fragments/9865.bugfix
@@ -1,3 +1,0 @@
-Fix crash in refactoring checker when calling a lambda bound as a method.
-
-Closes #9865

--- a/doc/whatsnew/fragments/9875.bugfix
+++ b/doc/whatsnew/fragments/9875.bugfix
@@ -1,3 +1,0 @@
-Fix a crash in ``undefined-loop-variable`` when providing the ``iterable`` argument to ``enumerate()``.
-
-Closes #9875

--- a/doc/whatsnew/fragments/9883.bugfix
+++ b/doc/whatsnew/fragments/9883.bugfix
@@ -1,3 +1,0 @@
-Fix to address indeterminacy of error message in case a module name is same as another in a separate namespace.
-
-Refs #9883

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.2.6"
+__version__ = "3.2.7"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.2.6"
+current = "3.2.7"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.2.6"
+version = "3.2.7"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.2/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.2.7?
---------------------------
Release date: 2024-08-31


False Positives Fixed
---------------------

- Fixed a false positive `unreachable` for `NoReturn` coroutine functions.

  Closes #9840



Other Bug Fixes
---------------

- Fix crash in refactoring checker when calling a lambda bound as a method.

  Closes #9865

- Fix a crash in ``undefined-loop-variable`` when providing the ``iterable`` argument to ``enumerate()``.

  Closes #9875

- Fix to address indeterminacy of error message in case a module name is same as another in a separate namespace.

  Refs #9883
