### PR TITLE
Add additional permissions for backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,8 +6,9 @@ on:
       - labeled
 
 permissions:
-  pull-requests: write
+  actions: write
   contents: write
+  pull-requests: write
 
 jobs:
   backport:


### PR DESCRIPTION
Backporting the release workflow improvements failed. E.g. #10267

```
  /usr/bin/git push --set-upstream origin backport-10267-to-maintenance/3.3.x
  To https://github.com/pylint-dev/pylint.git
   ! [remote rejected]     backport-10267-to-maintenance/3.3.x -> backport-10267-to-maintenance/3.3.x (refusing to allow a GitHub App to create or update workflow `.github/workflows/release.yml` without `workflows` permission)
  error: failed to push some refs to 'https://github.com/pylint-dev/pylint.git'
```

https://github.com/pylint-dev/pylint/actions/runs/13748264125/job/38445990683#step:2:32

Judging by the error message, the action needs additional permissions to update workflow files.