### PR TITLE
Fix `FUNDING.yml`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,17 +1,3 @@
 # These are supported funding model platforms
-
 tidelift: "pypi/pylint"
-github:
-  [
-    PCManticore,
-    Pierre-Sassoulas,
-    cdce8p,
-    hippo91,
-    AWhetter,
-    DanielNoord,
-    areveny,
-    DudeNr33,
-    jacobtylerwalls,
-    matusvalo,
-    yushao2,
-  ]
+github: [PCManticore, Pierre-Sassoulas, cdce8p, hippo91, AWhetter, DanielNoord, areveny, DudeNr33, jacobtylerwalls, matusvalo, yushao2]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 tidelift: "pypi/pylint"
-github: [PCManticore, Pierre-Sassoulas, cdce8p, hippo91, AWhetter, DanielNoord, areveny, DudeNr33, jacobtylerwalls, matusvalo, yushao2]
+github: [cdce8p, DanielNoord, jacobtylerwalls,Pierre-Sassoulas]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,7 @@ repos:
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
-        exclude: tests(/\w*)*data/|.github/FUNDING.yml
+        exclude: (tests(/\w*)*data/|.github/FUNDING.yml)
   - repo: https://github.com/DanielNoord/pydocstringformatter
     rev: v0.7.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,7 @@ repos:
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
-        exclude: tests(/\w*)*data/
+        exclude: tests(/\w*)*data/|.github/FUNDING.yml
   - repo: https://github.com/DanielNoord/pydocstringformatter
     rev: v0.7.2
     hooks:


### PR DESCRIPTION
@Pierre-Sassoulas I was wondering why me and @yushao2 do not show up on the homepage of the repository.

I think this is because you can't actually have these be multi-line.
See:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

In fact, I think for this to work we actually need to prune this list to 4 contributors 😅 

Should we do so? Or should we just remove this list as it is broken and only rely on tidelift?