### PR TITLE
🧪 Add a test for implicit ns src root lookup

### DIFF
--- a/tests/pyreverse/test_main.py
+++ b/tests/pyreverse/test_main.py
@@ -65,7 +65,15 @@ def test_project_root_in_sys_path() -> None:
         assert sys.path == [PROJECT_ROOT_DIR]
 
 
-def test_discover_package_path_source_root_as_parent(tmp_path: Any) -> None:
+@pytest.mark.parametrize(
+    "py_mod_base_name",
+    ("__init__", "impl"),
+    ids=("explicit-namespace", "implicit-namespace"),
+)
+def test_discover_package_path_source_root_as_parent(
+    py_mod_base_name: str,
+    tmp_path: Any,
+) -> None:
     """Test discover_package_path when source root is a parent of the module."""
     # Create this temporary structure:
     # /tmp_path/
@@ -75,14 +83,22 @@ def test_discover_package_path_source_root_as_parent(tmp_path: Any) -> None:
     project_dir = tmp_path / "project"
     package_dir = project_dir / "mypackage"
     package_dir.mkdir(parents=True)
-    (package_dir / "__init__.py").touch()
+    (package_dir / f"{py_mod_base_name}.py").touch()
 
     # Test with project_dir as source root (parent of package)
     result = discover_package_path(str(package_dir), [str(project_dir)])
     assert result == str(project_dir)
 
 
-def test_discover_package_path_source_root_as_child(tmp_path: Any) -> None:
+@pytest.mark.parametrize(
+    "py_mod_base_name",
+    ("__init__", "impl"),
+    ids=("explicit-namespace", "implicit-namespace"),
+)
+def test_discover_package_path_source_root_as_child(
+    py_mod_base_name: str,
+    tmp_path: Any,
+) -> None:
     """Test discover_package_path when source root is a child of the module."""
     # Create this temporary structure:
     # /tmp_path/
@@ -94,7 +110,7 @@ def test_discover_package_path_source_root_as_child(tmp_path: Any) -> None:
     src_dir = project_dir / "src"
     package_dir = src_dir / "mypackage"
     package_dir.mkdir(parents=True)
-    (package_dir / "__init__.py").touch()
+    (package_dir / f"{py_mod_base_name}.py").touch()
 
     # Test with src_dir as source root (child of project)
     result = discover_package_path(str(project_dir), [str(src_dir)])


### PR DESCRIPTION
This patch modifies the `test_discover_package_path_source_root_as_*` tests to also run against directory layouts with no exlicitly existing `__init__.py` file.

They were added in #10036 and seem to be insufficient, not covering PEP 420 implicit namespaces.

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :test_tube: Tests      |

## Description

I haven't found a pre-existing issue so far. It should be possible to mark these tests with xfail and merge them before working on the actual fix.
