### PR TITLE
Bump pylint to 3.3.1, update changelog

### DIFF
--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,20 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.3.1?
+---------------------------
+Release date: 2024-09-24
+
+
+False Positives Fixed
+---------------------
+
+- Fix regression causing some f-strings to not be inferred as strings.
+
+  Closes #9947 (`#9947 <https://github.com/pylint-dev/pylint/issues/9947>`_)
+
+
+
 What's new in Pylint 3.3.0?
 ---------------------------
 Release date: 2024-09-20

--- a/doc/whatsnew/fragments/9947.false_positive
+++ b/doc/whatsnew/fragments/9947.false_positive
@@ -1,3 +1,0 @@
-Fix regression causing some f-strings to not be inferred as strings.
-
-Closes #9947

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.0"
+current = "3.3.1"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.3.0"
+version = "3.3.1"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.3/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.3.1?
---------------------------
Release date: 2024-09-24


False Positives Fixed
---------------------

- Fix regression causing some f-strings to not be inferred as strings.

  Closes #9947