### PR TITLE
Fix false negative for `multiple-statements` on try... else/finally lines

### DIFF
--- a/doc/whatsnew/fragments/9759.false_negative
+++ b/doc/whatsnew/fragments/9759.false_negative
@@ -1,0 +1,3 @@
+Fix false negative for `multiple-statements` when multiple statements are present on `else` and `finally` lines of `try`.
+
+Refs #9759

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -496,6 +496,10 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
         prev_sibl = node.previous_sibling()
         if prev_sibl is not None:
             prev_line = prev_sibl.fromlineno
+        elif isinstance(
+            node.parent, nodes.Try
+        ) and self._is_first_node_in_else_finally_body(node, node.parent):
+            prev_line = self._infer_else_finally_line_number(node, node.parent)
         elif isinstance(node.parent, nodes.Module):
             prev_line = 0
         else:
@@ -519,6 +523,28 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                 lines.append(self._lines[line].rstrip())
             except KeyError:
                 lines.append("")
+
+    def _is_first_node_in_else_finally_body(
+        self, node: nodes.NodeNG, parent: nodes.Try
+    ) -> bool:
+        if parent.orelse and node == parent.orelse[0]:
+            return True
+        if parent.finalbody and node == parent.finalbody[0]:
+            return True
+        return False
+
+    def _infer_else_finally_line_number(
+        self, node: nodes.NodeNG, parent: nodes.Try
+    ) -> int:
+        last_line_of_prev_block = 0
+        if node in parent.finalbody and parent.orelse:
+            last_line_of_prev_block = parent.orelse[-1].tolineno
+        elif parent.handlers and parent.handlers[-1].body:
+            last_line_of_prev_block = parent.handlers[-1].body[-1].tolineno
+        elif parent.body:
+            last_line_of_prev_block = parent.body[-1].tolineno
+
+        return last_line_of_prev_block + 1 if last_line_of_prev_block else 0
 
     def _check_multi_statement_line(self, node: nodes.NodeNG, line: int) -> None:
         """Check for lines containing multiple statements."""

--- a/tests/functional/m/multiple_statements.py
+++ b/tests/functional/m/multiple_statements.py
@@ -43,3 +43,23 @@ finally:
 def concat2(arg1: str) -> str: ...
 
 def concat2(arg1: str) -> str: ...
+
+# Test for multiple statements on finally line
+try:
+    pass
+finally: pass  # [multiple-statements]
+
+# Test for multiple statements on else line
+try:
+    pass
+except:
+    pass
+else: pass  # [multiple-statements]
+
+# Test for multiple statements on else and finally lines
+try:
+    pass
+except:
+    pass
+else: pass  # [multiple-statements]
+finally: pass  # [multiple-statements]

--- a/tests/functional/m/multiple_statements.txt
+++ b/tests/functional/m/multiple_statements.txt
@@ -8,3 +8,7 @@ multiple-statements:26:30:26:59:MyException:More than one statement on a single 
 multiple-statements:27:26:27:30:MyError:More than one statement on a single line:HIGH
 multiple-statements:30:26:30:31:MyError:More than one statement on a single line:HIGH
 multiple-statements:32:26:32:31:MyError:More than one statement on a single line:HIGH
+multiple-statements:50:9:50:13::More than one statement on a single line:HIGH
+multiple-statements:57:6:57:10::More than one statement on a single line:HIGH
+multiple-statements:64:6:64:10::More than one statement on a single line:HIGH
+multiple-statements:65:9:65:13::More than one statement on a single line:HIGH


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

I took a look at 5bdc2218ef9891e9047823c26625c62d68f2dc52 and noticed that some inference logic got removed in `format.py` while refactoring to use the updated `Try` node. The purpose of this PR is to reintroduce the inference of `else` and `finally` line numbers to check for multiple statements on `else/finally` lines in a try statement.

This check is a little explicit because of how `else` and `finally` is represented in the AST, without a tree node to represent an `else` or `finally` line. However, it should work for general cases, except for unusual cases like:
```
try:
    pass
except:
    pass
#  this comment will prevent multiple-statements from flagging in the next line
finally: pass
```

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9759 
