### PR TITLE
Fix a false positive for ``invalid-getnewargs-ex-returned``

### DIFF
--- a/doc/whatsnew/fragments/10208.false_positive
+++ b/doc/whatsnew/fragments/10208.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``invalid-getnewargs-ex-returned`` when the tuple or dict has been assigned to a name.
+
+Closes #10208

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -391,7 +391,7 @@ class SpecialMethodsChecker(BaseChecker):
                 (inferred.elts[0], self._is_tuple),
                 (inferred.elts[1], self._is_dict),
             ):
-                if isinstance(arg, nodes.Call):
+                if isinstance(arg, (nodes.Call, nodes.Name)):
                     arg = safe_infer(arg)
 
                 if arg and not isinstance(arg, util.UninferableBase):

--- a/tests/functional/i/invalid/invalid_getnewargs/invalid_getnewargs_ex_returned.py
+++ b/tests/functional/i/invalid/invalid_getnewargs/invalid_getnewargs_ex_returned.py
@@ -30,6 +30,24 @@ class ThirdGoodGetNewArgsEx:
     """GetNewArgsEx through the metaclass."""
 
 
+class FourthGoodGetNewArgsEx:
+    """Test that `args` and `kwargs` (`Name` nodes) are inferred as tuples.
+
+    https://github.com/pylint-dev/pylint/issues/10208
+    """
+    def __init__(self, boo, far, *, hoo, haha):
+        self._foo = boo
+        self._bar = far
+        self._hoo = hoo
+        self._haha = haha
+
+    def __getnewargs_ex__(self):
+        args = (self._foo, self._bar)
+        kwargs = {'hoo': self._hoo,
+                  'haha': self._haha}
+        return args, kwargs
+
+
 class FirstBadGetNewArgsEx:
     """ __getnewargs_ex__ returns an integer """
 

--- a/tests/functional/i/invalid/invalid_getnewargs/invalid_getnewargs_ex_returned.txt
+++ b/tests/functional/i/invalid/invalid_getnewargs/invalid_getnewargs_ex_returned.txt
@@ -1,6 +1,6 @@
-invalid-getnewargs-ex-returned:36:4:36:25:FirstBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
-invalid-getnewargs-ex-returned:43:4:43:25:SecondBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
-invalid-getnewargs-ex-returned:50:4:50:25:ThirdBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
-invalid-getnewargs-ex-returned:57:4:57:25:FourthBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
-invalid-getnewargs-ex-returned:64:4:64:25:FifthBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
-invalid-getnewargs-ex-returned:71:4:71:25:SixthBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
+invalid-getnewargs-ex-returned:54:4:54:25:FirstBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
+invalid-getnewargs-ex-returned:61:4:61:25:SecondBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
+invalid-getnewargs-ex-returned:68:4:68:25:ThirdBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
+invalid-getnewargs-ex-returned:75:4:75:25:FourthBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
+invalid-getnewargs-ex-returned:82:4:82:25:FifthBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED
+invalid-getnewargs-ex-returned:89:4:89:25:SixthBadGetNewArgsEx.__getnewargs_ex__:__getnewargs_ex__ does not return a tuple containing (tuple, dict):UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Fix a false positive for ``invalid-getnewargs-ex-returned`` when the tuple or dict has been assigned to a name.

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10208
