### PR TITLE
GitHub Actions: Make pip commands more self-documenting

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -52,9 +52,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt
-          pip install -U -r doc/requirements.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test.txt --requirement doc/requirements.txt
       - name: Emit warning if news fragment is missing
         env:
           BASE_BRANCH: ${{ github.base_ref }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -60,9 +60,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt
-          pip install -U -r doc/requirements.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test.txt --requirement doc/requirements.txt
           pip install pre-commit
       - name: Generate pre-commit restore key
         id: generate-pre-commit-key

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -62,8 +62,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test.txt
 
   pytest-primer-stdlib:
     name: run on stdlib / ${{ matrix.python-version }} / Linux
@@ -72,7 +72,7 @@ jobs:
     needs: prepare-tests-linux
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -58,8 +58,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test.txt
       # Save cached Python environment (explicit because cancel-in-progress: true)
       - name: Save Python virtual environment to cache
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -70,8 +70,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test.txt
       # Save cached Python environment (explicit because cancel-in-progress: true)
       - name: Save Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}
     steps:
@@ -63,8 +63,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test.txt
       - name: Run pytest
         run: |
           . venv/bin/activate
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Set temp directory
         run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
@@ -210,8 +210,8 @@ jobs:
         run: |
           python -m venv venv
           . venv\\Scripts\\activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test_min.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test_min.txt
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate
@@ -227,7 +227,7 @@ jobs:
       fail-fast: false
       matrix:
         # We only run on the oldest supported version on Mac
-        python-version: [3.9]
+        python-version: ["3.9"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2
@@ -256,8 +256,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test_min.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test_min.txt
       - name: Run pytest
         run: |
           . venv/bin/activate
@@ -300,8 +300,8 @@ jobs:
         run: |
           python -m venv venv
           . venv/bin/activate
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements_test_min.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade --requirement requirements_test_min.txt
       - name: Run pytest
         run: |
           . venv/bin/activate


### PR DESCRIPTION
`pip install --help` shows six different `--u*` options so when writing commands that others will read, explicitly use the self-documenting `--upgrade` instead of `-U`.
* --user
* --upgrade
* --upgrade-strategy <upgrade_strategy>
* --use-pep517
* --use-feature <feature>
* --use-deprecated <feature>