### PR TITLE
Release branch 3.3.0

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -158,6 +158,7 @@ contributors:
   * Added new useless-return checker,
   * Added new try-except-raise checker
 - theirix <theirix@gmail.com>
+- correctmost <134317971+correctmost@users.noreply.github.com>
 - Téo Bouvard <teobouvard@gmail.com>
 - Stavros Ntentos <133706+stdedos@users.noreply.github.com>
 - Nicolas Boulenguez <nicolas@debian.org>
@@ -210,6 +211,7 @@ contributors:
 - wtracy <afishionado@gmail.com>
 - jessebrennan <jesse@jesse.computer>
 - chohner <mail@chohner.com>
+- aatle <168398276+aatle@users.noreply.github.com>
 - Tiago Honorato <61059243+tiagohonorato@users.noreply.github.com>
 - Steven M. Vascellaro <svascellaro@gmail.com>
 - Robin Tweedie <70587124+robin-wayve@users.noreply.github.com>
@@ -264,6 +266,7 @@ contributors:
 - Samuel FORESTIER <HorlogeSkynet@users.noreply.github.com>
 - Rémi Cardona <remi.cardona@polyconseil.fr>
 - Ryan Ozawa <ryan.ozawa21@gmail.com>
+- Roger Sheu <78449574+rogersheu@users.noreply.github.com>
 - Raphael Gaschignard <raphael@makeleaps.com>
 - Ram Rachum <ram@rachum.com> (cool-RR)
 - Radostin Stoyanov <rst0git@users.noreply.github.com>
@@ -287,9 +290,11 @@ contributors:
 - Justin Li <justinnhli@gmail.com>
 - John Kirkham <jakirkham@gmail.com>
 - Jens H. Nielsen <Jens.Nielsen@microsoft.com>
+- Jake Lishman <jake.lishman@ibm.com>
 - Ioana Tagirta <ioana.tagirta@gmail.com>: fix bad thread instantiation check
 - Ikraduya Edian <ikraduya@gmail.com>: Added new checks 'consider-using-generator' and 'use-a-generator'.
 - Hugues Bruant <hugues.bruant@affirm.com>
+- Hashem Nasarat <Hnasar@users.noreply.github.com>
 - Harut <yes@harutune.name>
 - Grygorii Iermolenko <gyermolenko@gmail.com>
 - Grizzly Nyo <grizzly.nyo@gmail.com>
@@ -317,9 +322,11 @@ contributors:
 - Ben Green <benhgreen@icloud.com>
 - Batuhan Taskaya <batuhanosmantaskaya@gmail.com>
 - Alexander Kapshuna <kapsh@kap.sh>
+- Akhil Kamat <akhil.kamat@gmail.com>
 - Adam Parkin <pzelnip@users.noreply.github.com>
 - 谭九鼎 <109224573@qq.com>
 - Łukasz Sznuk <ls@rdprojekt.pl>
+- zasca <gorstav@gmail.com>
 - y2kbugger <y2kbugger@users.noreply.github.com>
 - vinnyrose <vinnyrose@users.noreply.github.com>
 - ttenhoeve-aa <ttenhoeve@appannie.com>
@@ -382,10 +389,12 @@ contributors:
 - Trevor Bekolay <tbekolay@gmail.com>
   * Added --list-msgs-enabled command
 - Tomer Chachamu <tomer.chachamu@gmail.com>: simplifiable-if-expression
+- Tomasz Michalski <tomasz.michalski@rtbhouse.com>
 - Tomasz Magulski <tomasz@magullab.io>
 - Tom <tsarantis@proton.me>
 - Tim Hatch <tim@timhatch.com>
 - Tim Gates <tim.gates@iress.com>
+- Tianyu Chen <124018391+UTsweetyfish@users.noreply.github.com>
 - Théo Battrel <theo.util@protonmail.ch>
 - Thomas Benhamou <thomas@lightricks.com>
 - Theodore Ni <3806110+tjni@users.noreply.github.com>
@@ -412,6 +421,7 @@ contributors:
 - Ryan McGuire <ryan@enigmacurry.com>
 - Ry4an Brase <ry4an-hg@ry4an.org>
 - Ruro <ruro.ruro@ya.ru>
+- Roshan Shetty <roshan.shetty2816@gmail.com>
 - Roman Ivanov <me@roivanov.com>
 - Robert Schweizer <robert_schweizer@gmx.de>
 - Reverb Chu <reverbc@users.noreply.github.com>
@@ -438,6 +448,7 @@ contributors:
 - Oisín Moran <OisinMoran@users.noreply.github.com>
 - Obscuron <Abscuron@gmail.com>
 - Noam Yorav-Raphael <noamraph@gmail.com>
+- Noah-Agnel <138210920+Noah-Agnel@users.noreply.github.com>
 - Nir Soffer <nirsof@gmail.com>
 - Niko Wenselowski <niko@nerdno.de>
 - Nikita Sobolev <mail@sobolevn.me>
@@ -515,7 +526,6 @@ contributors:
 - James Broadhead <jamesbroadhead@gmail.com>
 - Jakub Kulík <Kulikjak@gmail.com>
 - Jakob Normark <jakobnormark@gmail.com>
-- Jake Lishman <jake@binhbar.com>
 - Jacques Kvam <jwkvam@gmail.com>
 - Jace Browning <jacebrowning@gmail.com>: updated default report format with clickable paths
 - JT Olds <jtolds@xnet5.com>
@@ -523,7 +533,6 @@ contributors:
 - Hayden Richards <62866982+SupImDos@users.noreply.github.com>
   * Fixed "no-self-use" for async methods
   * Fixed "docparams" extension for async functions and methods
-- Hashem Nasarat <Hnasar@users.noreply.github.com>
 - Harshil <37377066+harshil21@users.noreply.github.com>
 - Harry <harrymcwinters@gmail.com>
 - Grégoire <96051754+gregoire-mullvad@users.noreply.github.com>
@@ -537,6 +546,7 @@ contributors:
 - Eric Froemling <ericfroemling@gmail.com>
 - Emmanuel Chaudron <manu.chaud@hotmail.fr>
 - Elizabeth Bott <52465744+elizabethbott@users.noreply.github.com>
+- Ekin Dursun <ekindursun@gmail.com>
 - Eisuke Kawashima <e-kwsm@users.noreply.github.com>
 - Edward K. Ream <edreamleo@gmail.com>
 - Edgemaster <grand.edgemaster@gmail.com>
@@ -547,6 +557,7 @@ contributors:
 - Dmytro Kyrychuk <dmytro.kyrychuck@gmail.com>
 - Dionisio E Alonso <baco@users.noreply.github.com>
 - DetachHead <57028336+DetachHead@users.noreply.github.com>
+- Dennis Keck <26092524+fellhorn@users.noreply.github.com>
 - Denis Laxalde <denis.laxalde@logilab.fr>
 - David Lawson <dmrlawson@gmail.com>
 - David Cain <davidjosephcain@gmail.com>
@@ -582,12 +593,14 @@ contributors:
 - Benjamin Graham <benwilliamgraham@gmail.com>
 - Benedikt Morbach <benedikt.morbach@googlemail.com>
 - Ben Greiner <code@bnavigator.de>
+- Barak Shoshany <baraksh@gmail.com>
 - Banjamin Freeman <befreeman@users.noreply.github.com>
 - Avram Lubkin <avylove@rockhopper.net>
 - Athos Ribeiro <athoscr@fedoraproject.org>: Fixed dict-keys-not-iterating false positive for inverse containment checks
 - Arun Persaud <arun@nubati.net>
 - Arthur Lutz <arthur.lutz@logilab.fr>
 - Antonio Ossa <aaossa@uc.cl>
+- Antonio Gámiz Delgado <73933988+antoniogamizbadger@users.noreply.github.com>
 - Anthony VEREZ <anthony.verez.external@cassidian.com>
 - Anthony Tan <tanant@users.noreply.github.com>
 - Anthony Foglia <afoglia@users.noreply.github.com> (Google): Added simple string slots check.
@@ -617,6 +630,7 @@ contributors:
 - Adrian Chirieac <chirieacam@gmail.com>
 - Aditya Gupta <adityagupta1089@users.noreply.github.com> (adityagupta1089)
   * Added ignore_signatures to duplicate checker
+- Adam Tuft <73994535+adamtuft@users.noreply.github.com>
 - Adam Dangoor <adamdangoor@gmail.com>
 - 243f6a88 85a308d3 <33170174+243f6a8885a308d313198a2e037@users.noreply.github.com>
 

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -7,10 +7,148 @@
    :maxdepth: 2
 
 :Release:3.3
-:Date: TBA
+:Date: 2024-09-20
 
 Summary -- Release highlights
 =============================
 
-
 .. towncrier release notes start
+
+What's new in Pylint 3.3.0?
+---------------------------
+Release date: 2024-09-20
+
+
+Changes requiring user actions
+------------------------------
+
+- We migrated ``symilar`` to argparse, from getopt, so the error and help output changed
+  (for the better). We exit with 2 instead of sometime 1, sometime 2. The error output
+  is not captured by the runner anymore. It's not possible to use a value for the
+  boolean options anymore (``--ignore-comments 1`` should become ``--ignore-comments``).
+
+  Refs #9731 (`#9731 <https://github.com/pylint-dev/pylint/issues/9731>`_)
+
+
+
+New Features
+------------
+
+- Add new `declare-non-slot` error which reports when a class has a `__slots__` member and a type hint on the class is not present in `__slots__`.
+
+  Refs #9499 (`#9499 <https://github.com/pylint-dev/pylint/issues/9499>`_)
+
+
+
+New Checks
+----------
+
+- Added `too-many-positional-arguments` to allow distinguishing the configuration for too many
+  total arguments (with keyword-only params specified after `*`) from the configuration
+  for too many positional-or-keyword or positional-only arguments.
+
+  As part of evaluating whether this check makes sense for your project, ensure you
+  adjust the value of `--max-positional-arguments`.
+
+  Closes #9099 (`#9099 <https://github.com/pylint-dev/pylint/issues/9099>`_)
+
+- Add `using-exception-group-in-unsupported-version` and
+  `using-generic-type-syntax-in-unsupported-version` for uses of Python 3.11+ or
+  3.12+ features on lower supported versions provided with `--py-version`.
+
+  Closes #9791 (`#9791 <https://github.com/pylint-dev/pylint/issues/9791>`_)
+
+- Add `using-assignment-expression-in-unsupported-version` for uses of `:=` (walrus operator)
+  on Python versions below 3.8 provided with `--py-version`.
+
+  Closes #9820 (`#9820 <https://github.com/pylint-dev/pylint/issues/9820>`_)
+
+- Add `using-positional-only-args-in-unsupported-version` for uses of positional-only args on
+  Python versions below 3.8 provided with `--py-version`.
+
+  Closes #9823 (`#9823 <https://github.com/pylint-dev/pylint/issues/9823>`_)
+
+- Add ``unnecessary-default-type-args`` to the ``typing`` extension to detect the use
+  of unnecessary default type args for ``typing.Generator`` and ``typing.AsyncGenerator``.
+
+  Refs #9938 (`#9938 <https://github.com/pylint-dev/pylint/issues/9938>`_)
+
+
+
+False Negatives Fixed
+---------------------
+
+- Fix computation of never-returning function: `Never` is handled in addition to `NoReturn`, and priority is given to the explicit `--never-returning-functions` option.
+
+  Closes #7565. (`#7565 <https://github.com/pylint-dev/pylint/issues/7565>`_)
+
+- Fix a false negative for `await-outside-async` when await is inside Lambda.
+
+  Refs #9653 (`#9653 <https://github.com/pylint-dev/pylint/issues/9653>`_)
+
+- Fix a false negative for ``duplicate-argument-name`` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check.
+
+  Closes #9669 (`#9669 <https://github.com/pylint-dev/pylint/issues/9669>`_)
+
+- Fix false negative for `multiple-statements` when multiple statements are present on `else` and `finally` lines of `try`.
+
+  Refs #9759 (`#9759 <https://github.com/pylint-dev/pylint/issues/9759>`_)
+
+- Fix false negatives when `isinstance` does not have exactly two arguments.
+  pylint now emits a `too-many-function-args` or `no-value-for-parameter`
+  appropriately for `isinstance` calls.
+
+  Closes #9847 (`#9847 <https://github.com/pylint-dev/pylint/issues/9847>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- `--enable` with `--disable=all` now produces an error, when an unknown msg code is used. Internal `pylint` messages are no longer affected by `--disable=all`.
+
+  Closes #9403 (`#9403 <https://github.com/pylint-dev/pylint/issues/9403>`_)
+
+- Impossible to compile regexes for paths in the configuration or argument given to pylint won't crash anymore but
+  raise an argparse error and display the error message from ``re.compile`` instead.
+
+  Closes #9680 (`#9680 <https://github.com/pylint-dev/pylint/issues/9680>`_)
+
+- Fix a bug where a ``tox.ini`` file with pylint configuration was ignored and it exists in the current directory.
+
+  ``.cfg`` and ``.ini`` files containing a ``Pylint`` configuration may now use a section named ``[pylint]``. This enhancement impacts the scenario where these file types are used as defaults when they are present and have not been explicitly referred to, using the ``--rcfile`` option.
+
+  Closes #9727 (`#9727 <https://github.com/pylint-dev/pylint/issues/9727>`_)
+
+- Improve file discovery for directories that are not python packages.
+
+  Closes #9764 (`#9764 <https://github.com/pylint-dev/pylint/issues/9764>`_)
+
+
+
+Other Changes
+-------------
+
+- Remove support for launching pylint with Python 3.8.
+  Code that supports Python 3.8 can still be linted with the ``--py-version=3.8`` setting.
+
+  Refs #9774 (`#9774 <https://github.com/pylint-dev/pylint/issues/9774>`_)
+
+- Add support for Python 3.13.
+
+  Refs #9852 (`#9852 <https://github.com/pylint-dev/pylint/issues/9852>`_)
+
+
+
+Internal Changes
+----------------
+
+- All variables, classes, functions and file names containing the word 'similar', when it was,
+  in fact, referring to 'symilar' (the standalone program for the duplicate-code check) were renamed
+  to 'symilar'.
+
+  Closes #9734 (`#9734 <https://github.com/pylint-dev/pylint/issues/9734>`_)
+
+- Remove old-style classes (Python 2) code and remove check for new-style class since everything is new-style in Python 3. Updated doc for exception checker to remove reference to new style class.
+
+  Refs #9925 (`#9925 <https://github.com/pylint-dev/pylint/issues/9925>`_)

--- a/doc/whatsnew/3/3.4/index.rst
+++ b/doc/whatsnew/3/3.4/index.rst
@@ -1,0 +1,16 @@
+
+***************************
+ What's New in Pylint 3.4
+***************************
+
+.. toctree::
+   :maxdepth: 2
+
+:Release:3.4
+:Date: TBA
+
+Summary -- Release highlights
+=============================
+
+
+.. towncrier release notes start

--- a/doc/whatsnew/3/index.rst
+++ b/doc/whatsnew/3/index.rst
@@ -6,6 +6,7 @@ This is the full list of change in pylint 3.x minors, by categories.
 .. toctree::
    :maxdepth: 2
 
+   3.4/index
    3.3/index
    3.2/index
    3.1/index

--- a/doc/whatsnew/fragments/7565.false_negative
+++ b/doc/whatsnew/fragments/7565.false_negative
@@ -1,3 +1,0 @@
-Fix computation of never-returning function: `Never` is handled in addition to `NoReturn`, and priority is given to the explicit `--never-returning-functions` option.
-
-Closes #7565.

--- a/doc/whatsnew/fragments/9099.new_check
+++ b/doc/whatsnew/fragments/9099.new_check
@@ -1,8 +1,0 @@
-Added `too-many-positional-arguments` to allow distinguishing the configuration for too many
-total arguments (with keyword-only params specified after `*`) from the configuration
-for too many positional-or-keyword or positional-only arguments.
-
-As part of evaluating whether this check makes sense for your project, ensure you
-adjust the value of `--max-positional-arguments`.
-
-Closes #9099

--- a/doc/whatsnew/fragments/9403.bugfix
+++ b/doc/whatsnew/fragments/9403.bugfix
@@ -1,3 +1,0 @@
-`--enable` with `--disable=all` now produces an error, when an unknown msg code is used. Internal `pylint` messages are no longer affected by `--disable=all`.
-
-Closes #9403

--- a/doc/whatsnew/fragments/9499.feature
+++ b/doc/whatsnew/fragments/9499.feature
@@ -1,3 +1,0 @@
-Add new `declare-non-slot` error which reports when a class has a `__slots__` member and a type hint on the class is not present in `__slots__`.
-
-Refs #9499

--- a/doc/whatsnew/fragments/9653.false_negative
+++ b/doc/whatsnew/fragments/9653.false_negative
@@ -1,3 +1,0 @@
-Fix a false negative for `await-outside-async` when await is inside Lambda.
-
-Refs #9653

--- a/doc/whatsnew/fragments/9669.false_negative
+++ b/doc/whatsnew/fragments/9669.false_negative
@@ -1,3 +1,0 @@
-Fix a false negative for ``duplicate-argument-name`` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check.
-
-Closes #9669

--- a/doc/whatsnew/fragments/9680.bugfix
+++ b/doc/whatsnew/fragments/9680.bugfix
@@ -1,4 +1,0 @@
-Impossible to compile regexes for paths in the configuration or argument given to pylint won't crash anymore but
-raise an argparse error and display the error message from ``re.compile`` instead.
-
-Closes #9680

--- a/doc/whatsnew/fragments/9727.bugfix
+++ b/doc/whatsnew/fragments/9727.bugfix
@@ -1,5 +1,0 @@
-Fix a bug where a ``tox.ini`` file with pylint configuration was ignored and it exists in the current directory.
-
-``.cfg`` and ``.ini`` files containing a ``Pylint`` configuration may now use a section named ``[pylint]``. This enhancement impacts the scenario where these file types are used as defaults when they are present and have not been explicitly referred to, using the ``--rcfile`` option.
-
-Closes #9727

--- a/doc/whatsnew/fragments/9731.user_action
+++ b/doc/whatsnew/fragments/9731.user_action
@@ -1,6 +1,0 @@
-We migrated ``symilar`` to argparse, from getopt, so the error and help output changed
-(for the better). We exit with 2 instead of sometime 1, sometime 2. The error output
-is not captured by the runner anymore. It's not possible to use a value for the
-boolean options anymore (``--ignore-comments 1`` should become ``--ignore-comments``).
-
-Refs #9731

--- a/doc/whatsnew/fragments/9734.internal
+++ b/doc/whatsnew/fragments/9734.internal
@@ -1,5 +1,0 @@
-All variables, classes, functions and file names containing the word 'similar', when it was,
-in fact, referring to 'symilar' (the standalone program for the duplicate-code check) were renamed
-to 'symilar'.
-
-Closes #9734

--- a/doc/whatsnew/fragments/9759.false_negative
+++ b/doc/whatsnew/fragments/9759.false_negative
@@ -1,3 +1,0 @@
-Fix false negative for `multiple-statements` when multiple statements are present on `else` and `finally` lines of `try`.
-
-Refs #9759

--- a/doc/whatsnew/fragments/9764.bugfix
+++ b/doc/whatsnew/fragments/9764.bugfix
@@ -1,3 +1,0 @@
-Improve file discovery for directories that are not python packages.
-
-Closes #9764

--- a/doc/whatsnew/fragments/9774.other
+++ b/doc/whatsnew/fragments/9774.other
@@ -1,4 +1,0 @@
-Remove support for launching pylint with Python 3.8.
-Code that supports Python 3.8 can still be linted with the ``--py-version=3.8`` setting.
-
-Refs #9774

--- a/doc/whatsnew/fragments/9791.new_check
+++ b/doc/whatsnew/fragments/9791.new_check
@@ -1,5 +1,0 @@
-Add `using-exception-group-in-unsupported-version` and
-`using-generic-type-syntax-in-unsupported-version` for uses of Python 3.11+ or
-3.12+ features on lower supported versions provided with `--py-version`.
-
-Closes #9791

--- a/doc/whatsnew/fragments/9820.new_check
+++ b/doc/whatsnew/fragments/9820.new_check
@@ -1,4 +1,0 @@
-Add `using-assignment-expression-in-unsupported-version` for uses of `:=` (walrus operator)
-on Python versions below 3.8 provided with `--py-version`.
-
-Closes #9820

--- a/doc/whatsnew/fragments/9823.new_check
+++ b/doc/whatsnew/fragments/9823.new_check
@@ -1,4 +1,0 @@
-Add `using-positional-only-args-in-unsupported-version` for uses of positional-only args on
-Python versions below 3.8 provided with `--py-version`.
-
-Closes #9823

--- a/doc/whatsnew/fragments/9847.false_negative
+++ b/doc/whatsnew/fragments/9847.false_negative
@@ -1,5 +1,0 @@
-Fix false negatives when `isinstance` does not have exactly two arguments.
-pylint now emits a `too-many-function-args` or `no-value-for-parameter`
-appropriately for `isinstance` calls.
-
-Closes #9847

--- a/doc/whatsnew/fragments/9852.other
+++ b/doc/whatsnew/fragments/9852.other
@@ -1,3 +1,0 @@
-Add support for Python 3.13.
-
-Refs #9852

--- a/doc/whatsnew/fragments/9925.internal
+++ b/doc/whatsnew/fragments/9925.internal
@@ -1,3 +1,0 @@
-Remove old-style classes (Python 2) code and remove check for new-style class since everything is new-style in Python 3. Updated doc for exception checker to remove reference to new style class.
-
-Refs #9925

--- a/doc/whatsnew/fragments/9938.new_check
+++ b/doc/whatsnew/fragments/9938.new_check
@@ -1,4 +1,0 @@
-Add ``unnecessary-default-type-args`` to the ``typing`` extension to detect the use
-of unnecessary default type args for ``typing.Generator`` and ``typing.AsyncGenerator``.
-
-Refs #9938

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.0-dev0"
+__version__ = "3.3.0"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.0"
+__version__ = "3.4.0-dev0"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -567,6 +567,10 @@
     "mails": ["jaehoonhwang@users.noreply.github.com"],
     "name": "Jaehoon Hwang"
   },
+  "jake.lishman@ibm.com": {
+    "mails": ["jake.lishman@ibm.com", "jake@binhbar.com"],
+    "name": "Jake Lishman"
+  },
   "james.morgensen@gmail.com": {
     "comment": ": ignored-modules option applies to import errors.",
     "mails": ["james.morgensen@gmail.com"],

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.0-dev0"
+current = "3.3.0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.0"
+current = "3.4.0-dev0"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,7 +1,7 @@
 [tool.towncrier]
-version = "3.3.0"
+version = "3.4.0"
 directory = "doc/whatsnew/fragments"
-filename = "doc/whatsnew/3/3.3/index.rst"
+filename = "doc/whatsnew/3/3.4/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"
 issue_format = "`#{issue} <https://github.com/pylint-dev/pylint/issues/{issue}>`_"
 wrap = false  # doesn't wrap links correctly if beginning with indentation


### PR DESCRIPTION
What's new in Pylint 3.3.0?
---------------------------
Release date: 2024-09-20


Changes requiring user actions
------------------------------

- We migrated ``symilar`` to argparse, from getopt, so the error and help output changed
  (for the better). We exit with 2 instead of sometime 1, sometime 2. The error output
  is not captured by the runner anymore. It's not possible to use a value for the
  boolean options anymore (``--ignore-comments 1`` should become ``--ignore-comments``).

  Refs #9731



New Features
------------

- Add new `declare-non-slot` error which reports when a class has a `__slots__` member and a type hint on the class is not present in `__slots__`.

  Refs #9499



New Checks
----------

- Added `too-many-positional-arguments` to allow distinguishing the configuration for too many
  total arguments (with keyword-only params specified after `*`) from the configuration
  for too many positional-or-keyword or positional-only arguments.

  As part of evaluating whether this check makes sense for your project, ensure you
  adjust the value of `--max-positional-arguments`.

  Closes #9099

- Add `using-exception-group-in-unsupported-version` and
  `using-generic-type-syntax-in-unsupported-version` for uses of Python 3.11+ or
  3.12+ features on lower supported versions provided with `--py-version`.

  Closes #9791 

- Add `using-assignment-expression-in-unsupported-version` for uses of `:=` (walrus operator)
  on Python versions below 3.8 provided with `--py-version`.

  Closes #9820 

- Add `using-positional-only-args-in-unsupported-version` for uses of positional-only args on
  Python versions below 3.8 provided with `--py-version`.

  Closes #9823 

- Add ``unnecessary-default-type-args`` to the ``typing`` extension to detect the use
  of unnecessary default type args for ``typing.Generator`` and ``typing.AsyncGenerator``.

  Refs #9938 



False Negatives Fixed
---------------------

- Fix computation of never-returning function: `Never` is handled in addition to `NoReturn`, and priority is given to the explicit `--never-returning-functions` option.

  Closes #7565.

- Fix a false negative for `await-outside-async` when await is inside Lambda.

  Refs #9653 

- Fix a false negative for ``duplicate-argument-name`` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check.

  Closes #9669 

- Fix false negative for `multiple-statements` when multiple statements are present on `else` and `finally` lines of `try`.

  Refs #9759 

- Fix false negatives when `isinstance` does not have exactly two arguments.
  pylint now emits a `too-many-function-args` or `no-value-for-parameter`
  appropriately for `isinstance` calls.

  Closes #9847 



Other Bug Fixes
---------------

- `--enable` with `--disable=all` now produces an error, when an unknown msg code is used. Internal `pylint` messages are no longer affected by `--disable=all`.

  Closes #9403 

- Impossible to compile regexes for paths in the configuration or argument given to pylint won't crash anymore but
  raise an argparse error and display the error message from ``re.compile`` instead.

  Closes #9680 

- Fix a bug where a ``tox.ini`` file with pylint configuration was ignored and it exists in the current directory.

  ``.cfg`` and ``.ini`` files containing a ``Pylint`` configuration may now use a section named ``[pylint]``. This enhancement impacts the scenario where these file types are used as defaults when they are present and have not been explicitly referred to, using the ``--rcfile`` option.

  Closes #9727

- Improve file discovery for directories that are not python packages.

  Closes #9764



Other Changes
-------------

- Remove support for launching pylint with Python 3.8.
  Code that supports Python 3.8 can still be linted with the ``--py-version=3.8`` setting.

  Refs #9774 

- Add support for Python 3.13.

  Refs #9852



Internal Changes
----------------

- All variables, classes, functions and file names containing the word 'similar', when it was,
  in fact, referring to 'symilar' (the standalone program for the duplicate-code check) were renamed
  to 'symilar'.

  Closes #9734

- Remove old-style classes (Python 2) code and remove check for new-style class since everything is new-style in Python 3. Updated doc for exception checker to remove reference to new style class.

  Refs #9925 
