### PR TITLE
Fix visit_assign and visit_subscript to handle dictionary assignments

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2102,7 +2102,6 @@ class VariablesChecker(BaseChecker):
         except astroid.InferenceError:
             return
 
-
     # listcomp have now also their scope
     def visit_listcomp(self, node: nodes.ListComp) -> None:
         """Visit listcomp: update consumption analysis variable."""
@@ -3346,7 +3345,6 @@ class VariablesChecker(BaseChecker):
             return
 
         self._check_potential_index_error(node, inferred_slice)
-
 
     def _check_potential_index_error(
         self,


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

This PR addresses the handling of unsupported item assignments in nested dictionaries within the `visit_assign` and `visit_subscript` methods. It ensures that the code can handle cases where dictionaries are assigned to keys properly, preventing potential errors.

Closes #10050