### PR TITLE
Fix `potential-index-error` false positive when iterable contains starred element

### DIFF
--- a/doc/whatsnew/fragments/10076.false_positive
+++ b/doc/whatsnew/fragments/10076.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for `potential-index-error` when an indexed iterable
+contains a starred element that evaluates to more than one item.
+
+Closes #10076

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3366,6 +3366,19 @@ class VariablesChecker(BaseChecker):
 
         self._check_potential_index_error(node, inferred_slice)
 
+    def _inferred_iterable_length(self, iterable: nodes.Tuple | nodes.List) -> int:
+        length = 0
+        for elt in iterable.elts:
+            if not isinstance(elt, nodes.Starred):
+                length += 1
+                continue
+            unpacked = utils.safe_infer(elt.value)
+            if isinstance(unpacked, nodes.BaseContainer):
+                length += len(unpacked.elts)
+            else:
+                length += 1
+        return length
+
     def _check_potential_index_error(
         self,
         node: nodes.Subscript,
@@ -3381,7 +3394,7 @@ class VariablesChecker(BaseChecker):
         # If the node.value is a Tuple or List without inference it is defined in place
         if isinstance(node.value, (nodes.Tuple, nodes.List)):
             # Add 1 because iterables are 0-indexed
-            if len(node.value.elts) < inferred_slice.value + 1:
+            if self._inferred_iterable_length(node.value) < inferred_slice.value + 1:
                 self.add_message(
                     "potential-index-error", node=node, confidence=INFERENCE
                 )

--- a/tests/functional/p/potential_index_error.py
+++ b/tests/functional/p/potential_index_error.py
@@ -23,3 +23,26 @@ print(an_inner_list[3])
 # Test that we don't crash on more complicated indices/slices
 # We do not raise here (currently)
 print([1, 2, 3][2:3])
+
+
+# Test for cases with unpacking operation
+my_list = ["foo", "bar"]
+my_set = {"foo", "bar"}
+my_tuple = ("foo", "bar")
+my_iterable = (*my_list, *my_set, *my_tuple, *("foo", "bar"))
+my_non_iterable = None
+
+print([*my_list][1])
+print([*my_list][2])  # [potential-index-error]
+
+print([*my_set][1])
+print([*my_set][2])  # [potential-index-error]
+
+print((*my_tuple,)[1])
+print((*my_tuple,)[2])  # [potential-index-error]
+
+print((*my_iterable,)[7])
+print((*my_iterable,)[8])  # [potential-index-error]
+
+print((*my_non_iterable,)[0])
+print((*my_non_iterable,)[1])  # [potential-index-error]

--- a/tests/functional/p/potential_index_error.txt
+++ b/tests/functional/p/potential_index_error.txt
@@ -1,3 +1,8 @@
 potential-index-error:6:6:6:18::Invalid index for iterable length:INFERENCE
 potential-index-error:7:6:7:18::Invalid index for iterable length:INFERENCE
 potential-index-error:8:6:8:22::Invalid index for iterable length:INFERENCE
+potential-index-error:36:6:36:19::Invalid index for iterable length:INFERENCE
+potential-index-error:39:6:39:18::Invalid index for iterable length:INFERENCE
+potential-index-error:42:6:42:21::Invalid index for iterable length:INFERENCE
+potential-index-error:45:6:45:24::Invalid index for iterable length:INFERENCE
+potential-index-error:48:6:48:28::Invalid index for iterable length:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->
The current implementation calculates the length of an indexed iterable by using its literal length. However, this approach fails when the iterable contains a starred element that unpacks into multiple elements.

For example:
```
lst = [1, 2, 3]
print([*lst][1])  # error reported as checker assumes indexed iterable has 1 element instead of 3.
```

This PR addresses the issue by extending the check to account for the inferred length of starred nodes within the indexed iterable.

Closes #10076 
