### PR TITLE
[fix] Fix a crash for class decorators mistaken for class attributes

### DIFF
--- a/doc/whatsnew/fragments/10105.bugfix
+++ b/doc/whatsnew/fragments/10105.bugfix
@@ -1,0 +1,3 @@
+Fixed a crash when importing a class decorator that did not exist with the same name than a class attribute after the class definition.
+
+Closes #10105

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2445,7 +2445,7 @@ class VariablesChecker(BaseChecker):
         node_frame = node.frame()
 
         parent = node
-        while parent is not defstmt_frame.parent:
+        while parent not in {defstmt_frame.parent, None}:
             parent_scope = parent.scope()
 
             # Find out if any nonlocals receive values in nested functions

--- a/tests/functional/r/regression_02/regression_10105.py
+++ b/tests/functional/r/regression_02/regression_10105.py
@@ -1,0 +1,9 @@
+# pylint: disable=too-few-public-methods,missing-docstring,used-before-assignment,import-error,unused-import
+# pylint: disable=wrong-import-position
+
+
+@decorator
+class DecoratedClass:
+    decorator: int
+
+import decorator


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #10105
