### PR TITLE
Add detection for missing logging format arguments (#9999)

### DIFF
--- a/doc/whatsnew/fragments/9999.false_negative.rst
+++ b/doc/whatsnew/fragments/9999.false_negative.rst
@@ -1,0 +1,1 @@
+Add your info here

--- a/pylint/checkers/logging.py
+++ b/pylint/checkers/logging.py
@@ -326,12 +326,12 @@ class LoggingChecker(checkers.BaseChecker):
           format_arg: Index of the format string in the node arguments.
         """
         num_args = _count_supplied_tokens(node.args[format_arg + 1 :])
-        if not num_args:
+        format_string = node.args[format_arg].value
+        if not num_args and "%" not in format_string:
             # If no args were supplied the string is not interpolated and can contain
             # formatting characters - it's used verbatim. Don't check any further.
             return
 
-        format_string = node.args[format_arg].value
         required_num_args = 0
         if isinstance(format_string, bytes):
             format_string = format_string.decode()

--- a/tests/functional/l/logging/logging_too_few_args_static.py
+++ b/tests/functional/l/logging/logging_too_few_args_static.py
@@ -1,0 +1,7 @@
+"""Tests for logging-too-few-args when static placeholders are present."""
+
+import logging
+
+logging.error("foo %s")  # [logging-too-few-args]
+logging.info("Process %s started with ID %d")  # [logging-too-few-args]
+logging.debug("Missing args: %s %s")  # [logging-too-few-args]

--- a/tests/functional/l/logging/logging_too_few_args_static.rc
+++ b/tests/functional/l/logging/logging_too_few_args_static.rc
@@ -1,0 +1,2 @@
+[LOGGING]
+logging-format-style=new


### PR DESCRIPTION
Implements the detection of too-few-args in logging format strings. Includes new test cases and documentation updates.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description
- Modified the `logging-too-few-args` checker in `logging.py`.
- Added new test cases in `logging_too_few_args_static.py`.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #9999 
