### PR TITLE
Change _iterate_file_descrs to _get_file_items

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -323,8 +323,7 @@ class PyLinter(
             self.option_groups_descs[opt_group[0]] = opt_group[1]
         self._option_groups: tuple[tuple[str, str], ...] = (
             *option_groups,
-            ("Messages control", "Options controlling analysis messages"),
-            ("Reports", "Options related to output formatting and reporting"),
+            *PyLinter.option_groups_descs.items(),
         )
         self.fail_on_symbols: list[str] = []
         """List of message symbols on which pylint should fail, set by --fail-on."""

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1113,7 +1113,7 @@ def test_recursive_ignore(ignore_parameter: str, ignore_parameter_value: str) ->
         exit=False,
     )
 
-    linted_files = run.linter._iterate_file_descrs(
+    linted_files = run.linter._get_file_items(
         tuple(run.linter._discover_files([join(REGRTEST_DATA_DIR, "directory")]))
     )
     linted_file_paths = [file_item.filepath for file_item in linted_files]

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -353,7 +353,7 @@ class TestCheckParallel:
         check_parallel(
             linter,
             jobs=1,
-            files=iter(single_file_container),
+            files=single_file_container,
         )
         assert len(linter.get_checkers()) == 2, (
             "We should only have the 'main' and 'sequential-checker' "
@@ -422,7 +422,7 @@ class TestCheckParallel:
         check_parallel(
             linter,
             jobs=1,
-            files=iter(single_file_container),
+            files=single_file_container,
         )
 
         assert {
@@ -523,7 +523,7 @@ class TestCheckParallel:
                 assert (
                     linter.config.jobs == 1
                 ), "jobs>1 are ignored when calling _lint_files"
-                ast_mapping = linter._get_asts(iter(file_infos), None)
+                ast_mapping = linter._get_asts(file_infos, None)
                 with linter._astroid_module_checker() as check_astroid_module:
                     linter._lint_files(ast_mapping, check_astroid_module)
                 assert linter.msg_status == 0, "We should not fail the lint"
@@ -590,7 +590,7 @@ class TestCheckParallel:
                 assert (
                     linter.config.jobs == 1
                 ), "jobs>1 are ignored when calling _lint_files"
-                ast_mapping = linter._get_asts(iter(file_infos), None)
+                ast_mapping = linter._get_asts(file_infos, None)
                 with linter._astroid_module_checker() as check_astroid_module:
                     linter._lint_files(ast_mapping, check_astroid_module)
                 stats_single_proc = linter.stats
@@ -624,7 +624,7 @@ class TestCheckParallel:
             check_parallel(
                 linter,
                 jobs=1,
-                files=iter(single_file_container),
+                files=single_file_container,
                 # This will trigger an exception in the initializer for the parallel jobs
                 # because arguments has to be an Iterable.
                 extra_packages_paths=1,  # type: ignore[arg-type]


### PR DESCRIPTION
Returning a materialized list instead of an iterator lets us do simple progress reporting in the future.  As the list of FileItems is very lightweight, there shouldn't be a performance hit.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Refs

This work was initially done as part of draft PR #10134 , and it makes sense as a small refactor of the internal method.