### PR TITLE
Fix crash in `catching-non-exception` when something besides a class in `except`

### DIFF
--- a/doc/whatsnew/fragments/10106.bugfix
+++ b/doc/whatsnew/fragments/10106.bugfix
@@ -1,0 +1,3 @@
+Fix a crash when something besides a class is found in an except handler.
+
+Closes #10106

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -432,7 +432,13 @@ class ExceptionsChecker(checkers.BaseChecker):
                 return
             if all(
                 node
-                and (utils.inherit_from_std_ex(node) or not utils.has_known_bases(node))
+                and (
+                    utils.inherit_from_std_ex(node)
+                    or (
+                        isinstance(node, nodes.ClassDef)
+                        and not utils.has_known_bases(node)
+                    )
+                )
                 for node in inferred
             ):
                 return

--- a/tests/functional/i/invalid/invalid_exceptions/invalid_exceptions_caught.py
+++ b/tests/functional/i/invalid/invalid_exceptions/invalid_exceptions_caught.py
@@ -132,3 +132,11 @@ try:
     raise ValueError
 except EXCEPTIONS:
     pass
+
+
+LAMBDA = lambda x: 1, 2
+
+try:
+    pass
+except LAMBDA:  # [catching-non-exception]
+    pass

--- a/tests/functional/i/invalid/invalid_exceptions/invalid_exceptions_caught.txt
+++ b/tests/functional/i/invalid/invalid_exceptions/invalid_exceptions_caught.txt
@@ -10,3 +10,4 @@ catching-non-exception:71:7:71:52::"Catching an exception which doesn't inherit 
 catching-non-exception:84:7:84:26::"Catching an exception which doesn't inherit from Exception: NON_EXCEPTION_TUPLE":UNDEFINED
 catching-non-exception:102:7:102:13::"Catching an exception which doesn't inherit from Exception: object":UNDEFINED
 catching-non-exception:107:7:107:12::"Catching an exception which doesn't inherit from Exception: range":UNDEFINED
+catching-non-exception:141:7:141:13::"Catching an exception which doesn't inherit from Exception: LAMBDA":UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [X] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [X] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [X] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10106
