### PR TITLE
Fix two incorrect/broken tests in `tests/checkers/unittest_imports.py`

### DIFF
--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -5,7 +5,6 @@
 """Unit tests for the imports checker."""
 
 import os
-import sys
 
 import astroid
 from pytest import CaptureFixture

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -5,12 +5,14 @@
 """Unit tests for the imports checker."""
 
 import os
+import sys
 
 import astroid
 from pytest import CaptureFixture
 
 from pylint.checkers import imports
 from pylint.interfaces import UNDEFINED
+from pylint.lint import augmented_sys_path, discover_package_path
 from pylint.testutils import CheckerTestCase, MessageTest
 from pylint.testutils._run import _Run as Run
 
@@ -92,28 +94,33 @@ class TestImportsChecker(CheckerTestCase):
         assert errors == ""
 
     def test_wildcard_import_init(self) -> None:
-        module = astroid.MANAGER.ast_from_module_name("init_wildcard", REGR_DATA)
-        import_from = module.body[0]
+        context_file = os.path.join(REGR_DATA,"dummy_wildcard.py")
 
-        with self.assertNoMessages():
-            self.checker.visit_importfrom(import_from)
+        with augmented_sys_path([discover_package_path(context_file, [])]):
+            module = astroid.MANAGER.ast_from_module_name("init_wildcard", context_file)
+            import_from = module.body[0]
+
+            with self.assertNoMessages():
+                self.checker.visit_importfrom(import_from)
 
     def test_wildcard_import_non_init(self) -> None:
-        module = astroid.MANAGER.ast_from_module_name("wildcard", REGR_DATA)
-        import_from = module.body[0]
+        context_file = os.path.join(REGR_DATA,"dummy_wildcard.py")
 
-        msg = MessageTest(
-            msg_id="wildcard-import",
-            node=import_from,
-            args="empty",
-            confidence=UNDEFINED,
-            line=1,
-            col_offset=0,
-            end_line=1,
-            end_col_offset=19,
-        )
-        with self.assertAddsMessages(msg):
-            self.checker.visit_importfrom(import_from)
+        with augmented_sys_path([discover_package_path(context_file, [])]):
+            module = astroid.MANAGER.ast_from_module_name("wildcard", context_file)
+            import_from = module.body[0]
+            msg = MessageTest(
+                msg_id="wildcard-import",
+                node=import_from,
+                args="empty",
+                confidence=UNDEFINED,
+                line=1,
+                col_offset=0,
+                end_line=1,
+                end_col_offset=19,
+            )
+            with self.assertAddsMessages(msg):
+                self.checker.visit_importfrom(import_from)
 
     @staticmethod
     def test_preferred_module(capsys: CaptureFixture[str]) -> None:

--- a/tests/checkers/unittest_imports.py
+++ b/tests/checkers/unittest_imports.py
@@ -93,7 +93,7 @@ class TestImportsChecker(CheckerTestCase):
         assert errors == ""
 
     def test_wildcard_import_init(self) -> None:
-        context_file = os.path.join(REGR_DATA,"dummy_wildcard.py")
+        context_file = os.path.join(REGR_DATA, "dummy_wildcard.py")
 
         with augmented_sys_path([discover_package_path(context_file, [])]):
             module = astroid.MANAGER.ast_from_module_name("init_wildcard", context_file)
@@ -103,7 +103,7 @@ class TestImportsChecker(CheckerTestCase):
                 self.checker.visit_importfrom(import_from)
 
     def test_wildcard_import_non_init(self) -> None:
-        context_file = os.path.join(REGR_DATA,"dummy_wildcard.py")
+        context_file = os.path.join(REGR_DATA, "dummy_wildcard.py")
 
         with augmented_sys_path([discover_package_path(context_file, [])]):
             module = astroid.MANAGER.ast_from_module_name("wildcard", context_file)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This PR addresses an issue with two tests (`test_wildcard_import_init` and `test_wildcard_import_non_init`) in [tests/checkers/unittest_imports.py](https://github.com/pylint-dev/pylint/blob/main/tests/checkers/unittest_imports.py) that I discovered while attempting to fix #9883.

The issue with the tests is that the tests are invalid and only work due to modified `sys.path` in https://github.com/pylint-dev/pylint/blob/main/tests/pyreverse/conftest.py#L70. This can be reproduced by running the test on only the file:
```
tox -e py312 -- tests/checkers/unittest_imports.py
```
the above command fails and I see the following:
```
FAILED tests/checkers/unittest_imports.py::TestImportsChecker::test_wildcard_import_init - AssertionError: Expected messages did not match actual.
FAILED tests/checkers/unittest_imports.py::TestImportsChecker::test_wildcard_import_non_init - AssertionError: Expected messages did not match actual.
```

The fix is to augment the `sys.path` as part of the test.

<!-- If this PR references an issue without fixing it: -->

Refs #9883

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
