### PR TITLE
Bump pylint to 3.3.3, update changelog

### DIFF
--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,35 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.3.3?
+---------------------------
+Release date: 2024-12-23
+
+
+False Positives Fixed
+---------------------
+
+- Fix false positives for ``undefined-variable`` for classes using Python 3.12
+  generic type syntax.
+
+  Closes #9335 (`#9335 <https://github.com/pylint-dev/pylint/issues/9335>`_)
+
+- Fix a false positive for `use-implicit-booleaness-not-len`. No lint should be emitted for
+  generators (`len` is not defined for generators).
+
+  Refs #10100 (`#10100 <https://github.com/pylint-dev/pylint/issues/10100>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fix ``Unable to import 'collections.abc' (import-error)`` on Python 3.13.1.
+
+  Closes #10112 (`#10112 <https://github.com/pylint-dev/pylint/issues/10112>`_)
+
+
+
 What's new in Pylint 3.3.2?
 ---------------------------
 Release date: 2024-12-01

--- a/doc/whatsnew/fragments/10100.false_positive
+++ b/doc/whatsnew/fragments/10100.false_positive
@@ -1,4 +1,0 @@
-Fix a false positive for `use-implicit-booleaness-not-len`. No lint should be emitted for
-generators (`len` is not defined for generators).
-
-Refs #10100

--- a/doc/whatsnew/fragments/10112.bugfix
+++ b/doc/whatsnew/fragments/10112.bugfix
@@ -1,3 +1,0 @@
-Fix ``Unable to import 'collections.abc' (import-error)`` on Python 3.13.1.
-
-Closes #10112

--- a/doc/whatsnew/fragments/9335.false_positive
+++ b/doc/whatsnew/fragments/9335.false_positive
@@ -1,4 +1,0 @@
-Fix false positives for ``undefined-variable`` for classes using Python 3.12
-generic type syntax.
-
-Closes #9335

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.2"
+current = "3.3.3"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.3.2"
+version = "3.3.3"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.3/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.3.3?
---------------------------
Release date: 2024-12-23


False Positives Fixed
---------------------

- Fix false positives for ``undefined-variable`` for classes using Python 3.12
  generic type syntax.

  Closes #9335

- Fix a false positive for `use-implicit-booleaness-not-len`. No lint should be emitted for
  generators (`len` is not defined for generators).

  Refs #10100


Other Bug Fixes
---------------

- Fix ``Unable to import 'collections.abc' (import-error)`` on Python 3.13.1.

  Closes #10112