### PR TITLE
Bump pylint to 3.3.7, update changelog

### DIFF
--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,47 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.3.7?
+---------------------------
+Release date: 2025-05-04
+
+
+False Positives Fixed
+---------------------
+
+- Comparisons between two calls to `type()` won't raise an ``unidiomatic-typecheck`` warning anymore, consistent with the behavior applied only for ``==`` previously.
+
+  Closes #10161 (`#10161 <https://github.com/pylint-dev/pylint/issues/10161>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fixed a crash when importing a class decorator that did not exist with the same name than a class attribute after the class definition.
+
+  Closes #10105 (`#10105 <https://github.com/pylint-dev/pylint/issues/10105>`_)
+
+- Fix a crash caused by malformed format strings when using `.format` with keyword arguments.
+
+  Closes #10282 (`#10282 <https://github.com/pylint-dev/pylint/issues/10282>`_)
+
+- Using a slice as a class decorator now raise a 'not-callable' message instead of crashing pylint. A lot of checks that dealt with decorators (too many to list) are now shortcut if the decorator can't immediately be inferred to a function or class definition.
+
+  Closes #10334 (`#10334 <https://github.com/pylint-dev/pylint/issues/10334>`_)
+
+
+
+Other Changes
+-------------
+
+- The algorithm used for ``no-member`` suggestions is now more efficient and cut the
+  calculation when the distance score is already above the threshold.
+
+  Refs #10277 (`#10277 <https://github.com/pylint-dev/pylint/issues/10277>`_)
+
+
+
 What's new in Pylint 3.3.6?
 ---------------------------
 Release date: 2025-03-20

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -31,7 +31,7 @@ False Positives Fixed
 Other Bug Fixes
 ---------------
 
-- Fixed a crash when importing a class decorator that did not exist with the same name than a class attribute after the class definition.
+- Fixed a crash when importing a class decorator that did not exist with the same name as a class attribute after the class definition.
 
   Closes #10105 (`#10105 <https://github.com/pylint-dev/pylint/issues/10105>`_)
 
@@ -39,7 +39,7 @@ Other Bug Fixes
 
   Closes #10282 (`#10282 <https://github.com/pylint-dev/pylint/issues/10282>`_)
 
-- Using a slice as a class decorator now raise a 'not-callable' message instead of crashing pylint. A lot of checks that dealt with decorators (too many to list) are now shortcut if the decorator can't immediately be inferred to a function or class definition.
+- Using a slice as a class decorator now raises a ``not-callable`` message instead of crashing. A lot of checks that dealt with decorators (too many to list) are now shortcut if the decorator can't immediately be inferred to a function or class definition.
 
   Closes #10334 (`#10334 <https://github.com/pylint-dev/pylint/issues/10334>`_)
 
@@ -48,7 +48,7 @@ Other Bug Fixes
 Other Changes
 -------------
 
-- The algorithm used for ``no-member`` suggestions is now more efficient and cut the
+- The algorithm used for ``no-member`` suggestions is now more efficient and cuts the
   calculation when the distance score is already above the threshold.
 
   Refs #10277 (`#10277 <https://github.com/pylint-dev/pylint/issues/10277>`_)

--- a/doc/whatsnew/fragments/10105.bugfix
+++ b/doc/whatsnew/fragments/10105.bugfix
@@ -1,3 +1,0 @@
-Fixed a crash when importing a class decorator that did not exist with the same name than a class attribute after the class definition.
-
-Closes #10105

--- a/doc/whatsnew/fragments/10161.false_positive
+++ b/doc/whatsnew/fragments/10161.false_positive
@@ -1,3 +1,0 @@
-Comparisons between two calls to `type()` won't raise an ``unidiomatic-typecheck`` warning anymore, consistent with the behavior applied only for ``==`` previously.
-
-Closes #10161

--- a/doc/whatsnew/fragments/10277.other
+++ b/doc/whatsnew/fragments/10277.other
@@ -1,4 +1,0 @@
-The algorithm used for ``no-member`` suggestions is now more efficient and cut the
-calculation when the distance score is already above the threshold.
-
-Refs #10277

--- a/doc/whatsnew/fragments/10282.bugfix
+++ b/doc/whatsnew/fragments/10282.bugfix
@@ -1,3 +1,0 @@
-Fix a crash caused by malformed format strings when using `.format` with keyword arguments.
-
-Closes #10282

--- a/doc/whatsnew/fragments/10334.bugfix
+++ b/doc/whatsnew/fragments/10334.bugfix
@@ -1,3 +1,0 @@
-Using a slice as a class decorator now raise a 'not-callable' message instead of crashing pylint. A lot of checks that dealt with decorators (too many to list) are now shortcut if the decorator can't immediately be inferred to a function or class definition.
-
-Closes #10334

--- a/examples/pylintrc
+++ b/examples/pylintrc
@@ -495,10 +495,10 @@ evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor 
 # used to format the message information. See doc for all details.
 msg-template=
 
-# Set the output format. Available formats are: text, parseable, colorized,
-# json2 (improved json format), json (old json format) and msvs (visual
-# studio). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
 #output-format=
 
 # Tells whether to display a full report or only the messages.

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -438,9 +438,10 @@ evaluation = "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refact
 # used to format the message information. See doc for all details.
 # msg-template =
 
-# Set the output format. Available formats are: text, parseable, colorized, json2
-# (improved json format), json (old json format) and msvs (visual studio). You
-# can also give a reporter class, e.g. mypackage.mymodule.MyReporterClass.
+# Set the output format. Available formats are: 'text', 'parseable', 'colorized',
+# 'json2' (improved json format), 'json' (old json format), msvs (visual studio)
+# and 'github' (GitHub actions). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
 # output-format =
 
 # Tells whether to display a full report or only the messages.

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.6"
+__version__ = "3.3.7"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.6"
+current = "3.3.7"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.3.6"
+version = "3.3.7"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.3/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.3.7?
---------------------------
Release date: 2025-05-04


False Positives Fixed
---------------------

- Comparisons between two calls to `type()` won't raise an ``unidiomatic-typecheck`` warning anymore, consistent with the behavior applied only for ``==`` previously.

  Closes #10161



Other Bug Fixes
---------------

- Fixed a crash when importing a class decorator that did not exist with the same name than a class attribute after the class definition.

  Closes #10105

- Fix a crash caused by malformed format strings when using `.format` with keyword arguments.

  Closes #10282 

- Using a slice as a class decorator now raise a 'not-callable' message instead of crashing pylint. A lot of checks that dealt with decorators (too many to list) are now shortcut if the decorator can't immediately be inferred to a function or class definition.

  Closes #10334 



Other Changes
-------------

- The algorithm used for ``no-member`` suggestions is now more efficient and cut the
  calculation when the distance score is already above the threshold.

  Refs #10277