### PR TITLE
Issue 1554: add progress reporting

### DIFF
--- a/pylint/lint/progress_reporters.py
+++ b/pylint/lint/progress_reporters.py
@@ -1,0 +1,58 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+from typing import Optional
+
+class BaseProgressReporter:
+    """Progress reporter.
+    """
+
+    def __init__(self) -> None:
+        self.item_count = None
+        self.current_count = 0
+
+    def increment(self, filename: str) -> None:
+        """Print the next filename."""
+        self.current_count += 1
+        msg = filename
+        if self.item_count is not None:
+            msg = f"{msg} ({self.current_count} of {self.item_count})"
+        self.print_message(msg)
+
+    def print_message(self, msg: str) -> None:
+        """Display progress message."""
+        raise NotImplementedError()
+
+
+class StdoutProgressReporter(BaseProgressReporter):
+    """Print progress to stdout."""
+
+    def print_message(self, msg: str) -> None:
+        """Display progress message."""
+        print(msg, flush=True)
+
+
+class NullProgressReporter(BaseProgressReporter):
+    """Suppress progress output."""
+
+    def print_message(self, msg: str) -> None:
+        """Do nothing."""
+
+
+def get_progress_reporter(verbose: bool, item_count: Optional[int] = None) -> BaseProgressReporter:
+    """
+    Get a progress reporter.
+
+    Parameters:
+        verbose (bool): Whether the reporter should display output.
+        item_count (Optional[int]): total count of items.  If included, "(1 of n)" is printed.
+
+    Returns:
+        BaseProgressReporter: An instance of the progress reporter.
+    """
+    p: BaseProgressReporter = NullProgressReporter()
+    if verbose:
+        p = StdoutProgressReporter()
+    p.item_count = item_count
+    return p

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -42,6 +42,7 @@ from pylint.lint.expand_modules import (
 )
 from pylint.lint.message_state_handler import _MessageStateHandler
 from pylint.lint.parallel import check_parallel
+from pylint.lint.progress_reporters import get_progress_reporter
 from pylint.lint.report_functions import (
     report_messages_by_module_stats,
     report_messages_stats,
@@ -353,6 +354,7 @@ class PyLinter(
         self.current_file: str | None = None
         self._ignore_file = False
         self._ignore_paths: list[Pattern[str]] = []
+        self.verbose = False
 
         self.register_checker(self)
 
@@ -708,7 +710,15 @@ class PyLinter(
         """Get the AST for all given FileItems."""
         ast_per_fileitem: dict[FileItem, nodes.Module | None] = {}
 
+        # For progress reports, it would be nice to say "item 1 of N",
+        # but we can't get the total count of filenames without
+        # materializing the list, or creating a second iterator and
+        # iterating.
+        progress_reporter = get_progress_reporter(self.verbose)
+        progress_reporter.print_message(f"Get ASTs.")
+
         for fileitem in fileitems:
+            progress_reporter.increment(fileitem.filepath)
             self.set_current_module(fileitem.name, fileitem.filepath)
 
             try:
@@ -744,7 +754,10 @@ class PyLinter(
         check_astroid_module: Callable[[nodes.Module], bool | None],
     ) -> None:
         """Lint all AST modules from a mapping.."""
+        progress_reporter = get_progress_reporter(self.verbose, len(ast_mapping))
+        progress_reporter.print_message(f"Linting {len(ast_mapping)} modules.")
         for fileitem, module in ast_mapping.items():
+            progress_reporter.increment(fileitem.filepath)
             if module is None:
                 continue
             try:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -323,8 +323,7 @@ class PyLinter(
             self.option_groups_descs[opt_group[0]] = opt_group[1]
         self._option_groups: tuple[tuple[str, str], ...] = (
             *option_groups,
-            ("Messages control", "Options controlling analysis messages"),
-            ("Reports", "Options related to output formatting and reporting"),
+            *PyLinter.option_groups_descs.items(),
         )
         self.fail_on_symbols: list[str] = []
         """List of message symbols on which pylint should fail, set by --fail-on."""

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -227,6 +227,7 @@ group are mutually exclusive.",
             elif linter.config.jobs == 0:
                 linter.config.jobs = _cpu_count()
 
+        linter.verbose = self.verbose
         if self._output:
             try:
                 with open(self._output, "w", encoding="utf-8") as output:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -341,6 +341,38 @@ class TestRunTC:
             actual_output = actual_output[actual_output.find("\n") :]
         assert self._clean_paths(expected_output.strip()) == actual_output.strip()
 
+    def test_progress_reporting(self) -> None:
+        module1 = join(HERE, "regrtest_data", "import_something.py")
+        module2 = join(HERE, "regrtest_data", "wrong_import_position.py")
+
+        expected_output = textwrap.dedent(
+            f"""
+        Using config file pylint/testutils/testing_pylintrc
+        Get ASTs.
+        tests/regrtest_data/wrong_import_position.py
+        tests/regrtest_data/import_something.py
+        Linting 2 modules.
+        tests/regrtest_data/wrong_import_position.py (1 of 2)
+        ************* Module wrong_import_position
+        {module2}:11:0: C0413: Import "import os" should be placed at the top of the module (wrong-import-position)
+        tests/regrtest_data/import_something.py (2 of 2)
+        """
+        )
+        args = [
+            module2,
+            module1,
+            "--disable=all",
+            "--enable=wrong-import-position",
+            "--verbose",
+            "-rn",
+            "-sn",
+        ]
+        out = StringIO()
+        self._run_pylint(args, out=out)
+        actual_output = self._clean_paths(out.getvalue().strip())
+
+        assert self._clean_paths(expected_output.strip()) == actual_output.strip()
+
     def test_type_annotation_names(self) -> None:
         """Test resetting the `_type_annotation_names` list to `[]` when leaving a module.
 


### PR DESCRIPTION
Add simple progress reporting to single-core pylint runs, per #1554 

Simplified code changes after the discussion from draft PR https://github.com/pylint-dev/pylint/pull/10134 (thanks)

As requested, the PR adds simple progress reporting to the `--verbose` flag.  Sample output, as given in the test case:

```
Using config file pylint/testutils/testing_pylintrc
Get ASTs.
tests/regrtest_data/wrong_import_position.py
tests/regrtest_data/import_something.py
Linting 2 modules.
tests/regrtest_data/wrong_import_position.py (1 of 2)
************* Module wrong_import_position
{module2}:11:0: C0413: Import "import os" should be placed at the top of the module (wrong-import-position)
tests/regrtest_data/import_something.py (2 of 2)
```

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Notes

1. Partially closes #1554.  This PR doesn't address progress reporting for parallel processing: a) the current code has some notes implying that the parallel processing will be merged in with the other "step 3" code; b) adding single-core reporting is a step forward that might be useful for many users.

2. The single test added in this branch passes; however, CI for this branch *will fail*, because the branch is based off of main which currently has several failing tests.  On my local machine:

| branch | pytest results |
| --- | --- |
| `upstream/main` as at d94194bef | `30 failed, 1885 passed, 264 skipped, 5 xfailed in 122.39s (0:02:02) ` |
| this branch | `30 failed, 1886 passed, 264 skipped, 5 xfailed in 124.96s (0:02:04)` |

3. Adding this feature may alter some of the existing 30 failures, due to the changed `--verbose` output.  I had suggested that progress reporting be separated out from `--verbose` for this reason, but have left it as part of the `--verbose` because I can understand the desire for fewer flags.  I haven't looked into any new failures much as they're buried in the existing test failures.