### PR TITLE
[doc] exec-used, add a full example writing in an intermediary file

### DIFF
--- a/doc/data/messages/e/exec-used/bad.py
+++ b/doc/data/messages/e/exec-used/bad.py
@@ -1,4 +1,5 @@
-username = "Ada"
-code_to_execute = f"""input('Enter code to be executed please, {username}: ')"""
-program = exec(code_to_execute)  # [exec-used]
-exec(program)  # [exec-used]
+def get_user_code(name):
+    return input(f"Enter code to be executed please, {name}: ")
+
+
+exec(get_user_code("Ada"))  # [exec-used]

--- a/doc/data/messages/e/exec-used/bad.py
+++ b/doc/data/messages/e/exec-used/bad.py
@@ -1,5 +1,4 @@
-def get_user_code(name):
-    return input(f"Enter code to be executed please, {name}: ")
-
-
-exec(get_user_code("Ada"))  # [exec-used]
+username = "Ada"
+code_to_execute = f"""input('Enter code to be executed please, {username}: ')"""
+program = exec(code_to_execute)  # [exec-used]
+exec(program)  # [exec-used]

--- a/doc/data/messages/e/exec-used/details.rst
+++ b/doc/data/messages/e/exec-used/details.rst
@@ -2,9 +2,53 @@ The available methods and variables used in ``exec()`` may introduce a security 
 You can restrict the use of these variables and methods by passing optional globals
 and locals parameters (dictionaries) to the ``exec()`` method.
 
-However, use of ``exec`` is still insecure. For example, consider the following call
-that writes a file to the user's system:
+However, use of ``exec()`` is still insecure if you allow some functions like
+``__import__`` or ``open``. For example, consider the following call that writes a
+file to the user's system and then execute code unrestrained by the ``allowed_globals``,
+or ``allowed_locals`` parameters:
 
 .. code-block:: python
 
-    exec("""\nwith open("file.txt", "w", encoding="utf-8") as file:\n file.write("# code as nefarious as imaginable")\n""")
+    import textwrap
+
+
+    def forbid_print(*args):
+        raise ValueError("This is raised when a print is used")
+
+
+    allowed_globals = {
+        "__builtins__": {
+            "__import__": __builtins__.__import__,
+            "open": __builtins__.open,
+            "print": forbid_print,
+        }
+    }
+
+    exec(
+        textwrap.dedent(
+            """
+        import textwrap
+
+        with open("nefarious.py", "w") as f:
+            f.write(textwrap.dedent('''
+                def connive():
+                    print("Here's some code as nefarious as imaginable")
+            '''))
+
+        import nefarious
+
+        nefarious.connive()  # This will NOT raise a ValueError
+        """
+        ),
+        allowed_globals,
+    )
+
+
+The import is used only for readability of the example in this case but it could
+import a dangerous functions:
+
+- ``subprocess.run('echo "print(\"Hello, World!\")" > nefarious.py'``
+- ``pathlib.Path("nefarious.py").write_file("print(\"Hello, World!\")")``
+- ``os.system('echo "print(\"Hello, World!\")" > nefarious.py')``
+- ``logging.basicConfig(filename='nefarious.py'); logging.error('print("Hello, World!")')``
+- etc.

--- a/doc/data/messages/e/exec-used/good.py
+++ b/doc/data/messages/e/exec-used/good.py
@@ -3,7 +3,7 @@ def get_user_code(name):
 
 
 # If the globals dictionary does not contain a value for the key __builtins__,
-# all builtins are allowed. Uou need to be explicit about it being disallowed.
+# all builtins are allowed. You need to be explicit about it being disallowed.
 allowed_globals = {"__builtins__": {}}
 allowed_locals = {}
 # pylint: disable-next=exec-used

--- a/doc/data/messages/e/exec-used/good.py
+++ b/doc/data/messages/e/exec-used/good.py
@@ -2,8 +2,9 @@ def get_user_code(name):
     return input(f"Enter code to be executed please, {name}: ")
 
 
-username = "Ada"
-allowed_globals = {"__builtins__": None}
-allowed_locals = {"print": print}
+# If the globals dictionary does not contain a value for the key __builtins__,
+# all builtins are allowed. Uou need to be explicit about it being disallowed.
+allowed_globals = {"__builtins__": {}}
+allowed_locals = {}
 # pylint: disable-next=exec-used
-exec(get_user_code(username), allowed_globals, allowed_locals)
+exec(get_user_code("Ada"), allowed_globals, allowed_locals)

--- a/doc/data/messages/e/exec-used/good.py
+++ b/doc/data/messages/e/exec-used/good.py
@@ -2,9 +2,10 @@ def get_user_code(name):
     return input(f"Enter code to be executed please, {name}: ")
 
 
+username = "Ada"
 # If the globals dictionary does not contain a value for the key __builtins__,
 # all builtins are allowed. You need to be explicit about it being disallowed.
 allowed_globals = {"__builtins__": {}}
 allowed_locals = {}
 # pylint: disable-next=exec-used
-exec(get_user_code("Ada"), allowed_globals, allowed_locals)
+exec(get_user_code(username), allowed_globals, allowed_locals)

--- a/doc/data/messages/e/exec-used/related.rst
+++ b/doc/data/messages/e/exec-used/related.rst
@@ -1,1 +1,2 @@
 - `Be careful with exec and eval in Python <https://lucumr.pocoo.org/2011/2/1/exec-in-python/>`_
+- `Python documentation <https://docs.python.org/3/library/functions.html#exec>`_


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

I wanted to make the example's formatting better in details, ended up trying to reproduce it, but it seems the ``allow_globals`` parameters is smarter than we thought when originally documenting it. I get this error when uncommenting `` # allowed_globals``:
```
Traceback (most recent call last):
  File "/home/pierre/pylint/a.py", line 4, in <module>
    exec(
  File "<string>", line 2, in <module>
SystemError: ../Objects/dictobject.c:1490: bad argument to internal function
```

```python
import textwrap
allowed_globals = {"__builtins__": None}
exec(
    textwrap.dedent("""
    import textwrap

    with open("nefarious.py", "w") as f:
        f.write(textwrap.dedent('''
            def connive():
                print("Here's some code as nefarious as imaginable")
        '''))

    import nefarious
    nefarious.connive()
    """),
    allowed_globals,
)
```

What am I doing wrong @DanielNoord ?