### PR TITLE
Remove types-setuptools test dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,13 +128,7 @@ repos:
         args: []
         require_serial: true
         additional_dependencies:
-          [
-            "isort>=5",
-            "platformdirs==2.2.0",
-            "py==1.11",
-            "tomlkit>=0.10.1",
-            "types-setuptools==75.6.0.20241126",
-          ]
+          ["isort>=5", "platformdirs==2.2.0", "py==1.11", "tomlkit>=0.10.1"]
         exclude: tests(/\w*)*/functional/|tests/input|tests(/.*)+/conftest.py|doc/data/messages|tests(/\w*)*data/
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.5.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,6 +5,4 @@ contributors-txt>=1.0.0
 pytest-cov~=6.1
 pytest-xdist~=3.6
 six
-# Type packages for mypy
-types-setuptools==80.4.0.20250511
 tox>=3


### PR DESCRIPTION
AFAICT `types-setuptools` isn't needed anymore. In the past it was used for `pkg_resources` (see #10119), however since then the module includes a `py.typed` file. Furthermore, I couldn't find any active uses for `pkg_resources` in our codebase.