### PR TITLE
Bump astroid ceiling

### DIFF
--- a/doc/data/messages/m/missing-format-argument-key/related.rst
+++ b/doc/data/messages/m/missing-format-argument-key/related.rst
@@ -1,2 +1,2 @@
 - `PEP 3101 <https://peps.python.org/pep-3101/>`_
-- `Custom String Formmating <https://docs.python.org/3/library/string.html#custom-string-formatting>`_
+- `Custom String Formatting <https://docs.python.org/3/library/string.html#custom-string-formatting>`_

--- a/doc/data/messages/t/too-few-format-args/related.rst
+++ b/doc/data/messages/t/too-few-format-args/related.rst
@@ -1,1 +1,1 @@
-- `String Formmating <https://docs.python.org/3/library/string.html#formatstrings>`_
+- `String Formatting <https://docs.python.org/3/library/string.html#formatstrings>`_

--- a/doc/data/messages/t/too-many-format-args/related.rst
+++ b/doc/data/messages/t/too-many-format-args/related.rst
@@ -1,1 +1,1 @@
-- `String Formmating <https://docs.python.org/3/library/string.html#formatstrings>`_
+- `String Formatting <https://docs.python.org/3/library/string.html#formatstrings>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.3.5,<=3.4.0-dev0",
+    "astroid>=3.3.5,<=4.0.0-dev0",
     "isort>=4.2.5,<6,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",


### PR DESCRIPTION
The "second minor update" of astroid is 4.0.0-dev0, not 3.4 (there will not be a 3.4 of pylint or astroid 🤞)