### PR TITLE
Bump pylint to 3.3.2, update changelog

### DIFF
--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,30 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.3.2?
+---------------------------
+Release date: 2024-12-01
+
+
+False Positives Fixed
+---------------------
+
+- Fix a false positive for `potential-index-error` when an indexed iterable
+  contains a starred element that evaluates to more than one item.
+
+  Closes #10076 (`#10076 <https://github.com/pylint-dev/pylint/issues/10076>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fixes the issue with --source-root option not working when the source files are in a subdirectory of the source root (e.g. when using a /src layout).
+
+  Closes #10026 (`#10026 <https://github.com/pylint-dev/pylint/issues/10026>`_)
+
+
+
 What's new in Pylint 3.3.1?
 ---------------------------
 Release date: 2024-09-24

--- a/doc/whatsnew/fragments/10026.bugfix
+++ b/doc/whatsnew/fragments/10026.bugfix
@@ -1,3 +1,0 @@
-Fixes the issue with --source-root option not working when the source files are in a subdirectory of the source root (e.g. when using a /src layout).
-
-Closes #10026

--- a/doc/whatsnew/fragments/10076.false_positive
+++ b/doc/whatsnew/fragments/10076.false_positive
@@ -1,4 +1,0 @@
-Fix a false positive for `potential-index-error` when an indexed iterable
-contains a starred element that evaluates to more than one item.
-
-Closes #10076

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -93,7 +93,7 @@ prefer-stubs=no
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.12
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -83,7 +83,7 @@ persistent = true
 
 # Minimum Python version to use for version dependent checks. Will default to the
 # version used to run pylint.
-py-version = "3.10"
+py-version = "3.12"
 
 # Discover python modules and packages in the file system subtree.
 # recursive =

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.1"
+current = "3.3.2"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.3.1"
+version = "3.3.2"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.3/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
False Positives Fixed
---------------------

- Fix a false positive for `potential-index-error` when an indexed iterable
 contains a starred element that evaluates to more than one item.

  Closes #10076


Other Bug Fixes
---------------

- Fixes the issue with --source-root option not working when the source files are in a subdirectory of the source root (e.g. when using a /src layout).

  Closes #10026 

