### PR TITLE
Bump pylint to 3.3.5, update changelog

### DIFF
--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -16,7 +16,7 @@ Summary -- Release highlights
 
 What's new in Pylint 3.3.5?
 ---------------------------
-Release date: 2025-03-08
+Release date: 2025-03-09
 
 
 False Positives Fixed

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,54 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.3.5?
+---------------------------
+Release date: 2025-03-08
+
+
+False Positives Fixed
+---------------------
+
+- Fix false positives for `use-implicit-booleaness-not-comparison`, `use-implicit-booleaness-not-comparison-to-string`
+  and `use-implicit-booleaness-not-comparison-to-zero` when chained comparisons are checked.
+
+  Closes #10065 (`#10065 <https://github.com/pylint-dev/pylint/issues/10065>`_)
+
+- Fix a false positive for ``invalid-getnewargs-ex-returned`` when the tuple or dict has been assigned to a name.
+
+  Closes #10208 (`#10208 <https://github.com/pylint-dev/pylint/issues/10208>`_)
+
+- Remove `getopt` and `optparse` from the list of deprecated modules.
+
+  Closes #10211 (`#10211 <https://github.com/pylint-dev/pylint/issues/10211>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fixed conditional import x.y causing false positive possibly-used-before-assignment.
+
+  Closes #10081 (`#10081 <https://github.com/pylint-dev/pylint/issues/10081>`_)
+
+- Fix a crash when something besides a class is found in an except handler.
+
+  Closes #10106 (`#10106 <https://github.com/pylint-dev/pylint/issues/10106>`_)
+
+- Fixed raising invalid-name when using camelCase for private methods with two leading underscores.
+
+  Closes #10189 (`#10189 <https://github.com/pylint-dev/pylint/issues/10189>`_)
+
+
+
+Other Changes
+-------------
+
+- Upload release assets to PyPI via Trusted Publishing.
+
+  Closes #10256 (`#10256 <https://github.com/pylint-dev/pylint/issues/10256>`_)
+
+
 
 What's new in Pylint 3.3.4?
 ---------------------------

--- a/doc/whatsnew/fragments/10065.false_positive
+++ b/doc/whatsnew/fragments/10065.false_positive
@@ -1,4 +1,0 @@
-Fix false positives for `use-implicit-booleaness-not-comparison`, `use-implicit-booleaness-not-comparison-to-string`
-and `use-implicit-booleaness-not-comparison-to-zero` when chained comparisons are checked.
-
-Closes #10065

--- a/doc/whatsnew/fragments/10081.bugfix
+++ b/doc/whatsnew/fragments/10081.bugfix
@@ -1,3 +1,0 @@
-Fixed conditional import x.y causing false positive possibly-used-before-assignment.
-
-Closes #10081

--- a/doc/whatsnew/fragments/10106.bugfix
+++ b/doc/whatsnew/fragments/10106.bugfix
@@ -1,3 +1,0 @@
-Fix a crash when something besides a class is found in an except handler.
-
-Closes #10106

--- a/doc/whatsnew/fragments/10189.bugfix
+++ b/doc/whatsnew/fragments/10189.bugfix
@@ -1,3 +1,0 @@
-Fixed raising invalid-name when using camelCase for private methods with two leading underscores.
-
-Closes #10189

--- a/doc/whatsnew/fragments/10208.false_positive
+++ b/doc/whatsnew/fragments/10208.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``invalid-getnewargs-ex-returned`` when the tuple or dict has been assigned to a name.
-
-Closes #10208

--- a/doc/whatsnew/fragments/10211.false_positive
+++ b/doc/whatsnew/fragments/10211.false_positive
@@ -1,3 +1,0 @@
-Remove `getopt` and `optparse` from the list of deprecated modules.
-
-Closes #10211

--- a/doc/whatsnew/fragments/10256.other
+++ b/doc/whatsnew/fragments/10256.other
@@ -1,3 +1,0 @@
-Upload release assets to PyPI via Trusted Publishing.
-
-Closes #10256

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.5a0"
+__version__ = "3.3.5"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.5a0"
+current = "3.3.5"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.


### PR DESCRIPTION
What's new in Pylint 3.3.5?
---------------------------
Release date: 2025-03-09


False Positives Fixed
---------------------

- Fix false positives for `use-implicit-booleaness-not-comparison`, `use-implicit-booleaness-not-comparison-to-string`
  and `use-implicit-booleaness-not-comparison-to-zero` when chained comparisons are checked.

  Closes #10065 

- Fix a false positive for ``invalid-getnewargs-ex-returned`` when the tuple or dict has been assigned to a name.

  Closes #10208 

- Remove `getopt` and `optparse` from the list of deprecated modules.

  Closes #10211 



Other Bug Fixes
---------------

- Fixed conditional import x.y causing false positive possibly-used-before-assignment.

  Closes #10081 

- Fix a crash when something besides a class is found in an except handler.

  Closes #10106 

- Fixed raising invalid-name when using camelCase for private methods with two leading underscores.

  Closes #10189 



Other Changes
-------------

- Upload release assets to PyPI via Trusted Publishing.

  Closes #10256