### PR TITLE
Release branch 3.3.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,7 +109,7 @@ repos:
         entry: make -C doc/ html
         pass_filenames: false
         language: system
-        stages: [push]
+        stages: [pre-push]
       - id: check-newsfragments
         name: Check newsfragments
         entry: python3 -m script.check_newsfragments

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -334,6 +334,7 @@ contributors:
 - syutbai <syutbai@gmail.com>
 - sur.la.route <17788706+christopherpickering@users.noreply.github.com>
 - sdet_liang <liangway@users.noreply.github.com>
+- purajit <7026198+purajit@users.noreply.github.com>
 - paschich <millen@gridium.com>
 - oittaa <8972248+oittaa@users.noreply.github.com>
 - nyabkun <75878387+nyabkun@users.noreply.github.com>

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,29 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+
+What's new in Pylint 3.3.4?
+---------------------------
+Release date: 2025-01-28
+
+
+Other Bug Fixes
+---------------
+
+- Fixes "skipped files" count calculation; the previous method was displaying an arbitrary number.
+
+  Closes #10073 (`#10073 <https://github.com/pylint-dev/pylint/issues/10073>`_)
+
+- Fixes a crash that occurred when pylint was run in a container on a host with cgroupsv2 and restrictions on CPU usage.
+
+  Closes #10103 (`#10103 <https://github.com/pylint-dev/pylint/issues/10103>`_)
+
+- Relaxed the requirements for isort so pylint can benefit from isort 6.
+
+  Closes #10203 (`#10203 <https://github.com/pylint-dev/pylint/issues/10203>`_)
+
+
+
 What's new in Pylint 3.3.3?
 ---------------------------
 Release date: 2024-12-23

--- a/doc/whatsnew/fragments/10073.bugfix
+++ b/doc/whatsnew/fragments/10073.bugfix
@@ -1,3 +1,0 @@
-Fixes "skipped files" count calculation; the previous method was displaying an arbitrary number.
-
-Closes #10073

--- a/doc/whatsnew/fragments/10103.bugfix
+++ b/doc/whatsnew/fragments/10103.bugfix
@@ -1,3 +1,0 @@
-Fixes a crash that occurred when pylint was run in a container on a host with cgroupsv2 and restrictions on CPU usage.
-
-Closes #10103

--- a/doc/whatsnew/fragments/10203.bugfix
+++ b/doc/whatsnew/fragments/10203.bugfix
@@ -1,0 +1,3 @@
+Relaxed the requirements for isort so pylint can benefit from isort 6.
+
+Closes #10203

--- a/doc/whatsnew/fragments/10203.bugfix
+++ b/doc/whatsnew/fragments/10203.bugfix
@@ -1,3 +1,0 @@
-Relaxed the requirements for isort so pylint can benefit from isort 6.
-
-Closes #10203

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -93,7 +93,7 @@ prefer-stubs=no
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.12
+py-version=3.13
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -83,7 +83,7 @@ persistent = true
 
 # Minimum Python version to use for version dependent checks. Will default to the
 # version used to run pylint.
-py-version = "3.12"
+py-version = "3.13"
 
 # Discover python modules and packages in the file system subtree.
 # recursive =

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.3"
+__version__ = "3.3.4"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies    = [
     # Pinned to dev of second minor update to allow editable installs and fix primer issues,
     # see https://github.com/pylint-dev/astroid/issues/1341
     "astroid>=3.3.8,<=3.4.0-dev0",
-    "isort>=4.2.5,<6,!=5.13.0",
+    "isort>=4.2.5,<7,!=5.13.0",
     "mccabe>=0.6,<0.8",
     "tomli>=1.1.0;python_version<'3.11'",
     "tomlkit>=0.10.1",

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.3"
+current = "3.3.4"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.3.3"
+version = "3.3.4"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.3/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
Other Bug Fixes
---------------

- Fixes "skipped files" count calculation; the previous method was displaying an arbitrary number.

  Closes #10073

- Fixes a crash that occurred when pylint was run in a container on a host with cgroupsv2 and restrictions on CPU usage.

  Closes #10103 

- Relaxed the requirements for isort so pylint can benefit from isort 6.

  Closes #10203