### PR TITLE
Bump pylint to 3.3.6, update changelog

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -379,6 +379,7 @@ contributors:
 - Yang Yang <y4n9squared@gmail.com>
 - Xi Shen <davidshen84@gmail.com>
 - Winston H <56998716+winstxnhdw@users.noreply.github.com>
+- Wing Lian <wing.lian@gmail.com>
 - Will Shanks <wsha@posteo.net>
 - Viorel Știrbu <viorels@gmail.com>: intern-builtin warning.
 - VictorT <victor.taix@gmail.com>

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,21 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.3.6?
+---------------------------
+Release date: 2025-03-20
+
+
+False Positives Fixed
+---------------------
+
+- Fix a false positive for `used-before-assignment` when an inner function's return type
+  annotation is a class defined at module scope.
+
+  Closes #9391 (`#9391 <https://github.com/pylint-dev/pylint/issues/9391>`_)
+
+
+
 What's new in Pylint 3.3.5?
 ---------------------------
 Release date: 2025-03-09

--- a/doc/whatsnew/fragments/9391.false_positive
+++ b/doc/whatsnew/fragments/9391.false_positive
@@ -1,4 +1,0 @@
-Fix a false positive for `used-before-assignment` when an inner function's return type
-annotation is a class defined at module scope.
-
-Closes #9391

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.5"
+__version__ = "3.3.6"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.5"
+current = "3.3.6"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.3.5"
+version = "3.3.6"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.3/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.3.6?
---------------------------
Release date: 2025-03-20


False Positives Fixed
---------------------

- Fix a false positive for `used-before-assignment` when an inner function's return type
  annotation is a class defined at module scope.

  Closes #9391 