### PR TITLE
[mypy] Use type-setuptools instead of types-pkg-resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
             "platformdirs==2.2.0",
             "py==1.11",
             "tomlkit>=0.10.1",
-            "types-pkg_resources==0.1.3",
+            "types-setuptools==75.6.0.20241126",
           ]
         exclude: tests(/\w*)*/functional/|tests/input|tests(/.*)+/conftest.py|doc/data/messages|tests(/\w*)*data/
   - repo: https://github.com/rbubley/mirrors-prettier

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,5 +6,5 @@ pytest-cov~=6.0
 pytest-xdist~=3.6
 six
 # Type packages for mypy
-types-pkg_resources==0.1.3
+types-setuptools==75.6.0.20241126
 tox>=3


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Closes #10117 
