### PR TITLE
Fix typo in missing-member-hint-distance documentation

### DIFF
--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -603,7 +603,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
 # of finding the hint is based on edit distance.
 missing-member-hint=yes
 
-# The minimum edit distance a name should have in order to be considered a
+# The maximum edit distance a name should have in order to be considered a
 # similar match for a missing member name.
 missing-member-hint-distance=1
 

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -533,7 +533,7 @@ ignored-classes = [ "optparse.Values", "thread._local", "_thread._local", "argpa
 # finding the hint is based on edit distance.
 missing-member-hint = true
 
-# The minimum edit distance a name should have in order to be considered a
+# The maximum edit distance a name should have in order to be considered a
 # similar match for a missing member name.
 missing-member-hint-distance = 1
 

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -956,7 +956,7 @@ accessed. Python regular expressions are accepted.",
                 "default": 1,
                 "type": "int",
                 "metavar": "<member hint edit distance>",
-                "help": "The minimum edit distance a name should have in order "
+                "help": "The maximum edit distance a name should have in order "
                 "to be considered a similar match for a missing member name.",
             },
         ),

--- a/pylintrc
+++ b/pylintrc
@@ -378,7 +378,7 @@ ignore-on-opaque-inference=yes
 # of finding the hint is based on edit distance.
 missing-member-hint=yes
 
-# The minimum edit distance a name should have in order to be considered a
+# The maximum edit distance a name should have in order to be considered a
 # similar match for a missing member name.
 missing-member-hint-distance=1
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

The `missing-member-hint-distance` value is the upper limit rather than the lower limit:

https://github.com/pylint-dev/pylint/blob/9a6168d3041b1f155b4021fdfe79f1729d9f8ee6/pylint/checkers/typecheck.py#L203-L204