### PR TITLE
feat: Add option to list configuration values #9930

### DIFF
--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -426,6 +426,22 @@ def _make_linter_options(linter: PyLinter) -> Options:
                 "messages.",
             },
         ),
+        (
+            "config-list",
+            {
+                "action": "store_true",
+                "default": False,
+                "help": "Show current configuration values.",
+            },
+        ),
+        (
+            "config-list-show-origin",
+            {
+                "action": "store_true",
+                "default": False,
+                "help": "Show current configuration values along with their origin.",
+            },
+        ),
     )
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |



## Description
working on adding new config-related commands (pylint --config-list and pylint --config-list-show-origin) to help users debug Pylint configuration issues more easily. These commands will display the current configuration values and their origins, similar to how git config list and git config list --show-origin work.

We've added the corresponding options in base_options.py and are defining custom callback actions in callback_actions.py to handle these commands, ensuring that users can retrieve and verify their Pylint configuration setup in a clear and structured way.
<!-- If this PR references an issue without fixing it: -->



<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9930 
