### PR TITLE
[Backport maintenance/3.3.x] Fixed conditional import x.y causing possibly-used-before-assignment (#10240)

### DIFF
--- a/doc/whatsnew/fragments/10081.bugfix
+++ b/doc/whatsnew/fragments/10081.bugfix
@@ -1,0 +1,3 @@
+Fixed conditional import x.y causing false positive possibly-used-before-assignment.
+
+Closes #10081

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -967,7 +967,9 @@ scope_type : {self._atomic.scope_type}
             ):
                 return True
         if isinstance(node, (nodes.Import, nodes.ImportFrom)) and any(
-            (node_name[1] and node_name[1] == name) or (node_name[0] == name)
+            (node_name[1] and node_name[1] == name)
+            or (node_name[0] == name)
+            or (node_name[0].startswith(name + "."))
             for node_name in node.names
         ):
             return True

--- a/tests/functional/u/used/used_before_assignment.py
+++ b/tests/functional/u/used/used_before_assignment.py
@@ -222,3 +222,12 @@ class PlatformChecks:  # pylint: disable=missing-docstring
             self.skip("only runs on Linux/Windows")
 
         print(cmd)
+
+
+def conditional_import():
+    if input():
+        import os.path
+    else:
+        os = None
+    if os:
+        pass


### PR DESCRIPTION
(cherry picked from commit 7b28cf474796ecfb875c3c812e30865222623e41)