### PR TITLE
Replace codecs.open with open

### DIFF
--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -9,7 +9,6 @@
 
 from __future__ import annotations
 
-import codecs
 import os
 import shutil
 import subprocess
@@ -103,7 +102,7 @@ class DotBackend:
                 os.close(pdot)
             else:
                 dot_sourcepath = outputfile
-        with codecs.open(dot_sourcepath, "w", encoding="utf8") as file:
+        with open(dot_sourcepath, "w", encoding="utf8") as file:
             file.write(self.source)
         if target not in graphviz_extensions:
             if shutil.which(self.renderer) is None:

--- a/tests/pyreverse/test_writer.py
+++ b/tests/pyreverse/test_writer.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import codecs
 import os
 from collections.abc import Iterator, Sequence
 from difflib import unified_diff
@@ -65,7 +64,7 @@ class Config:
 
 def _file_lines(path: str) -> list[str]:
     # we don't care about the actual encoding, but python3 forces us to pick one
-    with codecs.open(path, encoding="latin1") as stream:
+    with open(path, encoding="latin1") as stream:
         lines = [
             line.strip()
             for line in stream.readlines()


### PR DESCRIPTION
`codecs.open` has been superseded by `open` and will raise a DeprecationWarning in Python 3.14.

https://docs.python.org/3.14/library/codecs.html#codecs.open