### PR TITLE
Move most ruff exclusions out of .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,17 +21,10 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
-        exclude: &fixtures tests(/\w*)*/functional/|tests/input|doc/data/messages|tests(/\w*)*data/
+        exclude: doc/data/messages
       - id: ruff
         name: ruff-doc
         files: doc/data/messages
-        exclude: |
-          (?x)^(
-            doc/data/messages/d/duplicate-argument-name/bad.py|
-            doc/data/messages/s/syntax-error/bad.py
-          )$
-
-        args: ["--config", "doc/data/ruff.toml"]
   - repo: https://github.com/Pierre-Sassoulas/copyright_notice_precommit
     rev: 0.1.2
     hooks:
@@ -49,7 +42,7 @@ repos:
     hooks:
       - id: black
         args: [--safe, --quiet]
-        exclude: *fixtures
+        exclude: &fixtures tests(/\w*)*/functional/|tests/input|doc/data/messages|tests(/\w*)*data/
       - id: black
         name: black-doc
         args: [--safe, --quiet]

--- a/doc/data/ruff.toml
+++ b/doc/data/ruff.toml
@@ -2,14 +2,19 @@
 # (Because of horizontal scrolling)
 line-length = 103
 
+extend-exclude = [
+    "messages/d/duplicate-argument-name/bad.py",
+    "messages/s/syntax-error/bad.py",
+]
+
 [lint]
 ignore = []
 select = ["E501", "I"]
 
 
 [lint.per-file-ignores]
-"doc/data/messages/r/reimported/bad.py" = ["I"]
-"doc/data/messages/w/wrong-import-order/bad.py" = ["I"]
-"doc/data/messages/u/ungrouped-imports/bad.py" = ["I"]
-"doc/data/messages/m/misplaced-future/bad.py" = ["I"]
-"doc/data/messages/m/multiple-imports/bad.py" = ["I"]
+"messages/m/misplaced-future/bad.py" = ["I"]
+"messages/m/multiple-imports/bad.py" = ["I"]
+"messages/r/reimported/bad.py" = ["I"]
+"messages/u/ungrouped-imports/bad.py" = ["I"]
+"messages/w/wrong-import-order/bad.py" = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,13 @@ module = [
 # (for docstrings, strings and comments in particular).
 line-length = 115
 
+extend-exclude = [
+    "tests/**/data/",
+    "tests/**/functional/",
+    "tests/input/",
+    "tests/regrtest_data/",
+]
+
 [tool.ruff.lint]
 select = [
     "B",  # bugbear


### PR DESCRIPTION
## Type of Changes
|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

This makes it easier to run `ruff check` outside of the pre-commit hooks.