### PR TITLE
Respect docstring-min-length in docparams extension

### DIFF
--- a/doc/whatsnew/fragments/10104.false_positive
+++ b/doc/whatsnew/fragments/10104.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for `missing-raises-doc` and `missing-yield-doc` when the method length is less than docstring-min-length.
+
+Refs #10104

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -688,7 +688,9 @@ class DocstringParameterChecker(BaseChecker):
         node_line_count = checker_utils.get_node_last_lineno(node) - node.lineno
         min_lines = self.linter.config.docstring_min_length
         result = -1 < node_line_count < min_lines
-        assert isinstance(result, bool), "Result of int comparison should have been a boolean"
+        assert isinstance(
+            result, bool
+        ), "Result of int comparison should have been a boolean"
         return result
 
 

--- a/pylint/extensions/docparams.py
+++ b/pylint/extensions/docparams.py
@@ -209,9 +209,7 @@ class DocstringParameterChecker(BaseChecker):
             return
 
         # skip functions smaller than 'docstring-min-length'
-        lines = checker_utils.get_node_last_lineno(node) - node.lineno
-        max_lines = self.linter.config.docstring_min_length
-        if max_lines > -1 and lines < max_lines:
+        if self._is_shorter_than_min_length(node):
             return
 
         self.check_functiondef_params(node, node_doc)
@@ -279,6 +277,10 @@ class DocstringParameterChecker(BaseChecker):
     def visit_raise(self, node: nodes.Raise) -> None:
         func_node = node.frame()
         if not isinstance(func_node, astroid.FunctionDef):
+            return
+
+        # skip functions smaller than 'docstring-min-length'
+        if self._is_shorter_than_min_length(node):
             return
 
         # skip functions that match the 'no-docstring-rgx' config option
@@ -362,6 +364,10 @@ class DocstringParameterChecker(BaseChecker):
 
     def visit_yield(self, node: nodes.Yield | nodes.YieldFrom) -> None:
         if self.linter.config.accept_no_yields_doc:
+            return
+
+        # skip functions smaller than 'docstring-min-length'
+        if self._is_shorter_than_min_length(node):
             return
 
         func_node: astroid.FunctionDef = node.frame()
@@ -670,6 +676,20 @@ class DocstringParameterChecker(BaseChecker):
                 node=node,
                 confidence=HIGH,
             )
+
+    def _is_shorter_than_min_length(self, node: nodes.FunctionDef) -> bool:
+        """Returns true on functions smaller than 'docstring-min-length'.
+
+        :param node: Node for a function or method definition in the AST
+        :type node: :class:`astroid.scoped_nodes.Function`
+
+        :rtype: bool
+        """
+        node_line_count = checker_utils.get_node_last_lineno(node) - node.lineno
+        min_lines = self.linter.config.docstring_min_length
+        result = -1 < node_line_count < min_lines
+        assert isinstance(result, bool), "Result of int comparison should have been a boolean"
+        return result
 
 
 def register(linter: PyLinter) -> None:

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_required_min_length.py
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_required_min_length.py
@@ -1,0 +1,10 @@
+"""Tests for missing-raises-doc for non-specified style docstrings
+with accept-no-raise-doc = no and docstring-min-length = 3
+"""
+# pylint: disable=invalid-name, broad-exception-raised
+
+# Example of a function that is less than 'docstring-min-length' config option
+# No error message is emitted.
+def test_skip_docstring_min_length():
+    """function is too short and is missing raise documentation"""
+    raise Exception

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_required_min_length.rc
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_required_min_length.rc
@@ -1,0 +1,7 @@
+[MAIN]
+load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-raise-doc=no
+docstring-min-length=3
+no-docstring-rgx=^$

--- a/tests/functional/ext/docparams/yield/missing_yield_doc_required_min_length.py
+++ b/tests/functional/ext/docparams/yield/missing_yield_doc_required_min_length.py
@@ -1,0 +1,10 @@
+"""Tests for missing-yield-doc for non-specified style docstrings
+with accept-no-yields-doc = no and docstring-min-length = 3
+"""
+# pylint: disable=invalid-name
+
+# Example of a function that is less than 'docstring-min-length' config option
+# No error message is emitted.
+def test_skip_docstring_min_length():
+    """function is too short and is missing yield documentation"""
+    yield None

--- a/tests/functional/ext/docparams/yield/missing_yield_doc_required_min_length.rc
+++ b/tests/functional/ext/docparams/yield/missing_yield_doc_required_min_length.rc
@@ -1,0 +1,7 @@
+[MAIN]
+load-plugins = pylint.extensions.docparams
+
+[BASIC]
+accept-no-yields-doc=no
+docstring-min-length=3
+no-docstring-rgx=^$


### PR DESCRIPTION
Even though visit_functiondef is checking for docstring-min-length, it is not enough. This commit fixes the issue by adding the same check to visit_raise and visit_yield

If there is a better way of implementing this, please go forward. I am just providing a working fix to this problem.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [✓] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [✓] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [✓] Write comprehensive commit messages and/or a good description of what the PR does.
- [✓] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [✓] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR references an issue without fixing it: -->

Refs #XXXX

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #XXXX
