### PR TITLE
Move typechecking imports under TYPE_CHECKING flag

### DIFF
--- a/pylint/checkers/bad_chained_comparison.py
+++ b/pylint/checkers/bad_chained_comparison.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from astroid import nodes
-
 from pylint.checkers import BaseChecker
 from pylint.interfaces import HIGH
 
 if TYPE_CHECKING:
+    from astroid import nodes
+
     from pylint.lint import PyLinter
 
 COMPARISON_OP = frozenset(("<", "<=", ">", ">=", "!=", "=="))

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import collections
 import itertools
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Literal, cast
 
 import astroid
@@ -16,12 +15,15 @@ from astroid import nodes, objects, util
 
 from pylint import utils as lint_utils
 from pylint.checkers import BaseChecker, utils
-from pylint.interfaces import HIGH, INFERENCE, Confidence
+from pylint.interfaces import HIGH, INFERENCE
 from pylint.reporters.ureports import nodes as reporter_nodes
-from pylint.utils import LinterStats
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from pylint.interfaces import Confidence
     from pylint.lint.pylinter import PyLinter
+    from pylint.utils import LinterStats
 
 
 class _BasicChecker(BaseChecker):

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -7,15 +7,19 @@
 from __future__ import annotations
 
 import itertools
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import nodes
-from astroid.typing import InferenceResult
 
 from pylint.checkers import utils
 from pylint.checkers.base.basic_checker import _BasicChecker
 from pylint.checkers.utils import infer_all
 from pylint.interfaces import HIGH
+
+if TYPE_CHECKING:
+    from astroid.typing import InferenceResult
+
 
 ABC_METACLASSES = {"_py_abc.ABCMeta", "abc.ABCMeta"}  # Python 3.7+,
 # List of methods which can be redefined

--- a/pylint/checkers/base/docstring_checker.py
+++ b/pylint/checkers/base/docstring_checker.py
@@ -7,7 +7,8 @@
 from __future__ import annotations
 
 import re
-from typing import Literal
+from typing import TYPE_CHECKING
+
 
 import astroid
 from astroid import nodes
@@ -20,6 +21,10 @@ from pylint.checkers.utils import (
     is_property_deleter,
     is_property_setter,
 )
+
+if TYPE_CHECKING:
+    from typing import Literal
+
 
 # do not require a doc string on private/system methods
 NO_REQUIRED_DOC_RGX = re.compile("^_")

--- a/pylint/checkers/base/docstring_checker.py
+++ b/pylint/checkers/base/docstring_checker.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-
 import astroid
 from astroid import nodes
 

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -6,14 +6,11 @@
 
 from __future__ import annotations
 
-import argparse
 import collections
 import itertools
 import re
 import sys
-from collections.abc import Iterable
 from enum import Enum, auto
-from re import Pattern
 from typing import TYPE_CHECKING
 
 import astroid
@@ -29,10 +26,14 @@ from pylint.checkers.base.name_checker.naming_style import (
     _create_naming_options,
 )
 from pylint.checkers.utils import is_property_deleter, is_property_setter
-from pylint.typing import Options
 
 if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Iterable
+    from re import Pattern
+
     from pylint.lint.pylinter import PyLinter
+    from pylint.typing import Options
 
 _BadNamesTuple = tuple[nodes.NodeNG, str, str, interfaces.Confidence]
 

--- a/pylint/checkers/base/name_checker/naming_style.py
+++ b/pylint/checkers/base/name_checker/naming_style.py
@@ -5,10 +5,14 @@
 from __future__ import annotations
 
 import re
-from re import Pattern
+from typing import TYPE_CHECKING
 
 from pylint import constants
-from pylint.typing import OptionDict, Options
+
+if TYPE_CHECKING:
+    from re import Pattern
+
+    from pylint.typing import OptionDict, Options
 
 
 class NamingStyle:

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
     from astroid import nodes
 
-    from pylint.lint import PyLinter
     from pylint.interfaces import Confidence
+    from pylint.lint import PyLinter
     from pylint.typing import (
         MessageDefinitionTuple,
         OptionDict,

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -6,29 +6,31 @@ from __future__ import annotations
 
 import abc
 import functools
-from collections.abc import Iterable, Sequence
 from inspect import cleandoc
-from tokenize import TokenInfo
-from typing import TYPE_CHECKING, Any
-
-from astroid import nodes
+from typing import TYPE_CHECKING
 
 from pylint.config.arguments_provider import _ArgumentsProvider
 from pylint.constants import _MSG_ORDER, MAIN_CHECKER_NAME, WarningScope
 from pylint.exceptions import InvalidMessageError
-from pylint.interfaces import Confidence
 from pylint.message.message_definition import MessageDefinition
-from pylint.typing import (
-    ExtraMessageOptions,
-    MessageDefinitionTuple,
-    OptionDict,
-    Options,
-    ReportsCallable,
-)
+from pylint.typing import ExtraMessageOptions
 from pylint.utils import get_rst_section, get_rst_title
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from tokenize import TokenInfo
+    from typing import Any
+
+    from astroid import nodes
+
     from pylint.lint import PyLinter
+    from pylint.interfaces import Confidence
+    from pylint.typing import (
+        MessageDefinitionTuple,
+        OptionDict,
+        Options,
+        ReportsCallable,
+    )
 
 
 @functools.total_ordering

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -7,16 +7,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Sequence
 from functools import cached_property
 from itertools import chain, zip_longest
-from re import Pattern
-from typing import TYPE_CHECKING, Any, NamedTuple, Union
+from typing import TYPE_CHECKING, NamedTuple
 
 import astroid
-from astroid import bases, nodes, util
-from astroid.nodes import LocalsDictNodeNG
-from astroid.typing import SuccessfulInferenceResult
+from astroid import nodes, util
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -40,13 +36,21 @@ from pylint.checkers.utils import (
     uninferable_final_decorators,
 )
 from pylint.interfaces import HIGH, INFERENCE
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from re import Pattern
+    from typing import Any, Union
+
+    from astroid import bases
+    from astroid.nodes import LocalsDictNodeNG
+    from astroid.typing import SuccessfulInferenceResult
+
     from pylint.lint.pylinter import PyLinter
+    from pylint.typing import MessageDefinitionTuple
 
+    _AccessNodes = Union[nodes.Attribute, nodes.AssignAttr]
 
-_AccessNodes = Union[nodes.Attribute, nodes.AssignAttr]
 
 INVALID_BASE_CLASSES = {"bool", "range", "slice", "memoryview"}
 ALLOWED_PROPERTIES = {"bultins.property", "functools.cached_property"}

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -6,12 +6,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import bases, nodes, util
-from astroid.context import InferenceContext
-from astroid.typing import InferenceResult
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import (
@@ -22,7 +20,15 @@ from pylint.checkers.utils import (
     only_required_for_messages,
     safe_infer,
 )
-from pylint.lint.pylinter import PyLinter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from astroid.context import InferenceContext
+    from astroid.typing import InferenceResult
+
+    from pylint.lint.pylinter import PyLinter
+
 
 NEXT_METHOD = "__next__"
 

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -6,8 +6,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Container, Iterable
 from itertools import chain
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import nodes
@@ -17,7 +17,12 @@ from pylint.checkers import utils
 from pylint.checkers.base_checker import BaseChecker
 from pylint.checkers.utils import get_import_name, infer_all, safe_infer
 from pylint.interfaces import INFERENCE
-from pylint.typing import MessageDefinitionTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Container, Iterable
+
+    from pylint.typing import MessageDefinitionTuple
+
 
 ACCEPTABLE_NODES = (
     astroid.BoundMethod,

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -8,19 +8,22 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import astroid
-from astroid import nodes
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import is_enum, only_required_for_messages
 from pylint.interfaces import HIGH
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from astroid import nodes
+
     from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
+
 
 MSGS: dict[str, MessageDefinitionTuple] = (
     {  # pylint: disable=consider-using-namedtuple-or-dataclass

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -8,21 +8,25 @@ from __future__ import annotations
 
 import builtins
 import inspect
-from collections.abc import Generator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import astroid
-from astroid import nodes, objects, util
-from astroid.context import InferenceContext
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
+from astroid import nodes, util
 
 from pylint import checkers
 from pylint.checkers import utils
 from pylint.interfaces import HIGH, INFERENCE
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import Any
+
+    from astroid import objects
+    from astroid.context import InferenceContext
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
+
     from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
 
 
 def _builtin_exceptions() -> set[str]:

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 
 import tokenize
 from functools import reduce
-from re import Match
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from astroid import nodes
 
@@ -24,11 +23,14 @@ from pylint.checkers import BaseRawFileChecker, BaseTokenChecker
 from pylint.checkers.utils import only_required_for_messages
 from pylint.constants import WarningScope
 from pylint.interfaces import HIGH
-from pylint.typing import MessageDefinitionTuple
 from pylint.utils.pragma_parser import OPTION_PO, PragmaParserError, parse_pragma
 
 if TYPE_CHECKING:
+    from re import Match
+    from typing import Literal
+
     from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
 
 
 _KEYWORD_TOKENS = {

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -11,13 +11,11 @@ import copy
 import os
 import sys
 from collections import defaultdict
-from collections.abc import ItemsView, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Union
 
 import astroid
 from astroid import nodes
-from astroid.nodes._base_nodes import ImportNode
 
 from pylint.checkers import BaseChecker, DeprecatedMixin
 from pylint.checkers.utils import (
@@ -32,13 +30,18 @@ from pylint.constants import MAX_NUMBER_OF_IMPORT_SHOWN
 from pylint.exceptions import EmptyReportError
 from pylint.graph import DotBackend, get_cycles
 from pylint.interfaces import HIGH
-from pylint.reporters.ureports.nodes import Paragraph, Section, VerbatimText
-from pylint.typing import MessageDefinitionTuple
+from pylint.reporters.ureports.nodes import Paragraph, VerbatimText
 from pylint.utils import IsortDriver
-from pylint.utils.linterstats import LinterStats
 
 if TYPE_CHECKING:
+    from collections.abc import ItemsView, Sequence
+
+    from astroid.nodes._base_nodes import ImportNode
+
     from pylint.lint import PyLinter
+    from pylint.reporters.ureports.nodes import Section
+    from pylint.typing import MessageDefinitionTuple
+    from pylint.utils.linterstats import LinterStats
 
 
 # The dictionary with Any should actually be a _ImportTree again

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -7,20 +7,25 @@
 from __future__ import annotations
 
 import string
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import astroid
-from astroid import bases, nodes
-from astroid.typing import InferenceResult
+from astroid import nodes
 
 from pylint import checkers
 from pylint.checkers import utils
 from pylint.checkers.utils import infer_all
 from pylint.interfaces import HIGH
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
+    from typing import Literal
+
+    from astroid import bases
+    from astroid.typing import InferenceResult
+
     from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
+
 
 MSGS: dict[str, MessageDefinitionTuple] = (
     {  # pylint: disable=consider-using-namedtuple-or-dataclass

--- a/pylint/checkers/misc.py
+++ b/pylint/checkers/misc.py
@@ -10,13 +10,13 @@ import re
 import tokenize
 from typing import TYPE_CHECKING
 
-from astroid import nodes
-
 from pylint.checkers import BaseRawFileChecker, BaseTokenChecker
-from pylint.typing import ManagedMessage
 
 if TYPE_CHECKING:
+    from astroid import nodes
+
     from pylint.lint import PyLinter
+    from pylint.typing import ManagedMessage
 
 
 class ByIdManagedMessagesChecker(BaseRawFileChecker):

--- a/pylint/checkers/newstyle.py
+++ b/pylint/checkers/newstyle.py
@@ -13,10 +13,11 @@ from astroid import nodes
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import node_frame_class, only_required_for_messages
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
+
 
 MSGS: dict[str, MessageDefinitionTuple] = {
     "E1003": (

--- a/pylint/checkers/non_ascii_names.py
+++ b/pylint/checkers/non_ascii_names.py
@@ -12,10 +12,15 @@ The following checkers are intended to make users are aware of these issues.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid import nodes
 
-from pylint import constants, interfaces, lint
+from pylint import constants, interfaces
 from pylint.checkers import base_checker, utils
+
+if TYPE_CHECKING:
+    from pylint import lint
 
 NON_ASCII_HELP = (
     "Used when the name contains at least one non-ASCII unicode character. "

--- a/pylint/checkers/raw_metrics.py
+++ b/pylint/checkers/raw_metrics.py
@@ -5,14 +5,18 @@
 from __future__ import annotations
 
 import tokenize
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from pylint.checkers import BaseTokenChecker
-from pylint.reporters.ureports.nodes import Paragraph, Section, Table, Text
-from pylint.utils import LinterStats, diff_string
+from pylint.reporters.ureports.nodes import Paragraph, Table, Text
+from pylint.utils import diff_string
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from pylint.lint import PyLinter
+    from pylint.reporters.ureports.nodes import Section
+    from pylint.utils import LinterStats
 
 
 def report_raw_stats(

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -5,13 +5,17 @@
 from __future__ import annotations
 
 import itertools
+from typing import TYPE_CHECKING
 
 import astroid
-from astroid import bases, nodes, util
+from astroid import bases, nodes
 
 from pylint import checkers
 from pylint.checkers import utils
 from pylint.interfaces import HIGH, INFERENCE
+
+if TYPE_CHECKING:
+    from astroid import util
 
 
 def _is_constant_zero(node: str | nodes.NodeNG) -> bool:

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -8,10 +8,8 @@ import collections
 import copy
 import itertools
 import tokenize
-from collections.abc import Iterator
 from functools import cached_property, reduce
-from re import Pattern
-from typing import TYPE_CHECKING, Any, NamedTuple, Union, cast
+from typing import TYPE_CHECKING, NamedTuple, Union, cast
 
 import astroid
 from astroid import bases, nodes
@@ -21,9 +19,14 @@ from pylint import checkers
 from pylint.checkers import utils
 from pylint.checkers.base.basic_error_checker import _loop_exits_early
 from pylint.checkers.utils import node_frame_class
-from pylint.interfaces import HIGH, INFERENCE, Confidence
+from pylint.interfaces import HIGH, INFERENCE
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from re import Pattern
+    from typing import Any
+
+    from pylint.interfaces import Confidence
     from pylint.lint import PyLinter
 
 

--- a/pylint/checkers/spelling.py
+++ b/pylint/checkers/spelling.py
@@ -8,15 +8,17 @@ from __future__ import annotations
 
 import re
 import tokenize
-from re import Pattern
-from typing import TYPE_CHECKING, Any, Literal
-
-from astroid import nodes
+from typing import TYPE_CHECKING
 
 from pylint.checkers import BaseTokenChecker
 from pylint.checkers.utils import only_required_for_messages
 
 if TYPE_CHECKING:
+    from re import Pattern
+    from typing import Any, Literal
+
+    from astroid import nodes
+
     from pylint.lint import PyLinter
 
 try:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -7,22 +7,26 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import nodes, util
-from astroid.typing import InferenceResult
 
 from pylint import interfaces
 from pylint.checkers import BaseChecker, DeprecatedMixin, utils
 from pylint.interfaces import HIGH, INFERENCE
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
-    from pylint.lint import PyLinter
+    from collections.abc import Iterable
+    from typing import Any
 
-DeprecationDict = dict[tuple[int, int, int], set[str]]
+    from astroid.typing import InferenceResult
+
+    from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
+
+    DeprecationDict = dict[tuple[int, int, int], set[str]]
+
 
 OPEN_FILES_MODE = ("open", "file")
 OPEN_FILES_FUNCS = (*OPEN_FILES_MODE, "read_text", "write_text")

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -6,25 +6,28 @@
 
 from __future__ import annotations
 
-import collections
 import re
 import sys
 import tokenize
 from collections import Counter
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import astroid
-from astroid import bases, nodes, util
-from astroid.typing import SuccessfulInferenceResult
+from astroid import nodes, util
 
 from pylint.checkers import BaseChecker, BaseRawFileChecker, BaseTokenChecker, utils
 from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import HIGH
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from typing import Literal
+
+    from astroid import bases
+    from astroid.typing import SuccessfulInferenceResult
+
     from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
 
 
 _AST_NODE_STR_TYPES = ("__builtin__.unicode", "__builtin__.str", "builtins.str")
@@ -439,7 +442,7 @@ class StringFormatChecker(BaseChecker):
     def _detect_vacuous_formatting(
         self, node: nodes.Call, positional_arguments: list[SuccessfulInferenceResult]
     ) -> None:
-        counter = collections.Counter(
+        counter = Counter(
             arg.name for arg in positional_arguments if isinstance(arg, nodes.Name)
         )
         for name, count in counter.items():
@@ -833,7 +836,7 @@ class StringConstantChecker(BaseTokenChecker, BaseRawFileChecker):
         Args:
           tokens: The tokens to be checked against for consistent usage.
         """
-        string_delimiters: Counter[str] = collections.Counter()
+        string_delimiters: Counter[str] = Counter()
 
         inside_fstring = False  # whether token is inside f-string (since 3.12)
         target_py312 = self.linter.config.py_version >= (3, 12)

--- a/pylint/checkers/symilar.py
+++ b/pylint/checkers/symilar.py
@@ -38,21 +38,26 @@ import re
 import sys
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Generator, Iterable, Sequence
 from io import BufferedIOBase, BufferedReader, BytesIO
 from itertools import chain
-from typing import TYPE_CHECKING, NamedTuple, NewType, NoReturn, TextIO, Union
+from typing import TYPE_CHECKING, NamedTuple, NewType, TextIO, Union
 
 import astroid
 from astroid import nodes
 
 from pylint.checkers import BaseChecker, BaseRawFileChecker, table_lines_from_stats
-from pylint.reporters.ureports.nodes import Section, Table
-from pylint.typing import MessageDefinitionTuple, Options
-from pylint.utils import LinterStats, decoding_stream
+from pylint.reporters.ureports.nodes import Table
+from pylint.utils import decoding_stream
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Iterable, Sequence
+    from typing import NoReturn
+
     from pylint.lint import PyLinter
+    from pylint.reporters.ureports.nodes import Section
+    from pylint.typing import MessageDefinitionTuple, Options
+    from pylint.utils import LinterStats
+
 
 DEFAULT_MIN_SIMILARITY_LINE = 4
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -12,17 +12,13 @@ import operator
 import re
 import shlex
 import sys
-from collections.abc import Callable, Iterable
 from functools import cached_property, singledispatch
-from re import Pattern
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING
 
 import astroid
 import astroid.exceptions
 import astroid.helpers
-from astroid import arguments, bases, nodes, util
-from astroid.nodes import _base_nodes
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
+from astroid import bases, nodes, util
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -51,18 +47,27 @@ from pylint.checkers.utils import (
 )
 from pylint.constants import PY310_PLUS
 from pylint.interfaces import HIGH, INFERENCE
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
-    from pylint.lint import PyLinter
+    from collections.abc import Callable, Iterable
+    from re import Pattern
+    from typing import Any, Literal, Union
 
-CallableObjects = Union[
-    bases.BoundMethod,
-    bases.UnboundMethod,
-    nodes.FunctionDef,
-    nodes.Lambda,
-    nodes.ClassDef,
-]
+    from astroid import arguments
+    from astroid.nodes import _base_nodes
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
+
+    from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
+
+    CallableObjects = Union[
+        bases.BoundMethod,
+        bases.UnboundMethod,
+        nodes.FunctionDef,
+        nodes.Lambda,
+        nodes.ClassDef,
+    ]
+
 
 STR_FORMAT = {"builtins.str.format"}
 ASYNCIO_COROUTINE = "asyncio.coroutines.coroutine"

--- a/pylint/checkers/unicode.py
+++ b/pylint/checkers/unicode.py
@@ -15,21 +15,25 @@ from __future__ import annotations
 
 import codecs
 import contextlib
-import io
 import re
 from collections import OrderedDict
-from collections.abc import Iterable
 from functools import lru_cache
 from tokenize import detect_encoding
-from typing import NamedTuple, TypeVar
-
-from astroid import nodes
+from typing import TYPE_CHECKING
+from typing import NamedTuple
 
 import pylint.interfaces
 import pylint.lint
 from pylint import checkers
 
-_StrLike = TypeVar("_StrLike", str, bytes)
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    import io
+    from typing import TypeVar
+
+    from astroid import nodes
+
+    _StrLike = TypeVar("_StrLike", str, bytes)
 
 # Based on:
 # https://golangexample.com/go-linter-which-checks-for-dangerous-unicode-character-sequences/

--- a/pylint/checkers/unicode.py
+++ b/pylint/checkers/unicode.py
@@ -19,16 +19,15 @@ import re
 from collections import OrderedDict
 from functools import lru_cache
 from tokenize import detect_encoding
-from typing import TYPE_CHECKING
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import pylint.interfaces
 import pylint.lint
 from pylint import checkers
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     import io
+    from collections.abc import Iterable
     from typing import TypeVar
 
     from astroid import nodes

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -13,28 +13,31 @@ import itertools
 import numbers
 import re
 import string
-from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache, partial
-from re import Match
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING
 
 import astroid.objects
 from astroid import TooManyLevelsError, nodes, util
-from astroid.context import InferenceContext
 from astroid.exceptions import AstroidError
-from astroid.nodes._base_nodes import ImportNode, Statement
-from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
 from pylint.constants import TYPING_NEVER, TYPING_NORETURN
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
     from functools import _lru_cache_wrapper
+    from re import Match
+    from typing import Any, TypeVar
+
+    from astroid.context import InferenceContext
+    from astroid.nodes._base_nodes import ImportNode, Statement
+    from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
     from pylint.checkers import BaseChecker
 
-_NodeT = TypeVar("_NodeT", bound=nodes.NodeNG)
-_CheckerT = TypeVar("_CheckerT", bound="BaseChecker")
-AstCallbackMethod = Callable[[_CheckerT, _NodeT], None]
+    _NodeT = TypeVar("_NodeT", bound=nodes.NodeNG)
+    _CheckerT = TypeVar("_CheckerT", bound="BaseChecker")
+    AstCallbackMethod = Callable[[_CheckerT, _NodeT], None]
+
 
 COMP_NODE_TYPES = (
     nodes.ListComp,

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -6,23 +6,19 @@
 
 from __future__ import annotations
 
-import collections
 import copy
 import itertools
 import math
 import os
 import re
 from collections import defaultdict
-from collections.abc import Generator, Iterable, Iterator
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import astroid
 import astroid.exceptions
 from astroid import bases, extract_node, nodes, util
-from astroid.nodes import _base_nodes
-from astroid.typing import InferenceResult
 
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import (
@@ -34,10 +30,17 @@ from pylint.checkers.utils import (
 )
 from pylint.constants import TYPING_NEVER, TYPING_NORETURN
 from pylint.interfaces import CONTROL_FLOW, HIGH, INFERENCE, INFERENCE_FAILURE
-from pylint.typing import MessageDefinitionTuple
 
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Iterator
+    from typing import Any
+
+    from astroid.nodes import _base_nodes
+    from astroid.typing import InferenceResult
+
     from pylint.lint import PyLinter
+    from pylint.typing import MessageDefinitionTuple
+
 
 SPECIAL_OBJ = re.compile("^_{2}[a-z]+_{2}$")
 FUTURE = "__future__"
@@ -538,7 +541,7 @@ class NamesConsumer:
 
     def __init__(self, node: nodes.NodeNG, scope_type: str) -> None:
         self._atomic = ScopeConsumer(
-            copy.copy(node.locals), {}, collections.defaultdict(list), scope_type
+            copy.copy(node.locals), {}, defaultdict(list), scope_type
         )
         self.node = node
         self.names_under_always_false_test: set[str] = set()
@@ -3200,7 +3203,7 @@ class VariablesChecker(BaseChecker):
         checked = set()
         unused_wildcard_imports: defaultdict[
             tuple[str, nodes.ImportFrom], list[str]
-        ] = collections.defaultdict(list)
+        ] = defaultdict(list)
         for name, stmt in local_names:
             for imports in stmt.names:
                 real_name = imported_name = imports[0]

--- a/pylint/config/_pylint_config/setup.py
+++ b/pylint/config/_pylint_config/setup.py
@@ -8,11 +8,14 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING
 
 from pylint.config._pylint_config.help_message import get_help
 from pylint.config.callback_actions import _AccessParserAction
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
 
 
 class _HelpAction(_AccessParserAction):

--- a/pylint/config/_pylint_config/utils.py
+++ b/pylint/config/_pylint_config/utils.py
@@ -7,17 +7,21 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable
 from pathlib import Path
-from typing import Literal, TypeVar
+from typing import TYPE_CHECKING
 
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Literal, TypeVar
 
-_P = ParamSpec("_P")
-_ReturnValueT = TypeVar("_ReturnValueT", bool, str)
+    if sys.version_info >= (3, 10):
+        from typing import ParamSpec
+    else:
+        from typing_extensions import ParamSpec
+
+    _P = ParamSpec("_P")
+    _ReturnValueT = TypeVar("_ReturnValueT", bool, str)
+
 
 SUPPORTED_FORMATS = {"t", "toml", "i", "ini"}
 YES_NO_ANSWERS = {"y", "yes", "n", "no"}

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -13,27 +13,31 @@ import argparse
 import os
 import pathlib
 import re
-from collections.abc import Callable, Sequence
 from glob import glob
 from re import Pattern
-from typing import Any, Literal, Union
+from typing import TYPE_CHECKING
 
 from pylint import interfaces
 from pylint import utils as pylint_utils
-from pylint.config.callback_actions import _CallbackAction
 from pylint.config.deprecation_actions import _NewNamesAction, _OldNamesAction
 
-_ArgumentTypes = Union[
-    str,
-    int,
-    float,
-    bool,
-    Pattern[str],
-    Sequence[str],
-    Sequence[Pattern[str]],
-    tuple[int, ...],
-]
-"""List of possible argument types."""
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from typing import Any, Literal, Union
+
+    from pylint.config.callback_actions import _CallbackAction
+
+    _ArgumentTypes = Union[
+        str,
+        int,
+        float,
+        bool,
+        Pattern[str],
+        Sequence[str],
+        Sequence[Pattern[str]],
+        tuple[int, ...],
+    ]
+    """List of possible argument types."""
 
 
 def _confidence_transformer(value: str) -> Sequence[str]:

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -42,9 +42,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any, TextIO
 
-    from pylint.typing import DirectoryNamespaceDict, OptionDict
-    from pylint.config.arguments_provider import _ArgumentsProvider
     from pylint.config.argument import _Argument
+    from pylint.config.arguments_provider import _ArgumentsProvider
+    from pylint.typing import DirectoryNamespaceDict, OptionDict
 
 
 class _ArgumentsManager:

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -11,14 +11,12 @@ import re
 import sys
 import textwrap
 import warnings
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, TextIO
+from typing import TYPE_CHECKING
 
 import tomlkit
 
 from pylint import utils
 from pylint.config.argument import (
-    _Argument,
     _CallableArgument,
     _ExtendArgument,
     _StoreArgument,
@@ -33,7 +31,6 @@ from pylint.config.exceptions import (
 from pylint.config.help_formatter import _HelpFormatter
 from pylint.config.utils import _convert_option_to_argument, _parse_rich_type_value
 from pylint.constants import MAIN_CHECKER_NAME
-from pylint.typing import DirectoryNamespaceDict, OptionDict
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -42,7 +39,12 @@ else:
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any, TextIO
+
+    from pylint.typing import DirectoryNamespaceDict, OptionDict
     from pylint.config.arguments_provider import _ArgumentsProvider
+    from pylint.config.argument import _Argument
 
 
 class _ArgumentsManager:

--- a/pylint/config/arguments_provider.py
+++ b/pylint/config/arguments_provider.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Iterator
+    from typing import Any
 
-    from pylint.typing import OptionDict, Options
     from pylint.config.arguments_manager import _ArgumentsManager
+    from pylint.typing import OptionDict, Options
 
 
 class _ArgumentsProvider:

--- a/pylint/config/arguments_provider.py
+++ b/pylint/config/arguments_provider.py
@@ -6,11 +6,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING
 
-from pylint.config.arguments_manager import _ArgumentsManager
-from pylint.typing import OptionDict, Options
+if TYPE_CHECKING:
+    from typing import Any
+    from collections.abc import Iterator
+
+    from pylint.typing import OptionDict, Options
+    from pylint.config.arguments_manager import _ArgumentsManager
 
 
 class _ArgumentsProvider:

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -11,13 +11,15 @@ from __future__ import annotations
 import abc
 import argparse
 import sys
-from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pylint import exceptions, extensions, interfaces, utils
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from typing import Any
+
     from pylint.config.help_formatter import _HelpFormatter
     from pylint.lint import PyLinter
     from pylint.lint.run import Run

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -19,8 +19,8 @@ from pylint.config.exceptions import (
 from pylint.utils import utils
 
 if TYPE_CHECKING:
-    from pylint.lint import PyLinter
     from pylint import reporters
+    from pylint.lint import PyLinter
 
 
 def _config_initialization(

--- a/pylint/config/config_initialization.py
+++ b/pylint/config/config_initialization.py
@@ -11,7 +11,6 @@ from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pylint import reporters
 from pylint.config.config_file_parser import _ConfigurationFileParser
 from pylint.config.exceptions import (
     ArgumentPreprocessingError,
@@ -21,6 +20,7 @@ from pylint.utils import utils
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
+    from pylint import reporters
 
 
 def _config_initialization(

--- a/pylint/config/deprecation_actions.py
+++ b/pylint/config/deprecation_actions.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import argparse
 import warnings
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
 
 
 class _OldNamesAction(argparse._StoreAction):

--- a/pylint/config/find_default_config_files.py
+++ b/pylint/config/find_default_config_files.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 import configparser
 import os
 import sys
-from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 RC_NAMES = (
     Path("pylintrc"),

--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -7,9 +7,8 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pylint import extensions, utils
 from pylint.config.argument import (
@@ -24,6 +23,9 @@ from pylint.config.callback_actions import _CallbackAction
 from pylint.config.exceptions import ArgumentPreprocessingError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from typing import Any
+
     from pylint.lint.run import Run
 
 

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -7,12 +7,16 @@ from __future__ import annotations
 import os
 import platform
 import sys
+from typing import TYPE_CHECKING
 
 import astroid
 import platformdirs
 
 from pylint.__pkginfo__ import __version__
-from pylint.typing import MessageTypesFullName
+
+if TYPE_CHECKING:
+    from pylint.typing import MessageTypesFullName
+
 
 PY310_PLUS = sys.version_info[:2] >= (3, 10)
 PY311_PLUS = sys.version_info[:2] >= (3, 11)

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -8,13 +8,16 @@ from __future__ import annotations
 
 import itertools
 import re
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import nodes
 from astroid.util import UninferableBase
 
 from pylint.checkers import utils
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def space_indentation(s: str) -> int:

--- a/pylint/extensions/check_elif.py
+++ b/pylint/extensions/check_elif.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import tokenize
-from tokenize import TokenInfo
 from typing import TYPE_CHECKING
 
 from astroid import nodes
@@ -15,6 +13,9 @@ from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import HIGH
 
 if TYPE_CHECKING:
+    import tokenize
+    from tokenize import TokenInfo
+
     from pylint.lint import PyLinter
 
 

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, cast
 
 from astroid import nodes
@@ -14,12 +13,14 @@ from pylint.checkers.utils import only_required_for_messages, safe_infer
 from pylint.interfaces import INFERENCE
 
 if TYPE_CHECKING:
+    import sys
+
     from pylint.lint import PyLinter
 
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard
-else:
-    from typing_extensions import TypeGuard
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard
+    else:
+        from typing_extensions import TypeGuard
 
 
 class CodeStyleChecker(BaseChecker):

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -10,15 +10,16 @@ import re
 from typing import TYPE_CHECKING
 
 import astroid
-from astroid import nodes
 
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils as checker_utils
 from pylint.extensions import _check_docs_utils as utils
-from pylint.extensions._check_docs_utils import Docstring
 from pylint.interfaces import HIGH
 
 if TYPE_CHECKING:
+    from astroid import nodes
+
+    from pylint.extensions._check_docs_utils import Docstring
     from pylint.lint import PyLinter
 
 

--- a/pylint/extensions/docstyle.py
+++ b/pylint/extensions/docstyle.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 import linecache
 from typing import TYPE_CHECKING
 
-from astroid import nodes
 
 from pylint import checkers
 from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import HIGH
 
 if TYPE_CHECKING:
+    from astroid import nodes
+
     from pylint.lint import PyLinter
 
 

--- a/pylint/extensions/docstyle.py
+++ b/pylint/extensions/docstyle.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import linecache
 from typing import TYPE_CHECKING
 
-
 from pylint import checkers
 from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import HIGH

--- a/pylint/extensions/dunder.py
+++ b/pylint/extensions/dunder.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from astroid import nodes
-
 from pylint.checkers import BaseChecker
 from pylint.constants import DUNDER_METHODS, DUNDER_PROPERTIES, EXTRA_DUNDER_METHODS
 from pylint.interfaces import HIGH
 
 if TYPE_CHECKING:
+    from astroid import nodes
+
     from pylint.lint import PyLinter
 
 

--- a/pylint/extensions/empty_comment.py
+++ b/pylint/extensions/empty_comment.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from astroid import nodes
-
 from pylint.checkers import BaseRawFileChecker
 
 if TYPE_CHECKING:
+    from astroid import nodes
+
     from pylint.lint import PyLinter
 
 

--- a/pylint/extensions/eq_without_hash.py
+++ b/pylint/extensions/eq_without_hash.py
@@ -9,11 +9,17 @@ behind us, but some checks are still useful in python3 after all.
 See https://github.com/pylint-dev/pylint/issues/5025
 """
 
-from astroid import nodes
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from pylint import checkers, interfaces
 from pylint.checkers import utils
-from pylint.lint import PyLinter
+
+if TYPE_CHECKING:
+    from astroid import nodes
+
+    from pylint.lint import PyLinter
 
 
 class EqWithoutHash(checkers.BaseChecker):

--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -6,8 +6,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, TypeVar, Union
+from typing import TYPE_CHECKING
 
 from astroid import nodes
 from mccabe import PathGraph as Mccabe_PathGraph
@@ -18,31 +17,34 @@ from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import HIGH
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any, TypeVar, Union
+
     from pylint.lint import PyLinter
 
-_StatementNodes = Union[
-    nodes.Assert,
-    nodes.Assign,
-    nodes.AugAssign,
-    nodes.Delete,
-    nodes.Raise,
-    nodes.Yield,
-    nodes.Import,
-    nodes.Call,
-    nodes.Subscript,
-    nodes.Pass,
-    nodes.Continue,
-    nodes.Break,
-    nodes.Global,
-    nodes.Return,
-    nodes.Expr,
-    nodes.Await,
-]
+    _StatementNodes = Union[
+        nodes.Assert,
+        nodes.Assign,
+        nodes.AugAssign,
+        nodes.Delete,
+        nodes.Raise,
+        nodes.Yield,
+        nodes.Import,
+        nodes.Call,
+        nodes.Subscript,
+        nodes.Pass,
+        nodes.Continue,
+        nodes.Break,
+        nodes.Global,
+        nodes.Return,
+        nodes.Expr,
+        nodes.Await,
+    ]
 
-_SubGraphNodes = Union[nodes.If, nodes.Try, nodes.For, nodes.While]
-_AppendableNodeT = TypeVar(
-    "_AppendableNodeT", bound=Union[_StatementNodes, nodes.While, nodes.FunctionDef]
-)
+    _SubGraphNodes = Union[nodes.If, nodes.Try, nodes.For, nodes.While]
+    _AppendableNodeT = TypeVar(
+        "_AppendableNodeT", bound=Union[_StatementNodes, nodes.While, nodes.FunctionDef]
+    )
 
 
 class PathGraph(Mccabe_PathGraph):  # type: ignore[misc]

--- a/pylint/extensions/overlapping_exceptions.py
+++ b/pylint/extensions/overlapping_exceptions.py
@@ -6,16 +6,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import astroid
-from astroid import nodes, util
+from astroid import util
 
 from pylint import checkers
 from pylint.checkers import utils
 from pylint.checkers.exceptions import _annotated_unpack_infer
 
 if TYPE_CHECKING:
+    from typing import Any
+
+    from astroid import nodes
+
     from pylint.lint import PyLinter
 
 

--- a/pylint/extensions/redefined_loop_name.py
+++ b/pylint/extensions/redefined_loop_name.py
@@ -6,12 +6,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from astroid import nodes
 
 from pylint import checkers
 from pylint.checkers import utils
 from pylint.interfaces import HIGH
-from pylint.lint import PyLinter
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
 
 
 class RedefinedLoopNameChecker(checkers.BaseChecker):

--- a/pylint/extensions/while_used.py
+++ b/pylint/extensions/while_used.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from astroid import nodes
-
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
 
 if TYPE_CHECKING:
+    from astroid import nodes
+
     from pylint.lint import PyLinter
 
 

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -14,8 +14,11 @@ import os
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+    from collections.abc import Sequence
 
 
 def target_info_from_filename(filename: str) -> tuple[str, str, str]:

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -17,8 +17,8 @@ import tempfile
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Sequence
+    from typing import Any
 
 
 def target_info_from_filename(filename: str) -> tuple[str, str, str]:

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -28,9 +28,9 @@ from pylint.config.callback_actions import (
     _MessageHelpAction,
     _OutputFormatAction,
 )
-from pylint.typing import Options
 
 if TYPE_CHECKING:
+    from pylint.typing import Options
     from pylint.lint import PyLinter, Run
 
 

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -30,8 +30,8 @@ from pylint.config.callback_actions import (
 )
 
 if TYPE_CHECKING:
-    from pylint.typing import Options
     from pylint.lint import PyLinter, Run
+    from pylint.typing import Options
 
 
 def _make_linter_options(linter: PyLinter) -> Options:

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -6,13 +6,16 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Sequence
 from pathlib import Path
-from re import Pattern
+from typing import TYPE_CHECKING
 
 from astroid import modutils
 
-from pylint.typing import ErrorDescriptionDict, ModuleDescriptionDict
+if TYPE_CHECKING:
+    from re import Pattern
+    from collections.abc import Sequence
+
+    from pylint.typing import ErrorDescriptionDict, ModuleDescriptionDict
 
 
 def _modpath_from_file(filename: str, is_namespace: bool, path: list[str]) -> list[str]:

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING
 from astroid import modutils
 
 if TYPE_CHECKING:
-    from re import Pattern
     from collections.abc import Sequence
+    from re import Pattern
 
     from pylint.typing import ErrorDescriptionDict, ModuleDescriptionDict
 

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import tokenize
 from collections import defaultdict
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pylint import exceptions, interfaces
 from pylint.constants import (
@@ -17,8 +17,7 @@ from pylint.constants import (
     MSG_TYPES_LONG,
 )
 from pylint.interfaces import HIGH
-from pylint.message import MessageDefinition
-from pylint.typing import ManagedMessage, MessageDefinitionTuple
+from pylint.typing import ManagedMessage
 from pylint.utils.pragma_parser import (
     OPTION_PO,
     InvalidPragmaError,
@@ -27,7 +26,11 @@ from pylint.utils.pragma_parser import (
 )
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from pylint.lint.pylinter import PyLinter
+    from pylint.message import MessageDefinition
+    from pylint.typing import MessageDefinitionTuple
 
 
 class _MessageStateHandler:

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -25,8 +25,8 @@ except ImportError:
     ProcessPoolExecutor = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Iterable, Sequence
+    from typing import Any
 
     from pylint.lint import PyLinter
     from pylint.message import Message

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -6,16 +6,13 @@ from __future__ import annotations
 
 import functools
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import dill
 
 from pylint import reporters
 from pylint.lint.utils import _augment_sys_path
-from pylint.message import Message
-from pylint.typing import FileItem
-from pylint.utils import LinterStats, merge_stats
+from pylint.utils import merge_stats
 
 try:
     import multiprocessing
@@ -28,7 +25,13 @@ except ImportError:
     ProcessPoolExecutor = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
+    from typing import Any
+    from collections.abc import Iterable, Sequence
+
     from pylint.lint import PyLinter
+    from pylint.message import Message
+    from pylint.typing import FileItem
+    from pylint.utils import LinterStats
 
 # PyLinter object used by worker processes when checking files using parallel mode
 # should only be used by the worker processes

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import argparse
-import collections
 import contextlib
 import functools
 import os
@@ -13,15 +11,11 @@ import sys
 import tokenize
 import traceback
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator, Sequence
 from io import TextIOWrapper
 from pathlib import Path
-from re import Pattern
-from types import ModuleType
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import astroid
-from astroid import nodes
 
 from pylint import checkers, exceptions, interfaces, reporters
 from pylint.checkers.base_checker import BaseChecker
@@ -52,20 +46,34 @@ from pylint.lint.utils import (
     get_fatal_error_message,
     prepare_crash_report,
 )
-from pylint.message import Message, MessageDefinition, MessageDefinitionStore
+from pylint.message import Message, MessageDefinitionStore
 from pylint.reporters.base_reporter import BaseReporter
 from pylint.reporters.text import TextReporter
 from pylint.reporters.ureports import nodes as report_nodes
 from pylint.typing import (
-    DirectoryNamespaceDict,
     FileItem,
-    ManagedMessage,
-    MessageDefinitionTuple,
     MessageLocationTuple,
-    ModuleDescriptionDict,
-    Options,
 )
 from pylint.utils import ASTWalker, FileState, LinterStats, utils
+
+if TYPE_CHECKING:
+    import argparse
+    from re import Pattern
+    from types import ModuleType
+    from typing import Any
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+
+    from astroid import nodes
+
+    from pylint.message import MessageDefinition
+    from pylint.typing import (
+        DirectoryNamespaceDict,
+        ManagedMessage,
+        MessageDefinitionTuple,
+        ModuleDescriptionDict,
+        Options,
+    )
+
 
 MANAGER = astroid.MANAGER
 
@@ -255,7 +263,7 @@ class PyLinter(
     _ArgumentsManager,
     _MessageStateHandler,
     reporters.ReportsHandlerMixIn,
-    checkers.BaseChecker,
+    BaseChecker,
 ):
     """Lint Python modules using external checkers.
 
@@ -307,9 +315,7 @@ class PyLinter(
         """Dictionary of possible but non-initialized reporters."""
 
         # Attributes for checkers and plugins
-        self._checkers: defaultdict[str, list[checkers.BaseChecker]] = (
-            collections.defaultdict(list)
-        )
+        self._checkers: defaultdict[str, list[BaseChecker]] = defaultdict(list)
         """Dictionary of registered and initialized checkers."""
         self._dynamic_plugins: dict[str, ModuleType | ModuleNotFoundError | bool] = {}
         """Set of loaded plugin names."""
@@ -331,7 +337,7 @@ class PyLinter(
         self._error_mode = False
 
         reporters.ReportsHandlerMixIn.__init__(self)
-        checkers.BaseChecker.__init__(self, self)
+        BaseChecker.__init__(self, self)
         # provided reports
         self.reports = (
             ("RP0001", "Messages by category", report_total_messages_stats),
@@ -482,7 +488,7 @@ class PyLinter(
 
     # checkers manipulation methods ############################################
 
-    def register_checker(self, checker: checkers.BaseChecker) -> None:
+    def register_checker(self, checker: BaseChecker) -> None:
         """This method auto registers the checker."""
         self._checkers[checker.name].append(checker)
         for r_id, r_title, r_cb in checker.reports:
@@ -1313,4 +1319,4 @@ class PyLinter(
                     line=0,
                     confidence=HIGH,
                 )
-        self._stashed_messages = collections.defaultdict(list)
+        self._stashed_messages = defaultdict(list)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -50,18 +50,15 @@ from pylint.message import Message, MessageDefinitionStore
 from pylint.reporters.base_reporter import BaseReporter
 from pylint.reporters.text import TextReporter
 from pylint.reporters.ureports import nodes as report_nodes
-from pylint.typing import (
-    FileItem,
-    MessageLocationTuple,
-)
+from pylint.typing import FileItem, MessageLocationTuple
 from pylint.utils import ASTWalker, FileState, LinterStats, utils
 
 if TYPE_CHECKING:
     import argparse
+    from collections.abc import Callable, Iterable, Iterator, Sequence
     from re import Pattern
     from types import ModuleType
     from typing import Any
-    from collections.abc import Callable, Iterable, Iterator, Sequence
 
     from astroid import nodes
 

--- a/pylint/lint/report_functions.py
+++ b/pylint/lint/report_functions.py
@@ -5,16 +5,15 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import cast
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from pylint import checkers, exceptions
 from pylint.reporters.ureports.nodes import Table
 from pylint.typing import MessageTypesFullName
 
 if TYPE_CHECKING:
-    from pylint.utils import LinterStats
     from pylint.reporters.ureports.nodes import Section
+    from pylint.utils import LinterStats
 
 
 def report_total_messages_stats(

--- a/pylint/lint/report_functions.py
+++ b/pylint/lint/report_functions.py
@@ -4,14 +4,17 @@
 
 from __future__ import annotations
 
-import collections
 from collections import defaultdict
 from typing import cast
+from typing import TYPE_CHECKING
 
 from pylint import checkers, exceptions
-from pylint.reporters.ureports.nodes import Section, Table
+from pylint.reporters.ureports.nodes import Table
 from pylint.typing import MessageTypesFullName
-from pylint.utils import LinterStats
+
+if TYPE_CHECKING:
+    from pylint.utils import LinterStats
+    from pylint.reporters.ureports.nodes import Section
 
 
 def report_total_messages_stats(
@@ -54,7 +57,7 @@ def report_messages_by_module_stats(
     if len(module_stats) == 1:
         # don't print this report when we are analysing a single module
         raise exceptions.EmptyReportError()
-    by_mod: defaultdict[str, dict[str, int | float]] = collections.defaultdict(dict)
+    by_mod: defaultdict[str, dict[str, int | float]] = defaultdict(dict)
     for m_type in ("fatal", "error", "warning", "refactor", "convention"):
         m_type = cast(MessageTypesFullName, m_type)
         total = stats.get_global_message_count(m_type)

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 import os
 import sys
 import warnings
-from collections.abc import Sequence
 from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING
 
 from pylint import config
 from pylint.checkers.utils import clear_lru_caches
@@ -23,7 +22,13 @@ from pylint.config.utils import _preprocess_options
 from pylint.constants import full_version
 from pylint.lint.base_options import _make_run_options
 from pylint.lint.pylinter import MANAGER, PyLinter
-from pylint.reporters.base_reporter import BaseReporter
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+    from collections.abc import Sequence
+
+    from pylint.reporters.base_reporter import BaseReporter
+
 
 try:
     import multiprocessing

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -24,8 +24,8 @@ from pylint.lint.base_options import _make_run_options
 from pylint.lint.pylinter import MANAGER, PyLinter
 
 if TYPE_CHECKING:
-    from typing import ClassVar
     from collections.abc import Sequence
+    from typing import ClassVar
 
     from pylint.reporters.base_reporter import BaseReporter
 

--- a/pylint/lint/utils.py
+++ b/pylint/lint/utils.py
@@ -8,11 +8,14 @@ import contextlib
 import platform
 import sys
 import traceback
-from collections.abc import Iterator, Sequence
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pylint.constants import PYLINT_HOME, full_version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
 
 
 def prepare_crash_report(ex: Exception, filepath: str, crash_file_path: str) -> Path:

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -5,10 +5,14 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
 
 from pylint.constants import MSG_TYPES
-from pylint.interfaces import UNDEFINED, Confidence
+from pylint.interfaces import UNDEFINED
 from pylint.typing import MessageLocationTuple
+
+if TYPE_CHECKING:
+    from pylint.interfaces import Confidence
 
 
 @dataclass(unsafe_hash=True)

--- a/pylint/message/message_definition.py
+++ b/pylint/message/message_definition.py
@@ -4,16 +4,17 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
-
-from astroid import nodes
 
 from pylint.constants import _SCOPE_EXEMPT, MSG_TYPES, WarningScope
 from pylint.exceptions import InvalidMessageError
 from pylint.utils import normalize_text
 
 if TYPE_CHECKING:
+    import sys
+
+    from astroid import nodes
+
     from pylint.checkers import BaseChecker
 
 

--- a/pylint/message/message_definition_store.py
+++ b/pylint/message/message_definition_store.py
@@ -6,16 +6,17 @@ from __future__ import annotations
 
 import collections
 import sys
-from collections.abc import Sequence, ValuesView
 from functools import cache
 from typing import TYPE_CHECKING
 
 from pylint.exceptions import UnknownMessageError
-from pylint.message.message_definition import MessageDefinition
 from pylint.message.message_id_store import MessageIdStore
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence, ValuesView
+
     from pylint.checkers import BaseChecker
+    from pylint.message.message_definition import MessageDefinition
 
 
 class MessageDefinitionStore:

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import NoReturn
+from typing import TYPE_CHECKING
 
 from pylint.exceptions import (
     DeletedMessageError,
@@ -18,6 +18,9 @@ from pylint.message._deleted_message_ids import (
     is_moved_msgid,
     is_moved_symbol,
 )
+
+if TYPE_CHECKING:
+    from typing import NoReturn
 
 
 class MessageIdStore:

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -6,17 +6,21 @@
 
 from __future__ import annotations
 
-import argparse
-from collections.abc import Generator
-from typing import Any
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import nodes
 from astroid.modutils import is_stdlib_module
 
 from pylint.pyreverse.diagrams import ClassDiagram, PackageDiagram
-from pylint.pyreverse.inspector import Linker, Project
 from pylint.pyreverse.utils import LocalsVisitor
+
+if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Generator
+    from typing import Any
+
+    from pylint.pyreverse.inspector import Linker, Project
 
 # diagram generators ##########################################################
 

--- a/pylint/pyreverse/diagrams.py
+++ b/pylint/pyreverse/diagrams.py
@@ -6,14 +6,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import nodes, util
 
 from pylint.checkers.utils import decorated_with_property, in_type_checking_block
 from pylint.pyreverse.utils import FilterMixIn
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
 
 
 class Figure:

--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -11,11 +11,13 @@ import subprocess
 import tempfile
 from enum import Enum
 from pathlib import Path
-
-from astroid import nodes
+from typing import TYPE_CHECKING
 
 from pylint.pyreverse.printer import EdgeType, Layout, NodeProperties, NodeType, Printer
 from pylint.pyreverse.utils import get_annotation_label
+
+if TYPE_CHECKING:
+    from astroid import nodes
 
 
 class HTMLLabels(Enum):

--- a/pylint/pyreverse/main.py
+++ b/pylint/pyreverse/main.py
@@ -7,8 +7,7 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Sequence
-from typing import NoReturn
+from typing import TYPE_CHECKING
 
 from pylint import constants
 from pylint.config.arguments_manager import _ArgumentsManager
@@ -23,7 +22,13 @@ from pylint.pyreverse.utils import (
     check_if_graphviz_supports_format,
     insert_default_options,
 )
-from pylint.typing import Options
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import NoReturn
+
+    from pylint.typing import Options
+
 
 DIRECTLY_SUPPORTED_FORMATS = (
     "dot",

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import NamedTuple
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from pylint.pyreverse.utils import get_annotation_label
 

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import NamedTuple
-
-from astroid import nodes
+from typing import TYPE_CHECKING
 
 from pylint.pyreverse.utils import get_annotation_label
+
+if TYPE_CHECKING:
+    from astroid import nodes
 
 
 class NodeType(Enum):

--- a/pylint/pyreverse/printer_factory.py
+++ b/pylint/pyreverse/printer_factory.py
@@ -4,10 +4,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pylint.pyreverse.dot_printer import DotPrinter
 from pylint.pyreverse.mermaidjs_printer import HTMLMermaidJSPrinter, MermaidJSPrinter
 from pylint.pyreverse.plantuml_printer import PlantUmlPrinter
-from pylint.pyreverse.printer import Printer
+
+if TYPE_CHECKING:
+    from pylint.pyreverse.printer import Printer
+
 
 filetype_to_printer: dict[str, type[Printer]] = {
     "plantuml": PlantUmlPrinter,

--- a/pylint/pyreverse/utils.py
+++ b/pylint/pyreverse/utils.py
@@ -11,14 +11,17 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING
 
 import astroid
 from astroid import nodes
-from astroid.typing import InferenceResult
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any, Optional, Union
+
+    from astroid.typing import InferenceResult
+
     from pylint.pyreverse.diagrams import ClassDiagram, PackageDiagram
 
     _CallbackT = Callable[

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -6,24 +6,29 @@
 
 from __future__ import annotations
 
-import argparse
 import itertools
 import os
 from collections import defaultdict
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from astroid import modutils, nodes
 
-from pylint.pyreverse.diagrams import (
-    ClassDiagram,
-    ClassEntity,
-    DiagramEntity,
-    PackageDiagram,
-    PackageEntity,
-)
-from pylint.pyreverse.printer import EdgeType, NodeProperties, NodeType, Printer
+from pylint.pyreverse.diagrams import PackageDiagram
+from pylint.pyreverse.printer import EdgeType, NodeProperties, NodeType
 from pylint.pyreverse.printer_factory import get_printer_for_filetype
 from pylint.pyreverse.utils import is_exception
+
+if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Iterable
+
+    from pylint.pyreverse.diagrams import (
+        ClassDiagram,
+        ClassEntity,
+        DiagramEntity,
+        PackageEntity,
+    )
+    from pylint.pyreverse.printer import Printer
 
 
 class DiagramWriter:

--- a/pylint/reporters/base_reporter.py
+++ b/pylint/reporters/base_reporter.py
@@ -6,15 +6,17 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import TYPE_CHECKING, TextIO
+from typing import TYPE_CHECKING
 
-from pylint.message import Message
 from pylint.reporters.ureports.nodes import Text
-from pylint.utils import LinterStats
 
 if TYPE_CHECKING:
+    from typing import TextIO
+
     from pylint.lint.pylinter import PyLinter
+    from pylint.message import Message
     from pylint.reporters.ureports.nodes import Section
+    from pylint.utils import LinterStats
 
 
 class BaseReporter:

--- a/pylint/reporters/multi_reporter.py
+++ b/pylint/reporters/multi_reporter.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
     from pylint.lint import PyLinter
     from pylint.message import Message
-    from pylint.reporters.ureports.nodes import Section
     from pylint.reporters.base_reporter import BaseReporter
+    from pylint.reporters.ureports.nodes import Section
     from pylint.utils import LinterStats
 
 

--- a/pylint/reporters/multi_reporter.py
+++ b/pylint/reporters/multi_reporter.py
@@ -5,17 +5,18 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
 from copy import copy
-from typing import TYPE_CHECKING, TextIO
-
-from pylint.message import Message
-from pylint.reporters.base_reporter import BaseReporter
-from pylint.utils import LinterStats
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import TextIO
+
     from pylint.lint import PyLinter
+    from pylint.message import Message
     from pylint.reporters.ureports.nodes import Section
+    from pylint.reporters.base_reporter import BaseReporter
+    from pylint.utils import LinterStats
 
 
 class MultiReporter:

--- a/pylint/reporters/reports_handler_mix_in.py
+++ b/pylint/reporters/reports_handler_mix_in.py
@@ -5,21 +5,23 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import MutableSequence
 from typing import TYPE_CHECKING
 
 from pylint.exceptions import EmptyReportError
 from pylint.reporters.ureports.nodes import Section
 from pylint.typing import ReportsCallable
-from pylint.utils import LinterStats
 
 if TYPE_CHECKING:
+    from collections.abc import MutableSequence
+
     from pylint.checkers import BaseChecker
     from pylint.lint.pylinter import PyLinter
+    from pylint.utils import LinterStats
 
-ReportsDict = collections.defaultdict[
-    "BaseChecker", list[tuple[str, str, ReportsCallable]]
-]
+    ReportsDict = collections.defaultdict[
+        BaseChecker,
+        list[tuple[str, str, ReportsCallable]],
+    ]
 
 
 class ReportsHandlerMixIn:

--- a/pylint/reporters/text.py
+++ b/pylint/reporters/text.py
@@ -15,13 +15,15 @@ import re
 import sys
 import warnings
 from dataclasses import asdict, fields
-from typing import TYPE_CHECKING, NamedTuple, TextIO
+from typing import TYPE_CHECKING, NamedTuple
 
 from pylint.message import Message
 from pylint.reporters import BaseReporter
 from pylint.reporters.ureports.text_writer import TextWriter
 
 if TYPE_CHECKING:
+    from typing import TextIO
+
     from pylint.lint import PyLinter
     from pylint.reporters.ureports.nodes import Section
 

--- a/pylint/reporters/ureports/base_writer.py
+++ b/pylint/reporters/ureports/base_writer.py
@@ -11,11 +11,13 @@ formatted as text and html.
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterator
 from io import StringIO
-from typing import TYPE_CHECKING, TextIO
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import TextIO
+
     from pylint.reporters.ureports.nodes import (
         BaseLayout,
         EvaluationSection,

--- a/pylint/reporters/ureports/nodes.py
+++ b/pylint/reporters/ureports/nodes.py
@@ -9,14 +9,17 @@ A micro report is a tree of layout and content objects.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING
 
-from pylint.reporters.ureports.base_writer import BaseWriter
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+    from typing import Any, TypeVar
 
-_T = TypeVar("_T")
-_VNodeT = TypeVar("_VNodeT", bound="VNode")
-VisitLeaveFunction = Callable[[_T, Any, Any], None]
+    from pylint.reporters.ureports.base_writer import BaseWriter
+
+    _T = TypeVar("_T")
+    _VNodeT = TypeVar("_VNodeT", bound="VNode")
+    VisitLeaveFunction = Callable[[_T, Any, Any], None]
 
 
 class VNode:

--- a/pylint/testutils/_primer/package_to_lint.py
+++ b/pylint/testutils/_primer/package_to_lint.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from git import GitCommandError
 from git.cmd import Git
 from git.repo import Repo
+
+if TYPE_CHECKING:
+    from typing import Literal
+
 
 PRIMER_DIRECTORY_PATH = Path("tests") / ".pylint_primer_tests"
 

--- a/pylint/testutils/_primer/primer.py
+++ b/pylint/testutils/_primer/primer.py
@@ -7,13 +7,17 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from pylint.testutils._primer import PackageToLint
-from pylint.testutils._primer.primer_command import PrimerCommand
 from pylint.testutils._primer.primer_compare_command import CompareCommand
 from pylint.testutils._primer.primer_prepare_command import PrepareCommand
 from pylint.testutils._primer.primer_run_command import RunCommand
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pylint.testutils._primer import PackageToLint
+    from pylint.testutils._primer.primer_command import PrimerCommand
 
 
 class Primer:

--- a/pylint/testutils/_primer/primer.py
+++ b/pylint/testutils/_primer/primer.py
@@ -9,6 +9,7 @@ import json
 import sys
 from typing import TYPE_CHECKING
 
+from pylint.testutils._primer import PackageToLint
 from pylint.testutils._primer.primer_compare_command import CompareCommand
 from pylint.testutils._primer.primer_prepare_command import PrepareCommand
 from pylint.testutils._primer.primer_run_command import RunCommand
@@ -16,7 +17,6 @@ from pylint.testutils._primer.primer_run_command import RunCommand
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pylint.testutils._primer import PackageToLint
     from pylint.testutils._primer.primer_command import PrimerCommand
 
 

--- a/pylint/testutils/_primer/primer_command.py
+++ b/pylint/testutils/_primer/primer_command.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import abc
-from typing import TypedDict, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     import argparse

--- a/pylint/testutils/_primer/primer_command.py
+++ b/pylint/testutils/_primer/primer_command.py
@@ -5,12 +5,14 @@
 from __future__ import annotations
 
 import abc
-import argparse
-from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, TYPE_CHECKING
 
-from pylint.reporters.json_reporter import OldJsonExport
-from pylint.testutils._primer import PackageToLint
+if TYPE_CHECKING:
+    import argparse
+    from pathlib import Path
+
+    from pylint.reporters.json_reporter import OldJsonExport
+    from pylint.testutils._primer import PackageToLint
 
 
 class PackageData(TypedDict):

--- a/pylint/testutils/_primer/primer_compare_command.py
+++ b/pylint/testutils/_primer/primer_compare_command.py
@@ -4,14 +4,19 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
 
-from pylint.reporters.json_reporter import OldJsonExport
 from pylint.testutils._primer.primer_command import (
     PackageData,
-    PackageMessages,
     PrimerCommand,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from pylint.reporters.json_reporter import OldJsonExport
+    from pylint.testutils._primer.primer_command import PackageMessages
+
 
 MAX_GITHUB_COMMENT_LENGTH = 65536
 

--- a/pylint/testutils/_primer/primer_compare_command.py
+++ b/pylint/testutils/_primer/primer_compare_command.py
@@ -7,13 +7,11 @@ import json
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
-from pylint.testutils._primer.primer_command import (
-    PackageData,
-    PrimerCommand,
-)
+from pylint.testutils._primer.primer_command import PackageData, PrimerCommand
 
 if TYPE_CHECKING:
     from pathlib import Path
+
     from pylint.reporters.json_reporter import OldJsonExport
     from pylint.testutils._primer.primer_command import PackageMessages
 

--- a/pylint/testutils/_primer/primer_run_command.py
+++ b/pylint/testutils/_primer/primer_run_command.py
@@ -14,10 +14,7 @@ from git.repo import Repo
 
 from pylint.lint import Run
 from pylint.reporters.json_reporter import JSONReporter
-from pylint.testutils._primer.primer_command import (
-    PackageData,
-    PrimerCommand,
-)
+from pylint.testutils._primer.primer_command import PackageData, PrimerCommand
 
 if TYPE_CHECKING:
     from pylint.message import Message

--- a/pylint/testutils/_primer/primer_run_command.py
+++ b/pylint/testutils/_primer/primer_run_command.py
@@ -8,18 +8,23 @@ import json
 import sys
 import warnings
 from io import StringIO
+from typing import TYPE_CHECKING
 
 from git.repo import Repo
 
 from pylint.lint import Run
-from pylint.message import Message
-from pylint.reporters.json_reporter import JSONReporter, OldJsonExport
-from pylint.testutils._primer.package_to_lint import PackageToLint
+from pylint.reporters.json_reporter import JSONReporter
 from pylint.testutils._primer.primer_command import (
     PackageData,
-    PackageMessages,
     PrimerCommand,
 )
+
+if TYPE_CHECKING:
+    from pylint.message import Message
+    from pylint.reporters.json_reporter import OldJsonExport
+    from pylint.testutils._primer.package_to_lint import PackageToLint
+    from pylint.testutils._primer.primer_command import PackageMessages
+
 
 GITHUB_CRASH_TEMPLATE_LOCATION = "/home/runner/.cache"
 CRASH_TEMPLATE_INTRO = "There is a pre-filled template"

--- a/pylint/testutils/_run.py
+++ b/pylint/testutils/_run.py
@@ -9,11 +9,15 @@ This module is considered private and can change at any time.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from pylint.lint import Run as LintRun
-from pylint.reporters.base_reporter import BaseReporter
 from pylint.testutils.lint_module_test import PYLINTRC
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pylint.reporters.base_reporter import BaseReporter
 
 
 def _add_rcfile_default_pylintrc(args: list[str]) -> list[str]:

--- a/pylint/testutils/checker_test_case.py
+++ b/pylint/testutils/checker_test_case.py
@@ -5,15 +5,19 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Generator, Iterator
-from typing import Any
-
-from astroid import nodes
+from typing import TYPE_CHECKING
 
 from pylint.testutils.global_test_linter import linter
-from pylint.testutils.output_line import MessageTest
 from pylint.testutils.unittest_linter import UnittestLinter
 from pylint.utils import ASTWalker
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
+    from typing import Any
+
+    from astroid import nodes
+
+    from pylint.testutils.output_line import MessageTest
 
 
 class CheckerTestCase:

--- a/pylint/testutils/decorator.py
+++ b/pylint/testutils/decorator.py
@@ -5,10 +5,13 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING
 
-from pylint.testutils.checker_test_case import CheckerTestCase
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    from pylint.testutils.checker_test_case import CheckerTestCase
 
 
 def set_config(**kwargs: Any) -> Callable[[Callable[..., None]], Callable[..., None]]:

--- a/pylint/testutils/functional/find_functional_tests.py
+++ b/pylint/testutils/functional/find_functional_tests.py
@@ -5,10 +5,14 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pylint.testutils.functional.test_file import FunctionalTestFile
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 REASONABLY_DISPLAYABLE_VERTICALLY = 49
 """'Wet finger' number of files that are reasonable to display by an IDE.

--- a/pylint/testutils/functional/lint_module_output_update.py
+++ b/pylint/testutils/functional/lint_module_output_update.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 
 import csv
 import os
+from typing import TYPE_CHECKING
 
-from pylint.testutils.lint_module_test import LintModuleTest, MessageCounter
-from pylint.testutils.output_line import OutputLine
+from pylint.testutils.lint_module_test import LintModuleTest
+
+if TYPE_CHECKING:
+    from pylint.testutils.lint_module_test import MessageCounter
+    from pylint.testutils.output_line import OutputLine
 
 
 class LintModuleOutputUpdate(LintModuleTest):

--- a/pylint/testutils/functional/test_file.py
+++ b/pylint/testutils/functional/test_file.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 import configparser
-from collections.abc import Callable
 from os.path import basename, exists, join
-from typing import TypedDict
+from typing import TypedDict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def parse_python_version(ver_str: str) -> tuple[int, ...]:

--- a/pylint/testutils/functional/test_file.py
+++ b/pylint/testutils/functional/test_file.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import configparser
 from os.path import basename, exists, join
-from typing import TypedDict, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -21,10 +21,7 @@ from pylint.lint import PyLinter
 from pylint.testutils.constants import _EXPECTED_RE, _OPERATORS, UPDATE_OPTION
 
 # need to import from functional.test_file to avoid cyclic import
-from pylint.testutils.functional.test_file import (
-    NoFileError,
-    parse_python_version,
-)
+from pylint.testutils.functional.test_file import NoFileError, parse_python_version
 from pylint.testutils.output_line import OutputLine
 from pylint.testutils.reporter_for_tests import FunctionalTestReporter
 

--- a/pylint/testutils/lint_module_test.py
+++ b/pylint/testutils/lint_module_test.py
@@ -11,27 +11,33 @@ import sys
 from collections import Counter
 from io import StringIO
 from pathlib import Path
-from typing import TextIO
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.config import Config
 
 from pylint import checkers
 from pylint.config.config_initialization import _config_initialization
 from pylint.lint import PyLinter
-from pylint.message.message import Message
 from pylint.testutils.constants import _EXPECTED_RE, _OPERATORS, UPDATE_OPTION
 
 # need to import from functional.test_file to avoid cyclic import
 from pylint.testutils.functional.test_file import (
-    FunctionalTestFile,
     NoFileError,
     parse_python_version,
 )
 from pylint.testutils.output_line import OutputLine
 from pylint.testutils.reporter_for_tests import FunctionalTestReporter
 
-MessageCounter = Counter[tuple[int, str]]
+if TYPE_CHECKING:
+    from typing import TextIO
+
+    from _pytest.config import Config
+
+    from pylint.message.message import Message
+    from pylint.testutils.functional.test_file import FunctionalTestFile
+
+    MessageCounter = Counter[tuple[int, str]]
+
 
 PYLINTRC = Path(__file__).parent / "testing_pylintrc"
 

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -4,15 +4,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, NamedTuple
 
-from astroid import nodes
+from pylint.interfaces import UNDEFINED
 
-from pylint.interfaces import UNDEFINED, Confidence
-from pylint.message.message import Message
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any, TypeVar
 
-_T = TypeVar("_T")
+    from astroid import nodes
+
+    from pylint.interfaces import Confidence
+    from pylint.message.message import Message
+
+    _T = TypeVar("_T")
 
 
 class MessageTest(NamedTuple):

--- a/pylint/testutils/pyreverse.py
+++ b/pylint/testutils/pyreverse.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 import argparse
 import configparser
 import shlex
-from pathlib import Path
-from typing import NamedTuple, TypedDict
+from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 from pylint.pyreverse.main import DEFAULT_COLOR_PALETTE
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 # This class could and should be replaced with a simple dataclass when support for Python < 3.7 is dropped.

--- a/pylint/testutils/reporter_for_tests.py
+++ b/pylint/testutils/reporter_for_tests.py
@@ -8,10 +8,10 @@ from io import StringIO
 from os import getcwd, sep
 from typing import TYPE_CHECKING
 
-from pylint.message import Message
 from pylint.reporters import BaseReporter
 
 if TYPE_CHECKING:
+    from pylint.message import Message
     from pylint.reporters.ureports.nodes import Section
 
 

--- a/pylint/testutils/tokenize_str.py
+++ b/pylint/testutils/tokenize_str.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 import tokenize
 from io import StringIO
-from tokenize import TokenInfo
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tokenize import TokenInfo
 
 
 def _tokenize_str(code: str) -> list[TokenInfo]:

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -6,13 +6,18 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING
 
-from astroid import nodes
-
-from pylint.interfaces import UNDEFINED, Confidence
+from pylint.interfaces import UNDEFINED
 from pylint.lint import PyLinter
 from pylint.testutils.output_line import MessageTest
+
+if TYPE_CHECKING:
+    from typing import Any, Literal
+
+    from astroid import nodes
+
+    from pylint.interfaces import Confidence
 
 
 class UnittestLinter(PyLinter):

--- a/pylint/testutils/utils.py
+++ b/pylint/testutils/utils.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-from collections.abc import Generator, Iterator
 from copy import copy
-from pathlib import Path
-from typing import TextIO
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterator
+    from pathlib import Path
+    from typing import TextIO
 
 
 @contextlib.contextmanager

--- a/pylint/utils/docs.py
+++ b/pylint/utils/docs.py
@@ -7,12 +7,14 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, TextIO
+from typing import TYPE_CHECKING
 
 from pylint.constants import MAIN_CHECKER_NAME
 from pylint.utils.utils import get_rst_section, get_rst_title
 
 if TYPE_CHECKING:
+    from typing import Any, TextIO
+
     from pylint.lint.pylinter import PyLinter
 
 

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -4,10 +4,8 @@
 
 from __future__ import annotations
 
-import collections
 from collections import defaultdict
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from astroid import nodes
 
@@ -18,6 +16,9 @@ from pylint.constants import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Literal
+
     from pylint.message import MessageDefinition, MessageDefinitionStore
 
 
@@ -38,9 +39,7 @@ class FileState:
         self.base_name = modname
         self._module_msgs_state: MessageStateDict = {}
         self._raw_module_msgs_state: MessageStateDict = {}
-        self._ignored_msgs: defaultdict[tuple[str, int], set[int]] = (
-            collections.defaultdict(set)
-        )
+        self._ignored_msgs: defaultdict[tuple[str, int], set[int]] = defaultdict(set)
         self._suppression_mapping: dict[tuple[str, int], int] = {}
         self._module = node
         if node:

--- a/pylint/utils/linterstats.py
+++ b/pylint/utils/linterstats.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict, cast
+from typing import Literal, TypedDict, cast, TYPE_CHECKING
 
-from pylint.typing import MessageTypesFullName
+if TYPE_CHECKING:
+    from pylint.typing import MessageTypesFullName
 
 
 class BadNames(TypedDict):

--- a/pylint/utils/linterstats.py
+++ b/pylint/utils/linterstats.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
 if TYPE_CHECKING:
     from pylint.typing import MessageTypesFullName

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import re
-from typing import NamedTuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/pylint/utils/pragma_parser.py
+++ b/pylint/utils/pragma_parser.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Generator
-from typing import NamedTuple
+from typing import NamedTuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 # Allow stopping after the first semicolon/hash encountered,
 # so that an option can be continued with the reasons

--- a/pylint/utils/utils.py
+++ b/pylint/utils/utils.py
@@ -14,7 +14,6 @@ except ImportError:  # isort < 5
 
     HAS_ISORT_5 = False
 
-import argparse
 import codecs
 import os
 import re
@@ -23,18 +22,24 @@ import textwrap
 import tokenize
 import warnings
 from collections import deque
-from collections.abc import Iterable, Sequence
-from io import BufferedReader, BytesIO
 from re import Pattern
-from typing import TYPE_CHECKING, Any, Literal, TextIO, TypeVar, Union
+from typing import TYPE_CHECKING, Literal, TypeVar, Union
 
-from astroid import Module, modutils, nodes
+from astroid import Module, modutils
 
 from pylint.constants import PY_EXTS
-from pylint.typing import OptionDict
 
 if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Iterable, Sequence
+    from io import BufferedReader, BytesIO
+    from typing import Any, TextIO
+
+    from astroid import nodes
+
     from pylint.lint import PyLinter
+    from pylint.typing import OptionDict
+
 
 DEFAULT_LINE_LENGTH = 79
 


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Putting https://github.com/pylint-dev/pylint/pull/9964 to the test. Move typechecking imports behind `TYPE_CHECKING`. Also move a few type aliases. The idea is to move out anything that isn't used at runtime.

Similar to https://github.com/pylint-dev/astroid/pull/2585