### PR TITLE
Explicitly save cache in primer jobs

### DIFF
--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -43,9 +43,9 @@ jobs:
           check-latest: true
 
       # Create a re-usable virtual environment
-      - name: Create Python virtual environment cache
+      - name: Restore Python virtual environment cache
         id: cache-venv
-        uses: actions/cache@v4.0.2
+        uses: actions/cache/restore@v4.0.2
         with:
           path: venv
           key:
@@ -60,6 +60,18 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test.txt
+      # Save cached Python environment (explicit because cancel-in-progress: true)
+      - name: Save Python virtual environment to cache
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        id: cache-venv
+        uses: actions/cache/save@v4.0.2
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
+            'requirements_test.txt', 'requirements_test_min.txt',
+            'requirements_test_pre_commit.txt') }}
 
       # Cache primer packages
       - name: Get commit string
@@ -71,7 +83,7 @@ jobs:
           echo "commitstring=$output" >> $GITHUB_OUTPUT
       - name: Restore projects cache
         id: cache-projects
-        uses: actions/cache@v4.0.2
+        uses: actions/cache/restore@v4.0.2
         with:
           path: tests/.pylint_primer_tests/
           key: >-
@@ -82,6 +94,15 @@ jobs:
         run: |
           . venv/bin/activate
           python tests/primer/__main__.py prepare --clone
+      - name: Save projects cache
+        if: steps.cache-projects.outputs.cache-hit != 'true'
+        id: cache-projects
+        uses: actions/cache/save@v4.0.2
+        with:
+          path: tests/.pylint_primer_tests/
+          key: >-
+            ${{ runner.os }}-${{ matrix.python-version }}-${{
+            steps.commitstring.outputs.commitstring }}-primer
       - name: Upload commit string
         uses: actions/upload-artifact@v4.4.0
         if: matrix.batchIdx == 0

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -56,7 +56,7 @@ jobs:
       # Restore cached Python environment
       - name: Restore Python virtual environment
         id: cache-venv
-        uses: actions/cache@v4.0.2
+        uses: actions/cache/restore@v4.0.2
         with:
           path: venv
           key:
@@ -72,6 +72,18 @@ jobs:
           . venv/bin/activate
           python -m pip install -U pip setuptools wheel
           pip install -U -r requirements_test.txt
+      # Save cached Python environment (explicit because cancel-in-progress: true)
+      - name: Save Python virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        id: cache-venv
+        uses: actions/cache/save@v4.0.2
+        with:
+          path: venv
+          key:
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
+            'requirements_test.txt', 'requirements_test_min.txt',
+            'requirements_test_pre_commit.txt') }}
 
       # Cache primer packages
       - name: Download last 'main' run info
@@ -140,7 +152,7 @@ jobs:
           echo "commitstring=$output" >> $GITHUB_OUTPUT
       - name: Restore projects cache
         id: cache-projects
-        uses: actions/cache@v4.0.2
+        uses: actions/cache/restore@v4.0.2
         with:
           path: tests/.pylint_primer_tests/
           key: >-
@@ -151,6 +163,14 @@ jobs:
         run: |
           . venv/bin/activate
           python tests/primer/__main__.py prepare --clone
+      - name: Save projects cache
+        if: steps.cache-projects.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4.0.2
+        with:
+          path: tests/.pylint_primer_tests/
+          key: >-
+            ${{ runner.os }}-${{ matrix.python-version }}-${{
+            steps.commitstring.outputs.commitstring }}-primer
       - name: Check cache
         run: |
           . venv/bin/activate


### PR DESCRIPTION
On the theory that we might see primer indeterminacy due to incompletely created virtual environments being cached when jobs are interrupted (due to `cancel-in-progress: true`), exercise some control by running separate `actions/restore` and `actions/save` actions.

Refs https://github.com/pylint-dev/pylint/pull/9925#issuecomment-2358249852

cc/ @akamat10