### PR TITLE
[too-many-positional-arguments] Better documentation following questions

### DIFF
--- a/doc/data/messages/t/too-many-positional-arguments/bad.py
+++ b/doc/data/messages/t/too-many-positional-arguments/bad.py
@@ -1,5 +1,6 @@
 # +1: [too-many-positional-arguments]
 def calculate_drag_force(velocity, area, density, drag_coefficient):
+    """By default, a function is 'Positional or Keyword' for all args."""
     return 0.5 * drag_coefficient * density * area * velocity**2
 
 

--- a/doc/data/messages/t/too-many-positional-arguments/details.rst
+++ b/doc/data/messages/t/too-many-positional-arguments/details.rst
@@ -1,10 +1,11 @@
+Good APIs don’t have many positional parameters. For almost all API,
+comprehensibility suffers beyond a handful of arguments.
+
 Positional arguments work well for cases where the the use cases are
-self-evident, such as unittest's ``assertEqual(first, second, msg=None)``.
-Comprehensibility suffers beyond a handful of arguments, though, so for
-functions that take more inputs, require that additional arguments be
-passed by *keyword only* by preceding them with ``*``:
-
-.. code-block:: python
-
-    def make_noise(self, volume, *, color=noise.PINK, debug=True):
-        ...
+self-evident, such as unittest's ``assertEqual(first, second, "assert msg")``
+or ``enumerate(fruits, 4)`` (The second arg of ``enumerate`` is seldom used,
+so maybe you'd already prefer to read ``enumerate(fruits, start=4)``).
+There are few exceptions where 4 or more positional parameters make sense,
+for example ``rgba(1.0, 0.5, 0.3, 1.0)`` because it uses a very well known and
+well established convention and using keywords all the time would be a waste
+of time.

--- a/doc/data/messages/t/too-many-positional-arguments/good.py
+++ b/doc/data/messages/t/too-many-positional-arguments/good.py
@@ -1,7 +1,14 @@
 def calculate_drag_force(*, velocity, area, density, drag_coefficient):
+    """This function is 'Keyword only' for all args due to the '*'."""
     return 0.5 * drag_coefficient * density * area * velocity**2
 
 
+# This is now impossible to do and will raise a TypeError:
+# drag_force = calculate_drag_force(30, 2.5, 1.225, 0.47)
+#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# TypeError: calculate_drag_force() takes 0 positional arguments but 4 were given
+
+# And this is the only way to call 'calculate_drag_force'
 drag_force = calculate_drag_force(
     velocity=30, area=2.5, density=1.225, drag_coefficient=0.47
 )

--- a/doc/data/messages/t/too-many-positional-arguments/related.rst
+++ b/doc/data/messages/t/too-many-positional-arguments/related.rst
@@ -1,2 +1,1 @@
-- `Ruff discussion <https://github.com/astral-sh/ruff/issues/8946>`_
-- `Pylint issue <https://github.com/pylint-dev/pylint/issues/9099>`_
+- `Special parameters in python <https://docs.python.org/3/tutorial/controlflow.html#special-parameters>`_


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Add clearer explanation for those who don't know about special parameters, cleanup remnant of the time the check was not implemented in pylint and only reserved the msgid/symbol to mirror ruff.

See https://github.com/astral-sh/ruff/issues/8946\#issuecomment-2437547742

