### PR TITLE
fix "skipped files" count calculation

### DIFF
--- a/doc/whatsnew/fragments/10073.bugfix
+++ b/doc/whatsnew/fragments/10073.bugfix
@@ -1,0 +1,3 @@
+Fixes "skipped files" count calculation; the previous method was displaying an arbitrary number.
+
+Closes #10073

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -87,6 +87,14 @@ def expand_modules(
         if _is_ignored_file(
             something, ignore_list, ignore_list_re, ignore_list_paths_re
         ):
+            result[something] = {
+                "path": something,
+                "name": "",
+                "isarg": False,
+                "basepath": something,
+                "basename": "",
+                "isignored": True,
+            }
             continue
         module_package_path = discover_package_path(something, source_roots)
         additional_search_path = [".", module_package_path, *path]
@@ -138,6 +146,7 @@ def expand_modules(
                     "isarg": True,
                     "basepath": filepath,
                     "basename": modname,
+                    "isignored": False,
                 }
         has_init = (
             not (modname.endswith(".__init__") or modname == "__init__")
@@ -153,6 +162,14 @@ def expand_modules(
                 if _is_in_ignore_list_re(
                     os.path.basename(subfilepath), ignore_list_re
                 ) or _is_in_ignore_list_re(subfilepath, ignore_list_paths_re):
+                    result[subfilepath] = {
+                        "path": subfilepath,
+                        "name": "",
+                        "isarg": False,
+                        "basepath": subfilepath,
+                        "basename": "",
+                        "isignored": True,
+                    }
                     continue
 
                 modpath = _modpath_from_file(
@@ -167,5 +184,6 @@ def expand_modules(
                     "isarg": isarg,
                     "basepath": filepath,
                     "basename": modname,
+                    "isignored": False,
                 }
     return result, errors

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -316,7 +316,6 @@ class PyLinter(
 
         # Attributes related to stats
         self.stats = LinterStats()
-        self.skipped_paths: set[str] = set()
 
         # Attributes related to (command-line) options and their parsing
         self.options: Options = options + _make_linter_options(self)
@@ -852,7 +851,7 @@ class PyLinter(
             self.config.ignore_patterns,
             self.config.ignore_paths,
         ):
-            self.skipped_paths.add(filepath)
+            self.stats.skipped += 1
             return
 
         try:
@@ -876,7 +875,7 @@ class PyLinter(
         for descr in self._expand_files(files_or_modules).values():
             name, filepath, is_arg = descr["name"], descr["path"], descr["isarg"]
             if descr["isignored"]:
-                self.skipped_paths.add(filepath)
+                self.stats.skipped += 1
             elif self.should_analyze_file(name, filepath, is_argument=is_arg):
                 yield FileItem(name, filepath, descr["basename"])
 
@@ -1148,8 +1147,7 @@ class PyLinter(
 
             if verbose:
                 checked_files_count = self.stats.node_count["module"]
-                skipped_paths_count = len(self.skipped_paths)
-                msg += f"\nChecked {checked_files_count} files, skipped {skipped_paths_count} files/modules"
+                msg += f"\nChecked {checked_files_count} files, skipped {self.stats.skipped} files/modules"
 
         if self.config.score:
             sect = report_nodes.EvaluationSection(msg)

--- a/pylint/typing.py
+++ b/pylint/typing.py
@@ -51,6 +51,7 @@ class ModuleDescriptionDict(TypedDict):
     isarg: bool
     basepath: str
     basename: str
+    isignored: bool
 
 
 class ErrorDescriptionDict(TypedDict):

--- a/pylint/utils/linterstats.py
+++ b/pylint/utils/linterstats.py
@@ -128,6 +128,7 @@ class LinterStats:
         self.refactor = 0
         self.statement = 0
         self.warning = 0
+        self.skipped = 0
 
         self.global_note = 0
         self.nb_duplicated_lines = 0
@@ -151,6 +152,7 @@ class LinterStats:
         {self.refactor}
         {self.statement}
         {self.warning}
+        {self.skipped}
         {self.global_note}
         {self.nb_duplicated_lines}
         {self.percent_duplicated_lines}"""
@@ -385,6 +387,7 @@ def merge_stats(stats: list[LinterStats]) -> LinterStats:
         merged.refactor += stat.refactor
         merged.statement += stat.statement
         merged.warning += stat.warning
+        merged.skipped += stat.skipped
 
         merged.global_note += stat.global_note
     return merged

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -40,6 +40,7 @@ this_file = {
     "isarg": True,
     "name": "lint.unittest_expand_modules",
     "path": EXPAND_MODULES,
+    "isignored": False,
 }
 
 this_file_relative_to_parent = {
@@ -48,6 +49,7 @@ this_file_relative_to_parent = {
     "isarg": True,
     "name": "lint.unittest_expand_modules",
     "path": EXPAND_MODULES_BASE,
+    "isignored": False,
 }
 
 this_file_from_init = {
@@ -56,6 +58,7 @@ this_file_from_init = {
     "isarg": False,
     "name": "lint.unittest_expand_modules",
     "path": EXPAND_MODULES,
+    "isignored": False,
 }
 
 this_file_from_init_deduplicated = {
@@ -64,6 +67,7 @@ this_file_from_init_deduplicated = {
     "isarg": True,
     "name": "lint.unittest_expand_modules",
     "path": EXPAND_MODULES,
+    "isignored": False,
 }
 
 unittest_lint = {
@@ -72,6 +76,7 @@ unittest_lint = {
     "isarg": False,
     "name": "lint.unittest_lint",
     "path": str(TEST_DIRECTORY / "lint/unittest_lint.py"),
+    "isignored": False,
 }
 
 test_utils = {
@@ -80,6 +85,7 @@ test_utils = {
     "isarg": False,
     "name": "lint.test_utils",
     "path": str(TEST_DIRECTORY / "lint/test_utils.py"),
+    "isignored": False,
 }
 
 test_run_pylint = {
@@ -88,6 +94,7 @@ test_run_pylint = {
     "isarg": False,
     "name": "lint.test_run_pylint",
     "path": str(TEST_DIRECTORY / "lint/test_run_pylint.py"),
+    "isignored": False,
 }
 
 test_pylinter = {
@@ -96,6 +103,7 @@ test_pylinter = {
     "isarg": False,
     "name": "lint.test_pylinter",
     "path": str(TEST_DIRECTORY / "lint/test_pylinter.py"),
+    "isignored": False,
 }
 
 test_caching = {
@@ -104,6 +112,7 @@ test_caching = {
     "isarg": False,
     "name": "lint.test_caching",
     "path": str(TEST_DIRECTORY / "lint/test_caching.py"),
+    "isignored": False,
 }
 
 init_of_package = {
@@ -112,6 +121,7 @@ init_of_package = {
     "isarg": True,
     "name": "lint",
     "path": INIT_PATH,
+    "isignored": False,
 }
 
 # A directory that is not a python package.
@@ -123,6 +133,7 @@ test_reporters = {  # pylint: disable=consider-using-namedtuple-or-dataclass
         "isarg": False,
         "basepath": str(REPORTERS_PATH / "__init__.py"),
         "basename": "reporters",
+        "isignored": False,
     },
     str(REPORTERS_PATH / "unittest_reporting.py"): {
         "path": str(REPORTERS_PATH / "unittest_reporting.py"),
@@ -130,6 +141,7 @@ test_reporters = {  # pylint: disable=consider-using-namedtuple-or-dataclass
         "isarg": False,
         "basepath": str(REPORTERS_PATH / "__init__.py"),
         "basename": "reporters",
+        "isignored": False,
     },
 }
 
@@ -304,5 +316,5 @@ class TestExpandModules(CheckerTestCase):
             ignore_list_re,
             self.linter.config.ignore_paths,
         )
-        assert modules == expected
+        assert {k: v for k, v in modules.items() if not v["isignored"]} == expected
         assert not errors

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -257,7 +257,7 @@ class TestRunTC:
             out=out,
             code=4,
         )
-        assert "Checked 1 files, skipped 1 files" in out.getvalue().strip()
+        assert "Checked 1 files, skipped 1 files/modules" in out.getvalue().strip()
 
     def test_no_out_encoding(self) -> None:
         """Test redirection of stdout with non ascii characters."""

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -241,8 +241,23 @@ class TestRunTC:
 
     def test_output_with_verbose(self) -> None:
         out = StringIO()
-        self._runtest([UNNECESSARY_LAMBDA, "--verbose"], out=out, code=4)
-        assert "Checked 1 files, skipped 0 files" in out.getvalue().strip()
+        self._runtest(
+            [
+                UNNECESSARY_LAMBDA,
+                join(
+                    HERE,
+                    "regrtest_data",
+                    "directory",
+                    "ignored_subdirectory",
+                    "failing.py",
+                ),
+                "--ignore-paths=.*failing.*",
+                "--verbose",
+            ],
+            out=out,
+            code=4,
+        )
+        assert "Checked 1 files, skipped 1 files" in out.getvalue().strip()
 
     def test_no_out_encoding(self) -> None:
         """Test redirection of stdout with non ascii characters."""
@@ -1104,7 +1119,7 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             (
                 "colorized",
                 (
-                    "{path}:4:4: W0612: \x1B[35mUnused variable 'variable'\x1B[0m (\x1B[35munused-variable\x1B[0m)"
+                    "{path}:4:4: W0612: \x1b[35mUnused variable 'variable'\x1b[0m (\x1b[35munused-variable\x1b[0m)"
                 ),
             ),
             ("json", '"message": "Unused variable \'variable\'",'),
@@ -1212,7 +1227,10 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
         test would fail due these errors.
         """
         directory = join(HERE, "regrtest_data", "directory")
-        self._runtest([directory, "--recursive=y", f"--ignore={ignore_value}"], code=0)
+        self._runtest(
+            [directory, "--verbose", "--recursive=y", f"--ignore={ignore_value}"],
+            code=0,
+        )
 
     @pytest.mark.parametrize("ignore_pattern_value", ["ignored_.*", "failing.*"])
     def test_ignore_pattern_recursive(self, ignore_pattern_value: str) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes https://github.com/pylint-dev/pylint/issues/10073. This bug has existed ever since the logic was introduced in https://github.com/pylint-dev/pylint/pull/9122. [This](https://github.com/pylint-dev/pylint/issues/8935) was 
the initial issue that inspired that PR, so we can see that the "skipped" count should obviously
have nothing to do with modules without docstrings.

Also enables more reports/output about skipped files in the future, which has been asked for.
I haven't implemented that since it would probably be a larger discussion as to how verbose 
`--verbose` should be.

## Testing
Fleshed out the test that was written when this was introduced that didn't actually test anything.

Ran this with several configs, including overlapping paths and modules. Additionally ran it on
our biggest repo with multiple packages, vendored code, etc, and got the expected results:

Before: `Checked 10xxx files, skipped 9391 files` (alarming!)
After: `Checked 10xxx files, skipped 75 files/modules` (whew, ok)