### PR TITLE
Fix pylint-config help output test for Python 3.14

### DIFF
--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -17,6 +17,7 @@ from pylint.typing import MessageTypesFullName
 PY310_PLUS = sys.version_info[:2] >= (3, 10)
 PY311_PLUS = sys.version_info[:2] >= (3, 11)
 PY312_PLUS = sys.version_info[:2] >= (3, 12)
+PY314_PLUS = sys.version_info[:2] >= (3, 14)
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 

--- a/tests/config/pylint_config/test_pylint_config_help.py
+++ b/tests/config/pylint_config/test_pylint_config_help.py
@@ -10,6 +10,7 @@ import warnings
 import pytest
 from pytest import CaptureFixture
 
+from pylint.constants import PY314_PLUS
 from pylint.lint.run import _PylintConfigRun as Run
 
 
@@ -29,7 +30,10 @@ def test_pylint_config_main_messages(capsys: CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit):
             Run(["generate", "-h"])
         captured = capsys.readouterr()
-        assert captured.out.startswith("usage: pylint-config [options] generate")
+        if PY314_PLUS:
+            assert captured.out.startswith("usage: pylint-config generate")
+        else:
+            assert captured.out.startswith("usage: pylint-config [options] generate")
         assert "--interactive" in captured.out
 
         with pytest.raises(SystemExit) as ex:


### PR DESCRIPTION
The output for `pylint-config generate -h` changed for 3.14. Adjust the test case accordingly.

**Python 3.13**
```
usage: pylint-config [options] generate [-h] [--interactive]

options:
  -h, --help     show this help message and exit
  --interactive
```

**Python 3.14**
```
usage: pylint-config generate [-h] [--interactive]

options:
  -h, --help     show this help message and exit
  --interactive
```