### PR TITLE
[too-many-positional-arguments doc] Add the main option to use, real example

### DIFF
--- a/doc/data/messages/t/too-many-positional-arguments/bad.py
+++ b/doc/data/messages/t/too-many-positional-arguments/bad.py
@@ -1,5 +1,6 @@
-class FiveArgumentMethods:
-    """The max positional arguments default is 5."""
+# +1: [too-many-positional-arguments]
+def calculate_drag_force(velocity, area, density, drag_coefficient):
+    return 0.5 * drag_coefficient * density * area * velocity**2
 
-    def take_five_args(self, a, b, c, d, e):  # [too-many-positional-arguments]
-        pass
+
+drag_force = calculate_drag_force(30, 2.5, 1.225, 0.47)

--- a/doc/data/messages/t/too-many-positional-arguments/good.py
+++ b/doc/data/messages/t/too-many-positional-arguments/good.py
@@ -1,5 +1,7 @@
-class FiveArgumentMethods:
-    """The max positional arguments default is 5."""
+def calculate_drag_force(*, velocity, area, density, drag_coefficient):
+    return 0.5 * drag_coefficient * density * area * velocity**2
 
-    def take_five_args(self, a, b, c, d, *, e=False):
-        pass
+
+drag_force = calculate_drag_force(
+    velocity=30, area=2.5, density=1.225, drag_coefficient=0.47
+)

--- a/doc/data/messages/t/too-many-positional-arguments/pylintrc
+++ b/doc/data/messages/t/too-many-positional-arguments/pylintrc
@@ -1,2 +1,2 @@
-[MESSAGES CONTROL]
-disable=too-many-arguments
+[DESIGN]
+max-positional-arguments=3


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Permits to see the option you have to change when reading the doc (probably the next frontier in our doc, is documenting the option that affect each message). Also made the example more concrete, added the effect on the API, and removed the class construct.
