### PR TITLE
Add check for `unnecessary-default-type-args`

### DIFF
--- a/doc/data/messages/u/unnecessary-default-type-args/bad.py
+++ b/doc/data/messages/u/unnecessary-default-type-args/bad.py
@@ -1,0 +1,4 @@
+from collections.abc import AsyncGenerator, Generator
+
+a1: AsyncGenerator[int, None]  # [unnecessary-default-type-args]
+b1: Generator[int, None, None]  # [unnecessary-default-type-args]

--- a/doc/data/messages/u/unnecessary-default-type-args/details.rst
+++ b/doc/data/messages/u/unnecessary-default-type-args/details.rst
@@ -2,5 +2,5 @@ At the moment, this check only works for ``Generator`` and ``AsyncGenerator``.
 
 Starting with Python 3.13, the ``SendType`` and ``ReturnType`` default to ``None``.
 As such it's no longer necessary to specify them. The ``collections.abc`` variants
-don't validated the number of type arguments. Therefore the defaults for these
+don't validate the number of type arguments. Therefore the defaults for these
 can be used in earlier versions as well.

--- a/doc/data/messages/u/unnecessary-default-type-args/details.rst
+++ b/doc/data/messages/u/unnecessary-default-type-args/details.rst
@@ -1,0 +1,6 @@
+At the moment, this check only works for ``Generator`` and ``AsyncGenerator``.
+
+Starting with Python 3.13, the ``SendType`` and ``ReturnType`` default to ``None``.
+As such it's no longer necessary to specify them. The ``collections.abc`` variants
+don't validated the number of type arguments. Therefore the defaults for these
+can be used in earlier versions as well.

--- a/doc/data/messages/u/unnecessary-default-type-args/good.py
+++ b/doc/data/messages/u/unnecessary-default-type-args/good.py
@@ -1,0 +1,4 @@
+from collections.abc import AsyncGenerator, Generator
+
+a1: AsyncGenerator[int]
+b1: Generator[int]

--- a/doc/data/messages/u/unnecessary-default-type-args/pylintrc
+++ b/doc/data/messages/u/unnecessary-default-type-args/pylintrc
@@ -1,0 +1,2 @@
+[main]
+load-plugins=pylint.extensions.typing

--- a/doc/data/messages/u/unnecessary-default-type-args/related.rst
+++ b/doc/data/messages/u/unnecessary-default-type-args/related.rst
@@ -1,0 +1,2 @@
+- `Python documentation for AsyncGenerator <https://docs.python.org/3.13/library/typing.html#typing.AsyncGenerator>`_
+- `Python documentation for Generator <https://docs.python.org/3.13/library/typing.html#typing.Generator>`_

--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -688,6 +688,9 @@ Typing checker Messages
 :consider-alternative-union-syntax (R6003): *Consider using alternative Union syntax instead of '%s'%s*
   Emitted when 'typing.Union' or 'typing.Optional' is used instead of the
   alternative Union syntax 'int | None'.
+:unnecessary-default-type-args (R6007): *Type `%s` has unnecessary default type args. Change it to `%s`.*
+  Emitted when types have default type args which can be omitted. Mainly used
+  for `typing.Generator` and `typing.AsyncGenerator`.
 :redundant-typehint-argument (R6006): *Type `%s` is used more than once in union type annotation. Remove redundant typehints.*
   Duplicated type arguments will be skipped by `mypy` tool, therefore should be
   removed to avoid confusion.

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -545,6 +545,7 @@ All messages in the refactor category:
    refactor/too-many-statements
    refactor/trailing-comma-tuple
    refactor/unnecessary-comprehension
+   refactor/unnecessary-default-type-args
    refactor/unnecessary-dict-index-lookup
    refactor/unnecessary-list-index-lookup
    refactor/use-a-generator

--- a/doc/whatsnew/fragments/9938.new_check
+++ b/doc/whatsnew/fragments/9938.new_check
@@ -1,0 +1,4 @@
+Add ``unnecessary-default-type-args`` to the ``typing`` extension to detect the use
+of unnecessary default type args for ``typing.Generator`` and ``typing.AsyncGenerator``.
+
+Refs #9938

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -35,7 +35,7 @@ def _builtin_exceptions() -> set[str]:
 
 def _annotated_unpack_infer(
     stmt: nodes.NodeNG, context: InferenceContext | None = None
-) -> Generator[tuple[nodes.NodeNG, SuccessfulInferenceResult], None, None]:
+) -> Generator[tuple[nodes.NodeNG, SuccessfulInferenceResult]]:
     """Recursively generate nodes inferred by the given statement.
 
     If the inferred value is a list or a tuple, recurse on the elements.

--- a/pylint/checkers/symilar.py
+++ b/pylint/checkers/symilar.py
@@ -468,7 +468,7 @@ class Symilar:
     # pylint: disable = too-many-locals
     def _find_common(
         self, lineset1: LineSet, lineset2: LineSet
-    ) -> Generator[Commonality, None, None]:
+    ) -> Generator[Commonality]:
         """Find similarities in the two given linesets.
 
         This the core of the algorithm. The idea is to compute the hashes of a
@@ -541,7 +541,7 @@ class Symilar:
             if eff_cmn_nb > self.namespace.min_similarity_lines:
                 yield com
 
-    def _iter_sims(self) -> Generator[Commonality, None, None]:
+    def _iter_sims(self) -> Generator[Commonality]:
         """Iterate on similarities among all files, by making a Cartesian
         product.
         """

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -249,9 +249,7 @@ def _detect_global_scope(
     return frame.lineno < defframe.lineno  # type: ignore[no-any-return]
 
 
-def _infer_name_module(
-    node: nodes.Import, name: str
-) -> Generator[InferenceResult, None, None]:
+def _infer_name_module(node: nodes.Import, name: str) -> Generator[InferenceResult]:
     context = astroid.context.InferenceContext()
     context.lookupname = name
     return node.infer(context, asname=False)  # type: ignore[no-any-return]

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -84,7 +84,7 @@ class DiaDefGenerator:
 
     def get_ancestors(
         self, node: nodes.ClassDef, level: int
-    ) -> Generator[nodes.ClassDef, None, None]:
+    ) -> Generator[nodes.ClassDef]:
         """Return ancestor nodes of a class node."""
         if level == 0:
             return
@@ -95,7 +95,7 @@ class DiaDefGenerator:
 
     def get_associated(
         self, klass_node: nodes.ClassDef, level: int
-    ) -> Generator[nodes.ClassDef, None, None]:
+    ) -> Generator[nodes.ClassDef]:
         """Return associated nodes of a class node."""
         if level == 0:
             return

--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -40,7 +40,7 @@ class CheckerTestCase:
     @contextlib.contextmanager
     def assertAddsMessages(
         self, *messages: MessageTest, ignore_position: bool = False
-    ) -> Generator[None, None, None]:
+    ) -> Generator[None]:
         """Assert that exactly the given method adds the given messages.
 
         The list of messages must exactly match *all* the messages added by the

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -27,7 +27,7 @@ def _patch_streams(out: TextIO) -> Iterator[None]:
 @contextlib.contextmanager
 def _test_sys_path(
     replacement_sys_path: list[str] | None = None,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     original_path = sys.path
     try:
         if replacement_sys_path is not None:
@@ -40,7 +40,7 @@ def _test_sys_path(
 @contextlib.contextmanager
 def _test_cwd(
     current_working_directory: str | Path | None = None,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     original_dir = os.getcwd()
     try:
         if current_working_directory is not None:
@@ -53,7 +53,7 @@ def _test_cwd(
 @contextlib.contextmanager
 def _test_environ_pythonpath(
     new_pythonpath: str | None = None,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     original_pythonpath = os.environ.get("PYTHONPATH")
     if new_pythonpath:
         os.environ["PYTHONPATH"] = new_pythonpath

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -86,7 +86,7 @@ class InvalidPragmaError(PragmaParserError):
     """Thrown in case the pragma is invalid."""
 
 
-def parse_pragma(pylint_pragma: str) -> Generator[PragmaRepresenter, None, None]:
+def parse_pragma(pylint_pragma: str) -> Generator[PragmaRepresenter]:
     action: str | None = None
     messages: list[str] = []
     assignment_required = False

--- a/tests/functional/ext/typing/unnecessary_default_type_args.py
+++ b/tests/functional/ext/typing/unnecessary_default_type_args.py
@@ -1,0 +1,17 @@
+# pylint: disable=missing-docstring,deprecated-typing-alias
+import collections.abc as ca
+import typing as t
+
+a1: t.Generator[int, str, str]
+a2: t.Generator[int, None, None]
+a3: t.Generator[int]
+b1: t.AsyncGenerator[int, str]
+b2: t.AsyncGenerator[int, None]
+b3: t.AsyncGenerator[int]
+
+c1: ca.Generator[int, str, str]
+c2: ca.Generator[int, None, None]  # [unnecessary-default-type-args]
+c3: ca.Generator[int]
+d1: ca.AsyncGenerator[int, str]
+d2: ca.AsyncGenerator[int, None]  # [unnecessary-default-type-args]
+d3: ca.AsyncGenerator[int]

--- a/tests/functional/ext/typing/unnecessary_default_type_args.rc
+++ b/tests/functional/ext/typing/unnecessary_default_type_args.rc
@@ -1,0 +1,3 @@
+[main]
+py-version=3.10
+load-plugins=pylint.extensions.typing

--- a/tests/functional/ext/typing/unnecessary_default_type_args.txt
+++ b/tests/functional/ext/typing/unnecessary_default_type_args.txt
@@ -1,0 +1,2 @@
+unnecessary-default-type-args:13:4:13:33::Type `ca.Generator[int, None, None]` has unnecessary default type args. Change it to `ca.Generator[int]`.:HIGH
+unnecessary-default-type-args:16:4:16:32::Type `ca.AsyncGenerator[int, None]` has unnecessary default type args. Change it to `ca.AsyncGenerator[int]`.:HIGH

--- a/tests/functional/ext/typing/unnecessary_default_type_args_py313.py
+++ b/tests/functional/ext/typing/unnecessary_default_type_args_py313.py
@@ -1,0 +1,17 @@
+# pylint: disable=missing-docstring,deprecated-typing-alias
+import collections.abc as ca
+import typing as t
+
+a1: t.Generator[int, str, str]
+a2: t.Generator[int, None, None]  # [unnecessary-default-type-args]
+a3: t.Generator[int]
+b1: t.AsyncGenerator[int, str]
+b2: t.AsyncGenerator[int, None]  # [unnecessary-default-type-args]
+b3: t.AsyncGenerator[int]
+
+c1: ca.Generator[int, str, str]
+c2: ca.Generator[int, None, None]  # [unnecessary-default-type-args]
+c3: ca.Generator[int]
+d1: ca.AsyncGenerator[int, str]
+d2: ca.AsyncGenerator[int, None]  # [unnecessary-default-type-args]
+d3: ca.AsyncGenerator[int]

--- a/tests/functional/ext/typing/unnecessary_default_type_args_py313.rc
+++ b/tests/functional/ext/typing/unnecessary_default_type_args_py313.rc
@@ -1,0 +1,3 @@
+[main]
+py-version=3.13
+load-plugins=pylint.extensions.typing

--- a/tests/functional/ext/typing/unnecessary_default_type_args_py313.txt
+++ b/tests/functional/ext/typing/unnecessary_default_type_args_py313.txt
@@ -1,0 +1,4 @@
+unnecessary-default-type-args:6:4:6:32::Type `t.Generator[int, None, None]` has unnecessary default type args. Change it to `t.Generator[int]`.:HIGH
+unnecessary-default-type-args:9:4:9:31::Type `t.AsyncGenerator[int, None]` has unnecessary default type args. Change it to `t.AsyncGenerator[int]`.:HIGH
+unnecessary-default-type-args:13:4:13:33::Type `ca.Generator[int, None, None]` has unnecessary default type args. Change it to `ca.Generator[int]`.:HIGH
+unnecessary-default-type-args:16:4:16:32::Type `ca.AsyncGenerator[int, None]` has unnecessary default type args. Change it to `ca.AsyncGenerator[int]`.:HIGH

--- a/tests/pyreverse/test_inspector.py
+++ b/tests/pyreverse/test_inspector.py
@@ -26,7 +26,7 @@ TESTS = HERE.parent.parent
 
 
 @pytest.fixture
-def project(get_project: GetProjectCallable) -> Generator[Project, None, None]:
+def project(get_project: GetProjectCallable) -> Generator[Project]:
     with _test_cwd(TESTS):
         project = get_project("data", "data")
         linker = inspector.Linker(project)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Starting with Python 3.13, `typing.Generator` and `typing.AsyncGenerator` have default type argument. E.g. it's no longer necessary to specify `None, None` for the send and return type.

```py
# before
a1: Generator[int, None, None]

# after
a1: Generator[int]
```

This check is similar to the one in ruff but extends on it to also cover the collections.abc` variants which can also be used with older Python versions.

https://docs.astral.sh/ruff/rules/unnecessary-default-type-args/
https://github.com/asottile/pyupgrade?tab=readme-ov-file#pep-696-typevar-defaults