### PR TITLE
Mention that unused-import skips __init__.py files

### DIFF
--- a/doc/data/messages/u/unused-import/details.rst
+++ b/doc/data/messages/u/unused-import/details.rst
@@ -1,0 +1,1 @@
+By default, this check is skipped for ``__init__.py`` files, as they often contain imports from submodules for the convenience of end users. While these imports are not used within ``__init__.py``, they serve the purpose of providing intuitive import paths for the module's important classes and constants.

--- a/doc/data/messages/u/unused-import/related.rst
+++ b/doc/data/messages/u/unused-import/related.rst
@@ -1,0 +1,1 @@
+- `The --init-import configuration option <https://pylint.readthedocs.io/en/latest/user_guide/configuration/all-options.html#init-import>`_

--- a/doc/data/messages/u/unused-import/related.rst
+++ b/doc/data/messages/u/unused-import/related.rst
@@ -1,1 +1,1 @@
-- `The --init-import configuration option <https://pylint.readthedocs.io/en/latest/user_guide/configuration/all-options.html#init-import>`_
+- :ref:`--init-import <variables-options>`


### PR DESCRIPTION
- Explained why __init__.py files may have unused imports by design.
- Linked to the config option that overrides this behavior

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10162
