### PR TITLE
Speed up the generation of no-member suggestions

### DIFF
--- a/doc/whatsnew/fragments/10277.other
+++ b/doc/whatsnew/fragments/10277.other
@@ -1,0 +1,4 @@
+The algorithm used for ``no-member`` suggestions is now more efficient and cut the
+calculation when the distance score is already above the threshold.
+
+Refs #10277

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -183,9 +183,6 @@ def _similar_names(
     The similar names are searched given a distance metric and only
     a given number of choices will be returned.
     """
-    if max_choices <= 0:
-        return []
-
     possible_names: list[tuple[str, int]] = []
     names = _node_names(owner)
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -150,8 +150,12 @@ def _(node: nodes.ClassDef | bases.Instance) -> Iterable[str]:
     return itertools.chain(values, other_values)
 
 
-def _string_distance(seq1: str, seq2: str) -> int:
-    seq2_length = len(seq2)
+def _string_distance(seq1: str, seq2: str, seq1_length: int, seq2_length: int) -> int:
+    if not seq1_length:
+        return seq2_length
+
+    if not seq2_length:
+        return seq1_length
 
     row = [*list(range(1, seq2_length + 1)), 0]
     for seq1_index, seq1_char in enumerate(seq1):
@@ -179,14 +183,26 @@ def _similar_names(
     The similar names are searched given a distance metric and only
     a given number of choices will be returned.
     """
+    if max_choices <= 0:
+        return []
+
     possible_names: list[tuple[str, int]] = []
     names = _node_names(owner)
+
+    attr_str = attrname or ""
+    attr_len = len(attr_str)
 
     for name in names:
         if name == attrname:
             continue
 
-        distance = _string_distance(attrname or "", name)
+        name_len = len(name)
+
+        min_distance = abs(attr_len - name_len)
+        if min_distance > distance_threshold:
+            continue
+
+        distance = _string_distance(attr_str, name, attr_len, name_len)
         if distance <= distance_threshold:
             possible_names.append((name, distance))
 

--- a/tests/checkers/unittest_typecheck.py
+++ b/tests/checkers/unittest_typecheck.py
@@ -221,3 +221,47 @@ class TestTypeCheckerOnDecorators(CheckerTestCase):
             )
         ):
             self.checker.visit_subscript(subscript)
+
+
+class TestTypeCheckerStringDistance:
+    """Tests for the _string_distance helper in pylint.checkers.typecheck."""
+
+    def test_string_distance_identical_strings(self) -> None:
+        seq1 = "hi"
+        seq2 = "hi"
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 0
+
+        seq1, seq2 = seq2, seq1
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 0
+
+    def test_string_distance_empty_string(self) -> None:
+        seq1 = ""
+        seq2 = "hi"
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 2
+
+        seq1, seq2 = seq2, seq1
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 2
+
+    def test_string_distance_edit_distance_one_character(self) -> None:
+        seq1 = "hi"
+        seq2 = "he"
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 1
+
+        seq1, seq2 = seq2, seq1
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 1
+
+    def test_string_distance_edit_distance_multiple_similar_characters(self) -> None:
+        seq1 = "hello"
+        seq2 = "yelps"
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 3
+
+        seq1, seq2 = seq2, seq1
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 3
+
+    def test_string_distance_edit_distance_all_dissimilar_characters(self) -> None:
+        seq1 = "yellow"
+        seq2 = "orange"
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 6
+
+        seq1, seq2 = seq2, seq1
+        assert typecheck._string_distance(seq1, seq2, len(seq1), len(seq2)) == 6


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

Previously, edit distances were calculated for strings that had length differences greater than the maximum suggestion threshold.

Related PR:
- https://github.com/pylint-dev/pylint/pull/9962

## Stats

I profiled yt-dlp (commit bd0a6681) with the following `.pylintrc` file:

```
[MAIN]
jobs=1

[MESSAGES CONTROL]
disable=all
enable=no-member

[REPORTS]
reports=no
score=no
```

### Before

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 39.161 ± 0.175 | 38.929 | 39.548 | 1.00 |


```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   103292    3.706    0.000    5.653    0.000 pylint/checkers/typecheck.py:153(_string_distance)
 19623350    1.938    0.000    1.938    0.000 {built-in method builtins.min}
      245    0.039    0.000    5.747    0.023 pylint/checkers/typecheck.py:171(_similar_names)
```

### After

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pylint --recursive=y .` | 37.009 ± 0.249 | 36.650 | 37.333 | 1.00 |

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    15159    0.460    0.000    0.704    0.000 pylint/checkers/typecheck.py:153(_string_distance)
  2429889    0.244    0.000    0.244    0.000 {built-in method builtins.min}
      245    0.035    0.000    0.807    0.003 pylint/checkers/typecheck.py:175(_similar_names)
```