### PR TITLE
Extend documentation for `redefined-builtin`

### DIFF
--- a/doc/data/messages/r/redefined-builtin/details.rst
+++ b/doc/data/messages/r/redefined-builtin/details.rst
@@ -1,0 +1,23 @@
+The `allowed-redefined-builtins <https://pylint.readthedocs.io/en/stable/user_guide/configuration/all-options.html#allowed-redefined-builtins>`_
+option lets you specify names that are permitted to shadow built-ins.
+
+However, this option is not effective for redefinitions at the module level or for global variables. For example:
+
+Module-Level Redefinitions::
+
+    # module_level_redefine.py
+    id = 1  # Shadows the built-in `id`
+
+Global Variable Redefinitions::
+
+    # global_variable_redefine.py
+    def my_func():
+        global len
+        len = 1  # Shadows the built-in `len`
+
+Rationale:
+
+Shadowing built-ins at the global scope is discouraged because it obscures their behavior
+throughout the entire module, increasing the risk of subtle bugs when the built-in is needed elsewhere.
+In contrast, local redefinitions are acceptable as their impact is confined to a specific scope,
+reducing unintended side effects and simplifying debugging.

--- a/doc/data/messages/r/redefined-builtin/details.rst
+++ b/doc/data/messages/r/redefined-builtin/details.rst
@@ -1,5 +1,4 @@
-The `allowed-redefined-builtins <https://pylint.readthedocs.io/en/stable/user_guide/configuration/all-options.html#allowed-redefined-builtins>`_
-option lets you specify names that are permitted to shadow built-ins.
+The :ref:`allowed-redefined-builtins <variables-options>` option lets you specify names that are permitted to shadow built-ins.
 
 However, this option is not effective for redefinitions at the module level or for global variables. For example:
 

--- a/tests/functional/r/redefined/redefined_builtin_allowed.py
+++ b/tests/functional/r/redefined/redefined_builtin_allowed.py
@@ -7,3 +7,8 @@ def function():
     print(dir, dict)
 
 list = "not in globals" # [redefined-builtin]
+
+def global_variable_redefine():
+    """Shadow `len` using the `global` keyword."""
+    global len
+    len = 1  # [redefined-builtin]

--- a/tests/functional/r/redefined/redefined_builtin_allowed.rc
+++ b/tests/functional/r/redefined/redefined_builtin_allowed.rc
@@ -1,4 +1,4 @@
 [messages control]
-disable = invalid-name
+disable = invalid-name, global-variable-undefined
 [variables]
-allowed-redefined-builtins = dir, list
+allowed-redefined-builtins = dir, list, len

--- a/tests/functional/r/redefined/redefined_builtin_allowed.txt
+++ b/tests/functional/r/redefined/redefined_builtin_allowed.txt
@@ -1,2 +1,3 @@
 redefined-builtin:6:4:6:8:function:Redefining built-in 'dict':UNDEFINED
 redefined-builtin:9:0:9:4::Redefining built-in 'list':UNDEFINED
+redefined-builtin:14:4:14:7:global_variable_redefine:Redefining built-in 'len':UNDEFINED


### PR DESCRIPTION
Closes https://github.com/pylint-dev/pylint/issues/10160

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|    | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

The `redefined-builtin` check has an option - `allowed-redefined-builtins` that allows users to specify names that are allowed to shadow built-ins. However, there are exceptions where this option does not apply, which might lead to confusion. Users may reasonably expect the option to be effective in all cases.

The option is not effective when:
- the shadowing occurs at module level
- the shadowing occurs at local scope, but the `global` keyword is applied to the name

The justification for these exceptions was discussed in #3643. Therefore, these cases should be documented to provide better clarity for users.

Additionally, add functional test for the `global` keyword case, as it is not covered by existing tests. 

Screenshot reference of updated doc page:

![image](https://github.com/user-attachments/assets/114817f1-b259-4cfa-8ca4-7b63e41ea729)

Closes #10160
