### PR TITLE
Don't use .get() with defaultdicts

### DIFF
--- a/pylint/utils/ast_walker.py
+++ b/pylint/utils/ast_walker.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import sys
 import traceback
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from astroid import nodes
@@ -75,8 +75,8 @@ class ASTWalker:
         """
         cid = astroid.__class__.__name__.lower()
 
-        visit_events: Sequence[AstCallback] = self.visit_events.get(cid, ())
-        leave_events: Sequence[AstCallback] = self.leave_events.get(cid, ())
+        visit_events = self.visit_events[cid]
+        leave_events = self.leave_events[cid]
 
         # pylint: disable = too-many-try-statements
         try:


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

`ASTWalker.walk` was calling `get` ~1.42 million times when linting yt-dlp.  This is a small speed-up that also helps unclutter profiler output.

## timeit data

```
$ python -m timeit -s 'from collections import defaultdict; visit_events = defaultdict(list)' -n 1000000 'x=visit_events.get("x", ())'
1000000 loops, best of 5: 50.7 nsec per loop

$ python -m timeit -s 'from collections import defaultdict; visit_events = defaultdict(list)' -n 1000000 'x=visit_events["x"]'
1000000 loops, best of 5: 29.4 nsec per loop
```

## Stats

### Before

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  2123486    0.529    0.000    0.529    0.000 {method 'get' of 'dict' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 33.597 ± 0.157 | 33.444 | 33.839 | 1.00 |


### After

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   697806    0.204    0.000    0.204    0.000 {method 'get' of 'dict' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 33.536 ± 0.134 | 33.308 | 33.731 | 1.00 |
