### PR TITLE
Fix source root not recognized

### DIFF
--- a/doc/whatsnew/fragments/10026.bugfix
+++ b/doc/whatsnew/fragments/10026.bugfix
@@ -1,0 +1,3 @@
+Fixes the issue with --source-root option not working when the source files are in a subdirectory of the source root (e.g. when using a /src layout).
+
+Closes #10026

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -33,7 +33,7 @@ def discover_package_path(modulepath: str, source_roots: Sequence[str]) -> str:
     # Look for a source root that contains the module directory
     for source_root in source_roots:
         source_root = os.path.realpath(os.path.expanduser(source_root))
-        if os.path.commonpath([source_root, dirname]) == source_root:
+        if os.path.commonpath([source_root, dirname]) in [dirname, source_root]:
             return source_root
 
     # Fall back to legacy discovery by looking for __init__.py upwards as

--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -65,12 +65,12 @@ def test_project_root_in_sys_path() -> None:
         assert sys.path == [PROJECT_ROOT_DIR]
 
 
-def test_discover_package_path_source_root_as_parent(tmp_path) -> None:
+def test_discover_package_path_source_root_as_parent(tmp_path: Any) -> None:
     """Test discover_package_path when source root is a parent of the module."""
     # Create this temporary structure:
     # /tmp_path/
     # └── project/
-    #     └── mypackage/
+    #     └── my-package/
     #         └── __init__.py
     project_dir = tmp_path / "project"
     package_dir = project_dir / "mypackage"
@@ -82,13 +82,13 @@ def test_discover_package_path_source_root_as_parent(tmp_path) -> None:
     assert result == str(project_dir)
 
 
-def test_discover_package_path_source_root_as_child(tmp_path) -> None:
+def test_discover_package_path_source_root_as_child(tmp_path: Any) -> None:
     """Test discover_package_path when source root is a child of the module."""
     # Create this temporary structure:
     # /tmp_path/
     # └── project/
     #     └── src/
-    #         └── mypackage/
+    #         └── my-package/
     #             └── __init__.py
     project_dir = tmp_path / "project"
     src_dir = project_dir / "src"

--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -76,7 +76,7 @@ def test_discover_package_path_source_root_as_parent(tmp_path) -> None:
     package_dir = project_dir / "mypackage"
     package_dir.mkdir(parents=True)
     (package_dir / "__init__.py").touch()
-    
+
     # Test with project_dir as source root (parent of package)
     result = discover_package_path(str(package_dir), [str(project_dir)])
     assert result == str(project_dir)
@@ -95,7 +95,7 @@ def test_discover_package_path_source_root_as_child(tmp_path) -> None:
     package_dir = src_dir / "mypackage"
     package_dir.mkdir(parents=True)
     (package_dir / "__init__.py").touch()
-    
+
     # Test with src_dir as source root (child of project)
     result = discover_package_path(str(project_dir), [str(src_dir)])
     assert result == str(src_dir)

--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -65,6 +65,42 @@ def test_project_root_in_sys_path() -> None:
         assert sys.path == [PROJECT_ROOT_DIR]
 
 
+def test_discover_package_path_source_root_as_parent(tmp_path) -> None:
+    """Test discover_package_path when source root is a parent of the module."""
+    # Create this temporary structure:
+    # /tmp_path/
+    # └── project/
+    #     └── mypackage/
+    #         └── __init__.py
+    project_dir = tmp_path / "project"
+    package_dir = project_dir / "mypackage"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").touch()
+    
+    # Test with project_dir as source root (parent of package)
+    result = discover_package_path(str(package_dir), [str(project_dir)])
+    assert result == str(project_dir)
+
+
+def test_discover_package_path_source_root_as_child(tmp_path) -> None:
+    """Test discover_package_path when source root is a child of the module."""
+    # Create this temporary structure:
+    # /tmp_path/
+    # └── project/
+    #     └── src/
+    #         └── mypackage/
+    #             └── __init__.py
+    project_dir = tmp_path / "project"
+    src_dir = project_dir / "src"
+    package_dir = src_dir / "mypackage"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").touch()
+    
+    # Test with src_dir as source root (child of project)
+    result = discover_package_path(str(project_dir), [str(src_dir)])
+    assert result == str(src_dir)
+
+
 @mock.patch("pylint.pyreverse.main.Linker", new=mock.MagicMock())
 @mock.patch("pylint.pyreverse.main.DiadefsHandler", new=mock.MagicMock())
 @mock.patch("pylint.pyreverse.main.writer")


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

Closes #10026

This PR fixes a bug in the `discover_package_path` function in pylint/pyreverse. The function was incorrectly handling cases where the source root is a child of the module directory, causing issues when using pyreverse with certain project structures, particularly those with a `src` layout.

The fix modifies the condition for identifying the correct source root, allowing it to handle both cases where the source root is a parent or a child of the module directory.

Changes made:
- Updated the condition in `discover_package_path` function to correctly identify the source root:
  ```python
  if os.path.commonpath([source_root, dirname]) in [dirname, source_root]:
      return source_root
