### PR TITLE
[ci] Install pylint before every test

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Run pylint checks
         run: |
           . venv/bin/activate
-          pip install .
+          pip install . --no-deps
           pip list | grep 'astroid\|pylint'
           pre-commit run --hook-stage manual pylint-with-spelling --all-files
 
@@ -148,7 +148,7 @@ jobs:
       - name: Run spelling checks
         run: |
           . venv/bin/activate
-          pip install .
+          pip install . --no-deps
           pytest tests/ -k unittest_spelling
 
   documentation:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -148,6 +148,7 @@ jobs:
       - name: Run spelling checks
         run: |
           . venv/bin/activate
+          pip install .
           pytest tests/ -k unittest_spelling
 
   documentation:

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -94,5 +94,5 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
-          pip install .
+          pip install . --no-deps
           pytest -m primer_stdlib --primer-stdlib -n auto -vv

--- a/.github/workflows/primer_run_main.yaml
+++ b/.github/workflows/primer_run_main.yaml
@@ -113,7 +113,7 @@ jobs:
       - name: Run pylint primer
         run: |
           . venv/bin/activate
-          pip install .
+          pip install . --no-deps
           python tests/primer/__main__.py run --type=main --batches=${{ matrix.batches }} --batchIdx=${{ matrix.batchIdx }} 2>warnings.txt
       - name: Echo warnings
         if: success() || failure()

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -187,7 +187,7 @@ jobs:
       - name: Run pylint primer
         run: |
           . venv/bin/activate
-          pip install .
+          pip install . --no-deps
           python tests/primer/__main__.py run --type=pr --batches=${{ matrix.batches }} --batchIdx=${{ matrix.batchIdx }} 2>warnings.txt
       - name: Echo warnings
         if: success() || failure()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,6 +78,7 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
+          pip install .
           pip list | grep 'astroid\|pylint'
           python -m pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
       - name: Run functional tests with minimal messages config
@@ -226,5 +227,6 @@ jobs:
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate
+          pip install .
           pip list | grep 'astroid\|pylint'
           python -m pytest --durations=10 --benchmark-disable tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Run pytest
         run: |
           . venv/bin/activate
-          pip install .
+          pip install . --no-deps
           pip list | grep 'astroid\|pylint'
           python -m pytest --durations=10 --benchmark-disable --cov --cov-report= tests/
       - name: Run functional tests with minimal messages config
@@ -161,7 +161,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip install pygal
-          pip install .
+          pip install . --no-deps
           pip list | grep 'astroid\|pylint'
           pytest --exitfirst \
             --benchmark-only \
@@ -227,6 +227,6 @@ jobs:
       - name: Run pytest
         run: |
           . venv\\Scripts\\activate
-          pip install .
+          pip install . --no-deps
           pip list | grep 'astroid\|pylint'
           python -m pytest --durations=10 --benchmark-disable tests/


### PR DESCRIPTION
Fix failing spelling tests: https://github.com/pylint-dev/pylint/actions/runs/15076143743/job/42383895655

Prevent using an old cached version of `pylint` for tests by reinstalling it from source before every pytest run in CI.
Furthermore adding `--no-deps` since we only care about `pylint` itself. For everything else, like an updated dependency, the cache is invalidated anyway.