### PR TITLE
Fix test imports

### DIFF
--- a/pylint/testutils/pyreverse.py
+++ b/pylint/testutils/pyreverse.py
@@ -8,9 +8,20 @@ import argparse
 import configparser
 import shlex
 from pathlib import Path
-from typing import NamedTuple, TypedDict
+from typing import NamedTuple, TypedDict, Protocol, TYPE_CHECKING
 
 from pylint.pyreverse.main import DEFAULT_COLOR_PALETTE
+
+if TYPE_CHECKING:
+    from pylint.pyreverse.inspector import Project
+
+
+class GetProjectCallable(Protocol):
+    def __call__(
+        self,
+        module: str,
+        name: str | None = "No Name",
+    ) -> Project: ...  # pragma: no cover
 
 
 # This class could and should be replaced with a simple dataclass when support for Python < 3.7 is dropped.

--- a/pylint/testutils/pyreverse.py
+++ b/pylint/testutils/pyreverse.py
@@ -8,7 +8,7 @@ import argparse
 import configparser
 import shlex
 from pathlib import Path
-from typing import NamedTuple, TypedDict, Protocol, TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple, Protocol, TypedDict
 
 from pylint.pyreverse.main import DEFAULT_COLOR_PALETTE
 

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -17,14 +17,12 @@ from typing import (
     Literal,
     NamedTuple,
     Optional,
-    Protocol,
     TypedDict,
     Union,
 )
 
 if TYPE_CHECKING:
     from pylint.config.callback_actions import _CallbackAction
-    from pylint.pyreverse.inspector import Project
     from pylint.reporters.ureports.nodes import Section
     from pylint.utils import LinterStats
 
@@ -127,9 +125,3 @@ MessageDefinitionTuple = Union[
     tuple[str, str, str, ExtraMessageOptions],
 ]
 DirectoryNamespaceDict = dict[Path, tuple[argparse.Namespace, "DirectoryNamespaceDict"]]
-
-
-class GetProjectCallable(Protocol):
-    def __call__(
-        self, module: str, name: str | None = "No Name"
-    ) -> Project: ...  # pragma: no cover

--- a/tests/benchmark/test_baseline_benchmarks.py
+++ b/tests/benchmark/test_baseline_benchmarks.py
@@ -6,14 +6,16 @@
 
 # pylint: disable=missing-function-docstring
 
+from __future__ import annotations
+
 import os
 import pprint
 import time
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 from astroid import nodes
-from pytest_benchmark.fixture import BenchmarkFixture
 
 from pylint.checkers import BaseRawFileChecker
 from pylint.lint import PyLinter, check_parallel
@@ -21,6 +23,9 @@ from pylint.testutils import GenericTestReporter as Reporter
 from pylint.testutils._run import _Run as Run
 from pylint.typing import FileItem
 from pylint.utils import register_plugins
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
 
 
 def _empty_filepath() -> str:

--- a/tests/pyreverse/conftest.py
+++ b/tests/pyreverse/conftest.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
 from astroid.nodes.scoped_nodes import Module
@@ -12,7 +13,9 @@ from astroid.nodes.scoped_nodes import Module
 from pylint.lint import augmented_sys_path, discover_package_path
 from pylint.pyreverse.inspector import Project, project_from_files
 from pylint.testutils.pyreverse import PyreverseConfig
-from pylint.typing import GetProjectCallable
+
+if TYPE_CHECKING:
+    from pylint.testutils.pyreverse import GetProjectCallable
 
 
 @pytest.fixture()
@@ -73,7 +76,9 @@ def get_project() -> GetProjectCallable:
         """Return an astroid project representation."""
 
         def _astroid_wrapper(
-            func: Callable[[str], Module], modname: str, _verbose: bool = False
+            func: Callable[[str], Module],
+            modname: str,
+            _verbose: bool = False,
         ) -> Module:
             return func(modname)
 

--- a/tests/pyreverse/test_diadefs.py
+++ b/tests/pyreverse/test_diadefs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from astroid import extract_node, nodes
@@ -24,7 +25,10 @@ from pylint.pyreverse.diagrams import DiagramEntity, Relationship
 from pylint.pyreverse.inspector import Linker, Project
 from pylint.testutils.pyreverse import PyreverseConfig
 from pylint.testutils.utils import _test_cwd
-from pylint.typing import GetProjectCallable
+
+if TYPE_CHECKING:
+    from pylint.testutils.pyreverse import GetProjectCallable
+
 
 HERE = Path(__file__)
 TESTS = HERE.parent.parent

--- a/tests/pyreverse/test_diagrams.py
+++ b/tests/pyreverse/test_diagrams.py
@@ -6,10 +6,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pylint.pyreverse.diadefslib import DefaultDiadefGenerator, DiadefsHandler
 from pylint.pyreverse.inspector import Linker
 from pylint.testutils.pyreverse import PyreverseConfig
-from pylint.typing import GetProjectCallable
+
+if TYPE_CHECKING:
+    from pylint.testutils.pyreverse import GetProjectCallable
 
 
 def test_property_handling(

--- a/tests/pyreverse/test_inspector.py
+++ b/tests/pyreverse/test_inspector.py
@@ -12,6 +12,7 @@ import os
 import warnings
 from collections.abc import Generator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import astroid
 import pytest
@@ -19,7 +20,10 @@ import pytest
 from pylint.pyreverse import inspector
 from pylint.pyreverse.inspector import Project
 from pylint.testutils.utils import _test_cwd
-from pylint.typing import GetProjectCallable
+
+if TYPE_CHECKING:
+    from pylint.testutils.pyreverse import GetProjectCallable
+
 
 HERE = Path(__file__)
 TESTS = HERE.parent.parent

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator
 from difflib import unified_diff
 from pathlib import Path
 from unittest.mock import Mock
+from typing import TYPE_CHECKING
 
 import pytest
 from pytest import MonkeyPatch
@@ -20,7 +21,10 @@ from pylint.pyreverse.diadefslib import DefaultDiadefGenerator, DiadefsHandler
 from pylint.pyreverse.inspector import Linker, Project
 from pylint.pyreverse.writer import DiagramWriter
 from pylint.testutils.pyreverse import PyreverseConfig
-from pylint.typing import GetProjectCallable
+
+if TYPE_CHECKING:
+    from pylint.testutils.pyreverse import GetProjectCallable
+
 
 _DEFAULTS = {
     "all_ancestors": None,

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -11,8 +11,8 @@ import os
 from collections.abc import Iterator
 from difflib import unified_diff
 from pathlib import Path
-from unittest.mock import Mock
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import pytest
 from pytest import MonkeyPatch


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Trying to run `pytest` locally without `git` package installed raises `ModuleNotFoundError`, even though primer is not run locally. Similar for `pytest_benchmark`.

This MR delays imports from `git` until they are actually used. The `pytest_benchmark` import was only used for typechecking, so it is pushed under `TYPE_CHECKING` flag. (This is yet another benefit to separating typechecking imports from runtime imports.)