### PR TITLE
remove metaclass check for protected access in properties

### DIFF
--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -470,13 +470,8 @@ def _is_attribute_property(name: str, klass: nodes.ClassDef) -> bool:
             inferred
         ):
             return True
-        if inferred.pytype() != property_name:
-            continue
-
-        cls = node_frame_class(inferred)
-        if cls == klass.declared_metaclass():
-            continue
-        return True
+        if inferred.pytype() == property_name:
+            return True
     return False
 
 

--- a/tests/functional/p/protected_access.py
+++ b/tests/functional/p/protected_access.py
@@ -19,18 +19,6 @@ OBJ._manager
 OBJ._teta  # [protected-access]
 
 
-# Make sure protect-access doesn't raise an exception Uninferable attributes
-class MC:
-    @property
-    def nargs(self):
-        return 1 if self._nargs else 2
-
-
-class Application(metaclass=MC):
-    def __no_special__(cls):
-        nargs = obj._nargs  # [protected-access]
-
-
 class Light:
     @property
     def _light_internal(self) -> None:

--- a/tests/functional/p/protected_access.txt
+++ b/tests/functional/p/protected_access.txt
@@ -1,4 +1,3 @@
 protected-access:19:0:19:9::Access to a protected member _teta of a client class:UNDEFINED
-protected-access:31:16:31:26:Application.__no_special__:Access to a protected member _nargs of a client class:UNDEFINED
-protected-access:41:14:41:35:Light.func:Access to a protected member _light_internal of a client class:UNDEFINED
-protected-access:45:10:45:31:func:Access to a protected member _light_internal of a client class:UNDEFINED
+protected-access:29:14:29:35:Light.func:Access to a protected member _light_internal of a client class:UNDEFINED
+protected-access:33:10:33:31:func:Access to a protected member _light_internal of a client class:UNDEFINED


### PR DESCRIPTION
1. it was incorrect when the property wasn't inside a class and the enclosing class didn't have an explicit metaclass

2. The conjugated test is full with errors and I can't understand the intention. (the errors: `MC` doesn't inherit `type`; `_nargs` isn't defined; `obj` isn't defined, etc). What is the pointed of testing protected access on an undefined variable?..

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->


## Description

The PR is intentionally extreme (removing the whole test), and I wouldn't be surprised if I missed something and my change is incorrect. I'd be happy to adapt based on the feedback.

The primary reason for this PR is marked as `1.` in the commit description (or above).

One situation where this happens is the following. In new astroid "function-call" style properties don't have the enclosing class as the parent. The reason is that the properties themselves are not defined within the class, they are defined within some builtin module. It's just the name that they are assigned to that is defined within the class. So, for example in:
```
class Foo:
  x = property(lambda self: 5)
```
`x` _is_ defined within `Foo`, but the property itself isn't. You can read more about it here: https://github.com/pylint-dev/astroid/pull/2553
