### PR TITLE
Also undeprecate optparse

### DIFF
--- a/doc/whatsnew/fragments/10211.false_positive
+++ b/doc/whatsnew/fragments/10211.false_positive
@@ -1,3 +1,3 @@
-Remove `getopt` from the list of deprecated modules.
+Remove `getopt` and `optparse` from the list of deprecated modules.
 
 Closes #10211

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -47,7 +47,6 @@ _ImportTree = dict[str, Union[list[dict[str, Any]], list[str]]]
 
 DEPRECATED_MODULES = {
     (0, 0, 0): {"tkinter.tix", "fpectl"},
-    (3, 2, 0): {"optparse"},
     (3, 3, 0): {"xml.etree.cElementTree"},
     (3, 4, 0): {"imp"},
     (3, 5, 0): {"formatter"},

--- a/tests/functional/d/deprecated/deprecated_module_py3.py
+++ b/tests/functional/d/deprecated/deprecated_module_py3.py
@@ -1,4 +1,4 @@
 """Test deprecated modules."""
-# pylint: disable=unused-import
+# pylint: disable=unused-import, import-error
 
-import optparse # [deprecated-module]
+import formatter # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module_py3.txt
+++ b/tests/functional/d/deprecated/deprecated_module_py3.txt
@@ -1,1 +1,1 @@
-deprecated-module:4:0:4:15::Deprecated module 'optparse':UNDEFINED
+deprecated-module:4:0:4:16::Deprecated module 'formatter':UNDEFINED

--- a/tests/functional/d/deprecated/deprecated_module_py36.py
+++ b/tests/functional/d/deprecated/deprecated_module_py36.py
@@ -1,4 +1,4 @@
 """Test deprecated modules from Python 3.6."""
 # pylint: disable=unused-import,import-error
 
-import optparse # [deprecated-module]
+import formatter # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module_py36.txt
+++ b/tests/functional/d/deprecated/deprecated_module_py36.txt
@@ -1,1 +1,1 @@
-deprecated-module:4:0:4:15::Deprecated module 'optparse':UNDEFINED
+deprecated-module:4:0:4:16::Deprecated module 'formatter':UNDEFINED

--- a/tests/functional/d/deprecated/deprecated_relative_import/dot_relative_import.py
+++ b/tests/functional/d/deprecated/deprecated_relative_import/dot_relative_import.py
@@ -1,7 +1,7 @@
 # pylint: disable=import-error, missing-module-docstring, unused-import
 
 # from import of stdlib optparse which should yield deprecated-module error
-from optparse import OptionParser # [deprecated-module]
+from formatter import NullFormatter # [deprecated-module]
 # from import of module internal optparse module inside this package.
 # This should not yield deprecated-module error
-from .optparse import Bar
+from .formatter import Bar

--- a/tests/functional/d/deprecated/deprecated_relative_import/dot_relative_import.txt
+++ b/tests/functional/d/deprecated/deprecated_relative_import/dot_relative_import.txt
@@ -1,1 +1,1 @@
-deprecated-module:4:0:4:33::Deprecated module 'optparse':UNDEFINED
+deprecated-module:4:0:4:35::Deprecated module 'formatter':UNDEFINED

--- a/tests/functional/d/deprecated/deprecated_relative_import/subpackage/dot_dot_relative_import.py
+++ b/tests/functional/d/deprecated/deprecated_relative_import/subpackage/dot_dot_relative_import.py
@@ -1,7 +1,7 @@
-# pylint: disable=import-error, unused-import, missing-module-docstring
+# pylint: disable=import-error, missing-module-docstring, unused-import
 
 # from import of stdlib optparse which should yield deprecated-module error
-from optparse import OptionParser # [deprecated-module]
+from formatter import NullFormatter # [deprecated-module]
 # from import of module internal optparse module inside this package.
 # This should not yield deprecated-module error
-from ..optparse import Bar
+from .formatter import Bar

--- a/tests/functional/d/deprecated/deprecated_relative_import/subpackage/dot_dot_relative_import.txt
+++ b/tests/functional/d/deprecated/deprecated_relative_import/subpackage/dot_dot_relative_import.txt
@@ -1,1 +1,1 @@
-deprecated-module:4:0:4:33::Deprecated module 'optparse':UNDEFINED
+deprecated-module:4:0:4:35::Deprecated module 'formatter':UNDEFINED

--- a/tests/functional/n/no/no_member_imports.py
+++ b/tests/functional/n/no/no_member_imports.py
@@ -1,6 +1,5 @@
 """Tests for no-member on imported modules"""
 # pylint: disable=import-outside-toplevel, pointless-statement, missing-function-docstring
-# pylint: disable=deprecated-module
 
 
 def test_no_member_in_getattr():

--- a/tests/functional/n/no/no_member_imports.txt
+++ b/tests/functional/n/no/no_member_imports.txt
@@ -1,3 +1,3 @@
-no-member:10:4:10:28:test_no_member_in_getattr:Module 'math' has no 'THIS_does_not_EXIST' member:INFERENCE
-no-member:25:4:25:33:test_ignored_modules_invalid_pattern:Module 'xml.etree' has no 'THIS_does_not_EXIST' member:INFERENCE
-no-member:44:4:44:27:test_ignored_classes_no_recursive_pattern:Module 'sys' has no 'THIS_does_not_EXIST' member:INFERENCE
+no-member:9:4:9:28:test_no_member_in_getattr:Module 'math' has no 'THIS_does_not_EXIST' member:INFERENCE
+no-member:24:4:24:33:test_ignored_modules_invalid_pattern:Module 'xml.etree' has no 'THIS_does_not_EXIST' member:INFERENCE
+no-member:43:4:43:27:test_ignored_classes_no_recursive_pattern:Module 'sys' has no 'THIS_does_not_EXIST' member:INFERENCE


### PR DESCRIPTION
Upstream also undeprecated it in December (python/cpython#126227). Feels a bit weird, and sorry for not noticing this earlier. Hopefully I got the news fragment thing right. I wonder if we should mention that these modules were undeprecated?

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Refs #10211
