### PR TITLE
Suggest disabling `ungrouped-imports` in FAQ when using `isort`

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -107,7 +107,7 @@ pydocstyle_: missing-module-docstring, missing-class-docstring, missing-function
 
 pep8-naming_: invalid-name, bad-classmethod-argument, bad-mcs-classmethod-argument, no-self-argument
 
-isort_ and flake8-import-order_: wrong-import-order
+isort_ and flake8-import-order_: ungrouped-imports, wrong-import-order
 
 .. _`pycodestyle`: https://github.com/PyCQA/pycodestyle
 .. _`pyflakes`: https://github.com/PyCQA/pyflakes


### PR DESCRIPTION
`isort` can be pretty flexible about grouping the imports, and sometimes its configuration may be incompatible with not only `wrong-imports-order` but with the `ungrouped-imports` rule too.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

$sbj.