### PR TITLE
Initial fixes for Python 3.14

### DIFF
--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -648,7 +648,7 @@ class NameChecker(_BasicChecker):
             qname = inferred.qname()
             if qname == "typing.TypeAlias":
                 return True
-            if qname in {".Union", "builtins.UnionType"}:
+            if qname in {".Union", "builtins.Union", "builtins.UnionType"}:
                 # Union is a special case because it can be used as a type alias
                 # or as a type annotation. We only want to check the former.
                 assert node is not None

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -354,7 +354,7 @@ class TypingChecker(BaseChecker):
         inferred = safe_infer(node)
         if not (
             (
-                isinstance(inferred, nodes.FunctionDef)
+                isinstance(inferred, (nodes.FunctionDef, nodes.ClassDef))
                 and inferred.qname() in {"typing.Optional", "typing.Union"}
             )
             or (
@@ -538,7 +538,7 @@ class TypingChecker(BaseChecker):
         inferred_parent = safe_infer(parent_subscript.value)
         if not (
             (
-                isinstance(inferred_parent, nodes.FunctionDef)
+                isinstance(inferred_parent, (nodes.FunctionDef, nodes.ClassDef))
                 and inferred_parent.qname() in {"typing.Optional", "typing.Union"}
             )
             or (

--- a/tests/functional/g/generic_alias/generic_alias_collections.py
+++ b/tests/functional/g/generic_alias/generic_alias_collections.py
@@ -66,9 +66,6 @@ collections.abc.Sized
 collections.abc.Hashable[int]  # [unsubscriptable-object]
 collections.abc.Sized[int]  # [unsubscriptable-object]
 
-# subscriptable with Python 3.9
-collections.abc.ByteString[int]
-
 
 # Missing implementation for 'collections.abc' derived classes
 class DerivedHashable(collections.abc.Hashable):  # [abstract-method]  # __hash__
@@ -117,7 +114,6 @@ var_iterable: collections.abc.Iterable[int]
 var_awaitable: collections.abc.Awaitable[int]
 var_contextmanager: contextlib.AbstractContextManager[int]
 var_pattern: re.Pattern[int]
-var_bytestring: collections.abc.ByteString
 var_hashable: collections.abc.Hashable
 var_sized: collections.abc.Sized
 
@@ -125,6 +121,3 @@ var_sized: collections.abc.Sized
 var_int: int[int]  # [unsubscriptable-object]
 var_hashable2: collections.abc.Hashable[int]  # [unsubscriptable-object]
 var_sized2: collections.abc.Sized[int]  # [unsubscriptable-object]
-
-# subscriptable with Python 3.9
-var_bytestring2: collections.abc.ByteString[int]

--- a/tests/functional/g/generic_alias/generic_alias_collections.txt
+++ b/tests/functional/g/generic_alias/generic_alias_collections.txt
@@ -1,16 +1,16 @@
 unsubscriptable-object:66:0:66:24::Value 'collections.abc.Hashable' is unsubscriptable:UNDEFINED
 unsubscriptable-object:67:0:67:21::Value 'collections.abc.Sized' is unsubscriptable:UNDEFINED
-abstract-method:74:0:74:21:DerivedHashable:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedHashable':INFERENCE
-abstract-method:77:0:77:21:DerivedIterable:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedIterable':INFERENCE
-abstract-method:80:0:80:23:DerivedCollection:Method '__contains__' is abstract in class 'Container' but is not overridden in child class 'DerivedCollection':INFERENCE
-abstract-method:80:0:80:23:DerivedCollection:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedCollection':INFERENCE
-abstract-method:80:0:80:23:DerivedCollection:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedCollection':INFERENCE
-abstract-method:99:0:99:21:DerivedMultiple:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedMultiple':INFERENCE
-abstract-method:99:0:99:21:DerivedMultiple:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedMultiple':INFERENCE
-abstract-method:104:0:104:24:CustomAbstractCls2:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
-abstract-method:104:0:104:24:CustomAbstractCls2:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
-abstract-method:106:0:106:26:CustomImplementation:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomImplementation':INFERENCE
-abstract-method:106:0:106:26:CustomImplementation:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomImplementation':INFERENCE
-unsubscriptable-object:125:9:125:12::Value 'int' is unsubscriptable:UNDEFINED
-unsubscriptable-object:126:15:126:39::Value 'collections.abc.Hashable' is unsubscriptable:UNDEFINED
-unsubscriptable-object:127:12:127:33::Value 'collections.abc.Sized' is unsubscriptable:UNDEFINED
+abstract-method:71:0:71:21:DerivedHashable:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedHashable':INFERENCE
+abstract-method:74:0:74:21:DerivedIterable:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedIterable':INFERENCE
+abstract-method:77:0:77:23:DerivedCollection:Method '__contains__' is abstract in class 'Container' but is not overridden in child class 'DerivedCollection':INFERENCE
+abstract-method:77:0:77:23:DerivedCollection:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedCollection':INFERENCE
+abstract-method:77:0:77:23:DerivedCollection:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedCollection':INFERENCE
+abstract-method:96:0:96:21:DerivedMultiple:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedMultiple':INFERENCE
+abstract-method:96:0:96:21:DerivedMultiple:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedMultiple':INFERENCE
+abstract-method:101:0:101:24:CustomAbstractCls2:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
+abstract-method:101:0:101:24:CustomAbstractCls2:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
+abstract-method:103:0:103:26:CustomImplementation:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomImplementation':INFERENCE
+abstract-method:103:0:103:26:CustomImplementation:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomImplementation':INFERENCE
+unsubscriptable-object:121:9:121:12::Value 'int' is unsubscriptable:UNDEFINED
+unsubscriptable-object:122:15:122:39::Value 'collections.abc.Hashable' is unsubscriptable:UNDEFINED
+unsubscriptable-object:123:12:123:33::Value 'collections.abc.Sized' is unsubscriptable:UNDEFINED

--- a/tests/functional/g/generic_alias/generic_alias_typing.py
+++ b/tests/functional/g/generic_alias/generic_alias_typing.py
@@ -55,15 +55,11 @@ typing.AsyncContextManager[int]
 # re
 typing.Pattern[str]
 typing.Match[str]
-typing.re.Pattern[str]
-typing.re.Match[str]
 
 
 # unsubscriptable types
-typing.ByteString
 typing.Hashable
 typing.Sized
-typing.ByteString[int]  # [unsubscriptable-object]
 typing.Hashable[int]  # [unsubscriptable-object]
 typing.Sized[int]  # [unsubscriptable-object]
 
@@ -129,14 +125,11 @@ var_iterable: typing.Iterable[int]
 var_awaitable: typing.Awaitable[int]
 var_contextmanager: typing.ContextManager[int]
 var_pattern: typing.Pattern[int]
-var_pattern2: typing.re.Pattern[int]
-var_bytestring: typing.ByteString
 var_hashable: typing.Hashable
 var_sized: typing.Sized
 
 # Type annotation with unsubscriptable type
 var_int: int[int]  # [unsubscriptable-object]
-var_bytestring2: typing.ByteString[int]  # [unsubscriptable-object]
 var_hashable2: typing.Hashable[int]  # [unsubscriptable-object]
 var_sized2: typing.Sized[int]  # [unsubscriptable-object]
 

--- a/tests/functional/g/generic_alias/generic_alias_typing.txt
+++ b/tests/functional/g/generic_alias/generic_alias_typing.txt
@@ -1,21 +1,19 @@
-unsubscriptable-object:66:0:66:17::Value 'typing.ByteString' is unsubscriptable:UNDEFINED
-unsubscriptable-object:67:0:67:15::Value 'typing.Hashable' is unsubscriptable:UNDEFINED
-unsubscriptable-object:68:0:68:12::Value 'typing.Sized' is unsubscriptable:UNDEFINED
-abstract-method:72:0:72:21:DerivedHashable:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedHashable':INFERENCE
-abstract-method:75:0:75:21:DerivedIterable:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedIterable':INFERENCE
-abstract-method:78:0:78:23:DerivedCollection:Method '__contains__' is abstract in class 'Container' but is not overridden in child class 'DerivedCollection':INFERENCE
-abstract-method:78:0:78:23:DerivedCollection:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedCollection':INFERENCE
-abstract-method:78:0:78:23:DerivedCollection:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedCollection':INFERENCE
-abstract-method:100:0:100:21:DerivedMultiple:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedMultiple':INFERENCE
-abstract-method:100:0:100:21:DerivedMultiple:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedMultiple':INFERENCE
-abstract-method:105:0:105:24:CustomAbstractCls2:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
-abstract-method:105:0:105:24:CustomAbstractCls2:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
-abstract-method:107:0:107:26:CustomImplementation:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomImplementation':INFERENCE
-abstract-method:107:0:107:26:CustomImplementation:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomImplementation':INFERENCE
-abstract-method:118:0:118:22:DerivedIterable2:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedIterable2':INFERENCE
-unsubscriptable-object:138:9:138:12::Value 'int' is unsubscriptable:UNDEFINED
-unsubscriptable-object:139:17:139:34::Value 'typing.ByteString' is unsubscriptable:UNDEFINED
-unsubscriptable-object:140:15:140:30::Value 'typing.Hashable' is unsubscriptable:UNDEFINED
-unsubscriptable-object:141:12:141:24::Value 'typing.Sized' is unsubscriptable:UNDEFINED
-unsubscriptable-object:148:8:148:9::Value 'A' is unsubscriptable:UNDEFINED
-unsubscriptable-object:150:8:150:9:B:Value 'A' is unsubscriptable:UNDEFINED
+unsubscriptable-object:63:0:63:15::Value 'typing.Hashable' is unsubscriptable:UNDEFINED
+unsubscriptable-object:64:0:64:12::Value 'typing.Sized' is unsubscriptable:UNDEFINED
+abstract-method:68:0:68:21:DerivedHashable:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedHashable':INFERENCE
+abstract-method:71:0:71:21:DerivedIterable:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedIterable':INFERENCE
+abstract-method:74:0:74:23:DerivedCollection:Method '__contains__' is abstract in class 'Container' but is not overridden in child class 'DerivedCollection':INFERENCE
+abstract-method:74:0:74:23:DerivedCollection:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedCollection':INFERENCE
+abstract-method:74:0:74:23:DerivedCollection:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedCollection':INFERENCE
+abstract-method:96:0:96:21:DerivedMultiple:Method '__hash__' is abstract in class 'Hashable' but is not overridden in child class 'DerivedMultiple':INFERENCE
+abstract-method:96:0:96:21:DerivedMultiple:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'DerivedMultiple':INFERENCE
+abstract-method:101:0:101:24:CustomAbstractCls2:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
+abstract-method:101:0:101:24:CustomAbstractCls2:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomAbstractCls2':INFERENCE
+abstract-method:103:0:103:26:CustomImplementation:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'CustomImplementation':INFERENCE
+abstract-method:103:0:103:26:CustomImplementation:Method '__len__' is abstract in class 'Sized' but is not overridden in child class 'CustomImplementation':INFERENCE
+abstract-method:114:0:114:22:DerivedIterable2:Method '__iter__' is abstract in class 'Iterable' but is not overridden in child class 'DerivedIterable2':INFERENCE
+unsubscriptable-object:132:9:132:12::Value 'int' is unsubscriptable:UNDEFINED
+unsubscriptable-object:133:15:133:30::Value 'typing.Hashable' is unsubscriptable:UNDEFINED
+unsubscriptable-object:134:12:134:24::Value 'typing.Sized' is unsubscriptable:UNDEFINED
+unsubscriptable-object:141:8:141:9::Value 'A' is unsubscriptable:UNDEFINED
+unsubscriptable-object:143:8:143:9:B:Value 'A' is unsubscriptable:UNDEFINED


### PR DESCRIPTION
Start fixing some Python 3.14 errors. Tested against 3.14.0b1 locally. Mainly
- Adjust checkers to handle the "new" Union inference result. I.e. it's now a `ClassDef` instead of a `FunctionDef` and the builtins type is `Union` instead of `UnionType`.
- Remove `typing.ByteString` and `collections.abc.ByteString` as these have been removed in `3.14`. It's probably not worth it to add separate test cases just for them.
- Also remove `typing.re.Pattern` and `typing.re.Match` which have been removed back in `3.13`. pylint doesn't emit `no-member` warnings for these since the typing module has a `__getattr__` function.