### PR TITLE
Issue 1554 generate progress output initial draft

### DIFF
--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -140,6 +140,26 @@ def _make_linter_options(linter: PyLinter) -> Options:
             },
         ),
         (
+            "show-progress",
+            {
+                "action": "store_true",
+                "default": False,
+                "metavar": "<flag>",
+                "group": "Progress",
+                "help": "Show progress bar.",
+            },
+        ),
+        (
+            "show-current-file",
+            {
+                "action": "store_true",
+                "default": False,
+                "metavar": "<flag>",
+                "group": "Progress",
+                "help": "Show name of current file being processed.",
+            },
+        ),
+        (
             "score",
             {
                 "default": True,

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -140,26 +140,6 @@ def _make_linter_options(linter: PyLinter) -> Options:
             },
         ),
         (
-            "show-progress",
-            {
-                "action": "store_true",
-                "default": False,
-                "metavar": "<flag>",
-                "group": "Progress",
-                "help": "Show progress bar.",
-            },
-        ),
-        (
-            "show-current-file",
-            {
-                "action": "store_true",
-                "default": False,
-                "metavar": "<flag>",
-                "group": "Progress",
-                "help": "Show name of current file being processed.",
-            },
-        ),
-        (
             "score",
             {
                 "default": True,

--- a/pylint/lint/parallel.py
+++ b/pylint/lint/parallel.py
@@ -147,6 +147,18 @@ def check_parallel(
             defaultdict(list)
         )
 
+        # NOTE: for progress reporting here, I *guess* the right
+        # approach would be to materialize the Iterable[FileItem] to a
+        # list, to get the current count.  Then, the
+        # _worker_check_single_file() function would also get a
+        # thread-safe lock on a multiprocessing.Value() object, and
+        # within the lock, increment a progress counter, and print out
+        # the filename.  I haven't tried this yet as a) some of the
+        # code comments imply that the parallel processing will be
+        # merged in with the other "step 3" code, and b) maybe giving
+        # status reporting for single core linting will be good enough
+        # for many people
+
         # Maps each file to be worked on by a single _worker_check_single_file() call,
         # collecting any map/reduce data by checker module so that we can 'reduce' it
         # later.

--- a/pylint/lint/progress_reporters.py
+++ b/pylint/lint/progress_reporters.py
@@ -1,0 +1,58 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+from argparse import Namespace
+
+
+class BaseProgressReporter:
+    """Progress reporter.
+
+    NOTE: for discussion in draft PR.  This class keeps progress
+    reporting separate from linting, and potentially allows for
+    reporting to a filestream, etc.
+    """
+
+    def __init__(self) -> None:
+        self.item_count = 0
+        self.output_filenames = False
+        self.current_count = 0
+
+    def increment(self, filename: str) -> None:
+        """Print the next filename."""
+        # NOTE: This currently just prints each increment, perhaps would
+        # be better to output every, say 5 or 10% of the total count.
+        self.current_count += 1
+        msg = f"{self.current_count} of {self.item_count}"
+        if self.output_filenames:
+            msg = f"{filename} ({msg})"
+        self.print_message(msg)
+
+    def print_message(self, msg: str) -> None:
+        """Display progress message."""
+        raise NotImplementedError()
+
+
+class StdoutProgressReporter(BaseProgressReporter):
+    """Print progress to stdout."""
+
+    def print_message(self, msg: str) -> None:
+        """Display progress message."""
+        print(msg, flush=True)
+
+
+class NullProgressReporter(BaseProgressReporter):
+    """Suppress progress output."""
+
+    def print_message(self, msg: str) -> None:
+        """Do nothing."""
+
+
+def get_progress_reporter(config: Namespace, item_count: int) -> BaseProgressReporter:
+    """Get progress reporter as requested by command line args."""
+    p: BaseProgressReporter = NullProgressReporter()
+    if config.show_progress:
+        p = StdoutProgressReporter()
+    p.item_count = item_count
+    p.output_filenames = config.show_current_file
+    return p

--- a/pylint/lint/progress_reporters.py
+++ b/pylint/lint/progress_reporters.py
@@ -15,7 +15,6 @@ class BaseProgressReporter:
 
     def __init__(self) -> None:
         self.item_count = 0
-        self.output_filenames = False
         self.current_count = 0
 
     def increment(self, filename: str) -> None:
@@ -23,9 +22,7 @@ class BaseProgressReporter:
         # NOTE: This currently just prints each increment, perhaps would
         # be better to output every, say 5 or 10% of the total count.
         self.current_count += 1
-        msg = f"{self.current_count} of {self.item_count}"
-        if self.output_filenames:
-            msg = f"{filename} ({msg})"
+        msg = f"{filename} ({self.current_count} of {self.item_count})"
         self.print_message(msg)
 
     def print_message(self, msg: str) -> None:
@@ -51,7 +48,7 @@ class NullProgressReporter(BaseProgressReporter):
 def get_progress_reporter(config: Namespace, item_count: int) -> BaseProgressReporter:
     """Get progress reporter as requested by command line args."""
     p: BaseProgressReporter = NullProgressReporter()
-    if config.show_progress:
+    if config.verbose:
         p = StdoutProgressReporter()
     p.item_count = item_count
     p.output_filenames = config.show_current_file

--- a/pylint/lint/progress_reporters.py
+++ b/pylint/lint/progress_reporters.py
@@ -2,9 +2,6 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
-from argparse import Namespace
-
-
 class BaseProgressReporter:
     """Progress reporter.
 
@@ -45,11 +42,10 @@ class NullProgressReporter(BaseProgressReporter):
         """Do nothing."""
 
 
-def get_progress_reporter(config: Namespace, item_count: int) -> BaseProgressReporter:
+def get_progress_reporter(verbose: bool, item_count: int) -> BaseProgressReporter:
     """Get progress reporter as requested by command line args."""
     p: BaseProgressReporter = NullProgressReporter()
-    if config.verbose:
+    if verbose:
         p = StdoutProgressReporter()
     p.item_count = item_count
-    p.output_filenames = config.show_current_file
     return p

--- a/pylint/lint/progress_reporters.py
+++ b/pylint/lint/progress_reporters.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
+
 class BaseProgressReporter:
     """Progress reporter.
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -354,6 +354,7 @@ class PyLinter(
         self.current_file: str | None = None
         self._ignore_file = False
         self._ignore_paths: list[Pattern[str]] = []
+        self.verbose = False
 
         self.register_checker(self)
 
@@ -709,7 +710,7 @@ class PyLinter(
         """Get the AST for all given FileItems."""
         ast_per_fileitem: dict[FileItem, nodes.Module | None] = {}
 
-        progress_reporter = get_progress_reporter(self.config, len(fileitems))
+        progress_reporter = get_progress_reporter(self.verbose, len(fileitems))
         progress_reporter.print_message(f"Get ASTs for {len(fileitems)} files.")
 
         for fileitem in fileitems:
@@ -749,7 +750,7 @@ class PyLinter(
         check_astroid_module: Callable[[nodes.Module], bool | None],
     ) -> None:
         """Lint all AST modules from a mapping.."""
-        progress_reporter = get_progress_reporter(self.config, len(ast_mapping))
+        progress_reporter = get_progress_reporter(self.verbose, len(ast_mapping))
         progress_reporter.print_message(f"Linting {len(ast_mapping)} modules.")
         for fileitem, module in ast_mapping.items():
             progress_reporter.increment(fileitem.filepath)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -282,7 +282,6 @@ class PyLinter(
     option_groups_descs = {
         "Messages control": "Options controlling analysis messages",
         "Reports": "Options related to output formatting and reporting",
-        "Progress": "Options related to progress reporting",
     }
 
     def __init__(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -42,6 +42,7 @@ from pylint.lint.expand_modules import (
 )
 from pylint.lint.message_state_handler import _MessageStateHandler
 from pylint.lint.parallel import check_parallel
+from pylint.lint.progress_reporters import get_progress_reporter
 from pylint.lint.report_functions import (
     report_messages_by_module_stats,
     report_messages_stats,
@@ -281,6 +282,7 @@ class PyLinter(
     option_groups_descs = {
         "Messages control": "Options controlling analysis messages",
         "Reports": "Options related to output formatting and reporting",
+        "Progress": "Options related to progress reporting",
     }
 
     def __init__(
@@ -708,7 +710,11 @@ class PyLinter(
         """Get the AST for all given FileItems."""
         ast_per_fileitem: dict[FileItem, nodes.Module | None] = {}
 
+        progress_reporter = get_progress_reporter(self.config, len(fileitems))
+        progress_reporter.print_message(f"Get ASTs for {len(fileitems)} files.")
+
         for fileitem in fileitems:
+            progress_reporter.increment(fileitem.filepath)
             self.set_current_module(fileitem.name, fileitem.filepath)
 
             try:
@@ -744,7 +750,10 @@ class PyLinter(
         check_astroid_module: Callable[[nodes.Module], bool | None],
     ) -> None:
         """Lint all AST modules from a mapping.."""
+        progress_reporter = get_progress_reporter(self.config, len(ast_mapping))
+        progress_reporter.print_message(f"Linting {len(ast_mapping)} modules.")
         for fileitem, module in ast_mapping.items():
+            progress_reporter.increment(fileitem.filepath)
             if module is None:
                 continue
             try:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -323,8 +323,7 @@ class PyLinter(
             self.option_groups_descs[opt_group[0]] = opt_group[1]
         self._option_groups: tuple[tuple[str, str], ...] = (
             *option_groups,
-            ("Messages control", "Options controlling analysis messages"),
-            ("Reports", "Options related to output formatting and reporting"),
+            *PyLinter.option_groups_descs.items(),
         )
         self.fail_on_symbols: list[str] = []
         """List of message symbols on which pylint should fail, set by --fail-on."""

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -202,6 +202,7 @@ group are mutually exclusive.",
             elif linter.config.jobs == 0:
                 linter.config.jobs = _cpu_count()
 
+        linter.config.verbose = self.verbose
         if self._output:
             try:
                 with open(self._output, "w", encoding="utf-8") as output:

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -202,7 +202,7 @@ group are mutually exclusive.",
             elif linter.config.jobs == 0:
                 linter.config.jobs = _cpu_count()
 
-        linter.config.verbose = self.verbose
+        linter.verbose = self.verbose
         if self._output:
             try:
                 with open(self._output, "w", encoding="utf-8") as output:

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1113,7 +1113,7 @@ def test_recursive_ignore(ignore_parameter: str, ignore_parameter_value: str) ->
         exit=False,
     )
 
-    linted_files = run.linter._iterate_file_descrs(
+    linted_files = run.linter._get_file_items(
         tuple(run.linter._discover_files([join(REGRTEST_DATA_DIR, "directory")]))
     )
     linted_file_paths = [file_item.filepath for file_item in linted_files]

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -353,7 +353,7 @@ class TestCheckParallel:
         check_parallel(
             linter,
             jobs=1,
-            files=iter(single_file_container),
+            files=single_file_container,
         )
         assert len(linter.get_checkers()) == 2, (
             "We should only have the 'main' and 'sequential-checker' "
@@ -422,7 +422,7 @@ class TestCheckParallel:
         check_parallel(
             linter,
             jobs=1,
-            files=iter(single_file_container),
+            files=single_file_container,
         )
 
         assert {
@@ -523,7 +523,7 @@ class TestCheckParallel:
                 assert (
                     linter.config.jobs == 1
                 ), "jobs>1 are ignored when calling _lint_files"
-                ast_mapping = linter._get_asts(iter(file_infos), None)
+                ast_mapping = linter._get_asts(file_infos, None)
                 with linter._astroid_module_checker() as check_astroid_module:
                     linter._lint_files(ast_mapping, check_astroid_module)
                 assert linter.msg_status == 0, "We should not fail the lint"
@@ -590,7 +590,7 @@ class TestCheckParallel:
                 assert (
                     linter.config.jobs == 1
                 ), "jobs>1 are ignored when calling _lint_files"
-                ast_mapping = linter._get_asts(iter(file_infos), None)
+                ast_mapping = linter._get_asts(file_infos, None)
                 with linter._astroid_module_checker() as check_astroid_module:
                     linter._lint_files(ast_mapping, check_astroid_module)
                 stats_single_proc = linter.stats
@@ -624,7 +624,7 @@ class TestCheckParallel:
             check_parallel(
                 linter,
                 jobs=1,
-                files=iter(single_file_container),
+                files=single_file_container,
                 # This will trigger an exception in the initializer for the parallel jobs
                 # because arguments has to be an Iterable.
                 extra_packages_paths=1,  # type: ignore[arg-type]

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -330,45 +330,10 @@ class TestRunTC:
         module1 = join(HERE, "regrtest_data", "import_something.py")
         module2 = join(HERE, "regrtest_data", "wrong_import_position.py")
 
-        # NOTE: the progress counter messages are interleaved with the
-        # report output.  I'm just printing the progress output to STDOUT,
-        # maybe something else is preferred.
-        expected_output = textwrap.dedent(
-            f"""
-        Get ASTs for 2 files.
-        1 of 2
-        2 of 2
-        Linting 2 modules.
-        1 of 2
-        ************* Module wrong_import_position
-        {module2}:11:0: C0413: Import "import os" should be placed at the top of the module (wrong-import-position)
-        2 of 2
-        """
-        )
-        print(expected_output)
-        args = [
-            module2,
-            module1,
-            "--disable=all",
-            "--enable=wrong-import-position",
-            "--show-progress",
-            "-rn",
-            "-sn",
-        ]
-        out = StringIO()
-        self._run_pylint(args, out=out)
-        actual_output = self._clean_paths(out.getvalue().strip())
-
-        assert self._clean_paths(expected_output.strip()) == actual_output.strip()
-
-    # NOTE: this test's code is pretty much identical to the above, should refactor.
-    def test_progress_reporting_show_file(self) -> None:
-        module1 = join(HERE, "regrtest_data", "import_something.py")
-        module2 = join(HERE, "regrtest_data", "wrong_import_position.py")
-
         # NOTE: same notes about interleaving, STDOUT usage here.
         expected_output = textwrap.dedent(
             f"""
+        Using config file pylint/testutils/testing_pylintrc
         Get ASTs for 2 files.
         tests/regrtest_data/wrong_import_position.py (1 of 2)
         tests/regrtest_data/import_something.py (2 of 2)
@@ -385,8 +350,7 @@ class TestRunTC:
             module1,
             "--disable=all",
             "--enable=wrong-import-position",
-            "--show-progress",
-            "--show-current-file",
+            "--verbose",
             "-rn",
             "-sn",
         ]

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -326,6 +326,76 @@ class TestRunTC:
             actual_output = actual_output[actual_output.find("\n") :]
         assert self._clean_paths(expected_output.strip()) == actual_output.strip()
 
+    def test_progress_reporting(self) -> None:
+        module1 = join(HERE, "regrtest_data", "import_something.py")
+        module2 = join(HERE, "regrtest_data", "wrong_import_position.py")
+
+        # NOTE: the progress counter messages are interleaved with the
+        # report output.  I'm just printing the progress output to STDOUT,
+        # maybe something else is preferred.
+        expected_output = textwrap.dedent(
+            f"""
+        Get ASTs for 2 files.
+        1 of 2
+        2 of 2
+        Linting 2 modules.
+        1 of 2
+        ************* Module wrong_import_position
+        {module2}:11:0: C0413: Import "import os" should be placed at the top of the module (wrong-import-position)
+        2 of 2
+        """
+        )
+        print(expected_output)
+        args = [
+            module2,
+            module1,
+            "--disable=all",
+            "--enable=wrong-import-position",
+            "--show-progress",
+            "-rn",
+            "-sn",
+        ]
+        out = StringIO()
+        self._run_pylint(args, out=out)
+        actual_output = self._clean_paths(out.getvalue().strip())
+
+        assert self._clean_paths(expected_output.strip()) == actual_output.strip()
+
+    # NOTE: this test's code is pretty much identical to the above, should refactor.
+    def test_progress_reporting_show_file(self) -> None:
+        module1 = join(HERE, "regrtest_data", "import_something.py")
+        module2 = join(HERE, "regrtest_data", "wrong_import_position.py")
+
+        # NOTE: same notes about interleaving, STDOUT usage here.
+        expected_output = textwrap.dedent(
+            f"""
+        Get ASTs for 2 files.
+        tests/regrtest_data/wrong_import_position.py (1 of 2)
+        tests/regrtest_data/import_something.py (2 of 2)
+        Linting 2 modules.
+        tests/regrtest_data/wrong_import_position.py (1 of 2)
+        ************* Module wrong_import_position
+        {module2}:11:0: C0413: Import "import os" should be placed at the top of the module (wrong-import-position)
+        tests/regrtest_data/import_something.py (2 of 2)
+        """
+        )
+        print(expected_output)
+        args = [
+            module2,
+            module1,
+            "--disable=all",
+            "--enable=wrong-import-position",
+            "--show-progress",
+            "--show-current-file",
+            "-rn",
+            "-sn",
+        ]
+        out = StringIO()
+        self._run_pylint(args, out=out)
+        actual_output = self._clean_paths(out.getvalue().strip())
+
+        assert self._clean_paths(expected_output.strip()) == actual_output.strip()
+
     def test_type_annotation_names(self) -> None:
         """Test resetting the `_type_annotation_names` list to `[]` when leaving a module.
 


### PR DESCRIPTION
This is a **DRAFT PR** addressing issue https://github.com/pylint-dev/pylint/issues/1554 ("generate progress").

It adds the following section to `pylint --help` :

```
Progress:
  Options related to progress reporting

  --show-progress       Show progress bar. (default: False)
  --show-current-file   Show name of current file being processed. (default: False)
```

And a sample output from the unit tests using both of these flags is as follows:

```
        Checking 2 modules.
        1 of 2
        tests/regrtest_data/wrong_import_position.py
        ************* Module wrong_import_position
        tests/regrtest_data/wrong_import_position.py:11:0: C0413: Import "import os" should be placed at the top of the module (wrong-import-position)
        2 of 2
        tests/regrtest_data/import_something.py
```

This is totally primitive, but maybe it's a useful starting point for concrete discussion.

The code has a few `# NOTE:` comments for discussion.

Cheers and thanks for the great project!