### PR TITLE
[Backport maintenance/3.3.x] Bump astroid from 3.3.5 to 3.3.8 (#10125)

### DIFF
--- a/doc/whatsnew/fragments/10112.bugfix
+++ b/doc/whatsnew/fragments/10112.bugfix
@@ -1,0 +1,3 @@
+Fix ``Unable to import 'collections.abc' (import-error)`` on Python 3.13.1.
+
+Closes #10112

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies    = [
     # Also upgrade requirements_test_min.txt.
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
-    "astroid>=3.3.5,<=3.4.0-dev0",
+    "astroid>=3.3.8,<=3.4.0-dev0",
     "isort>=4.2.5,<6,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==3.3.5  # Pinned to a specific version for tests
+astroid==3.3.8  # Pinned to a specific version for tests
 typing-extensions~=4.12
 py~=1.11.0
 pytest~=8.3

--- a/tests/functional/n/no/no_member_imports.py
+++ b/tests/functional/n/no/no_member_imports.py
@@ -33,9 +33,9 @@ def test_ignored_modules_root_one_applies_as_well() -> None:
 
 
 def test_ignored_modules_patterns() -> None:
-    import collections
+    import importlib
 
-    collections.abc.THIS_does_not_EXIST
+    importlib.metadata.THIS_does_not_EXIST
 
 
 def test_ignored_classes_no_recursive_pattern() -> None:

--- a/tests/functional/n/no/no_member_imports.rc
+++ b/tests/functional/n/no/no_member_imports.rc
@@ -1,3 +1,3 @@
 [TYPECHECK]
-ignored-modules=argparse,xml.etree.,collections.abc*
+ignored-modules=argparse,xml.etree.,importlib.metadata*
 ignored-classes=sys*,optparse.Values,Option


### PR DESCRIPTION
(cherry picked from commit 31e7674ad44c9cbd3120e7e42497bf8af911df79)