### PR TITLE
Fix crash caused by invalid format strings in `.format` context

### DIFF
--- a/doc/whatsnew/fragments/10282.bugfix
+++ b/doc/whatsnew/fragments/10282.bugfix
@@ -1,0 +1,3 @@
+Fix a crash caused by malformed format strings when using `.format` with keyword arguments.
+
+Closes #10282

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -417,9 +417,12 @@ class RecommendationChecker(checkers.BaseChecker):
                     keyword = utils.safe_infer(keyword.value)
 
                     # If lists of more than one element are being unpacked
-                    if isinstance(keyword, nodes.Dict):
-                        if len(keyword.items) > 1 and len(keyword_args) > 1:
-                            return
+                    if (
+                        isinstance(keyword, nodes.Dict)
+                        and len(keyword.items) > 1
+                        and len(keyword_args) > 1
+                    ):
+                        return
 
             # If all tests pass, then raise message
             self.add_message(
@@ -447,12 +450,10 @@ class RecommendationChecker(checkers.BaseChecker):
             inferred_right = utils.safe_infer(node.parent.right)
 
             # If dicts or lists of length > 1 are used
-            if isinstance(inferred_right, nodes.Dict):
-                if len(inferred_right.items) > 1:
-                    return
-            elif isinstance(inferred_right, nodes.List):
-                if len(inferred_right.elts) > 1:
-                    return
+            if isinstance(inferred_right, nodes.Dict) and len(inferred_right.items) > 1:
+                return
+            if isinstance(inferred_right, nodes.List) and len(inferred_right.elts) > 1:
+                return
 
             # If all tests pass, then raise message
             self.add_message(

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -386,6 +386,14 @@ class RecommendationChecker(checkers.BaseChecker):
             if not isinstance(node.parent.parent, nodes.Call):
                 return
 
+            # Don't raise message on bad format string
+            try:
+                keyword_args = [
+                    i[0] for i in utils.parse_format_method_string(node.value)[0]
+                ]
+            except utils.IncompleteFormatString:
+                return
+
             if node.parent.parent.args:
                 for arg in node.parent.parent.args:
                     # If star expressions with more than 1 element are being used
@@ -401,9 +409,6 @@ class RecommendationChecker(checkers.BaseChecker):
                         return
 
             elif node.parent.parent.keywords:
-                keyword_args = [
-                    i[0] for i in utils.parse_format_method_string(node.value)[0]
-                ]
                 for keyword in node.parent.parent.keywords:
                     # If keyword is used multiple times
                     if keyword_args.count(keyword.arg) > 1:

--- a/tests/functional/c/consider/consider_using_f_string.py
+++ b/tests/functional/c/consider/consider_using_f_string.py
@@ -128,3 +128,11 @@ def regression_tests():
         print(value)
 
     wrap_print(value="{}".format)
+
+
+def invalid_format_string_good():
+    """Should not raise message when `.format` is called with an invalid format string."""
+    # pylint: disable=bad-format-string
+    print("{a[0] + a[1]}".format(a=[0, 1]))
+    print("{".format(a=1))
+    print("{".format(1))


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->

This PR addresses a crash in the `consider-using-f-string` check that occurs when `.format` is used with keyword arguments and the format string is malformed. The `utils.parse_format_method_string` raises an uncaught `IncompleteFormatString` exception, leading to the unexpected crash.

Another observation is `consider-using-f-string` is raised when `.format` is used with positional arguments:

```
print("{".format(1))  # [consider-using-f-string], [bad-format-string]
```

In such cases, it seems more appropriate to suppress `consider-using-f-string`, since the `bad-format-string` message already covers the issue.


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10282
