### PR TITLE
Fix max-positional-arguments comments in example config files

### DIFF
--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -307,6 +307,9 @@ max-locals=15
 # Maximum number of parents for a class (see R0901).
 max-parents=7
 
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
@@ -319,8 +322,6 @@ max-statements=50
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2
 
-# Minimum number of public methods for a class (see R0903).
-max-positional-arguments=5
 
 [EXCEPTIONS]
 

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -269,6 +269,9 @@ max-locals = 15
 # Maximum number of parents for a class (see R0901).
 max-parents = 7
 
+# Maximum number of positional arguments for function / method.
+max-positional-arguments = 5
+
 # Maximum number of public methods for a class (see R0904).
 max-public-methods = 20
 
@@ -280,9 +283,6 @@ max-statements = 50
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods = 2
-
-# Maximum number of positional arguments (see R0917).
-max-positional-arguments = 5
 
 [tool.pylint.exceptions]
 # Exceptions that will emit a warning when caught.


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description
The comment for `min-public-methods` got accidentally reused.