### PR TITLE
Update OSS-Fuzz docs to use uv instead of pyenv

### DIFF
--- a/doc/development_guide/contributor_guide/oss_fuzz.rst
+++ b/doc/development_guide/contributor_guide/oss_fuzz.rst
@@ -47,22 +47,19 @@ commands:
 
 .. code:: bash
 
-  # Note: Atheris doesn't support Python 3.12+ yet:
-  # https://github.com/google/atheris/issues/82
   mkdir fuzzing-repro
   cd fuzzing-repro
 
-  pyenv install --skip-existing 3.11
-  pyenv shell 3.11
-
-  python -m venv .venv-fuzzing-repro
-  source .venv-fuzzing-repro/bin/activate
+  # Note: Atheris doesn't support Python 3.12+ yet:
+  # https://github.com/google/atheris/issues/82
+  uv venv --python 3.11
+  source .venv/bin/activate
 
   git clone https://github.com/pylint-dev/astroid.git
   cd astroid
 
-  pip install atheris
-  pip install --editable .
+  uv pip install atheris==2.3.0
+  uv pip install --editable .
 
   # Save the minimized testcase as `minimized.py` in the astroid directory
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

uv seems easier to use than pyenv for temporary virtual environments with older Python versions.