### PR TITLE
Improve backport job permissions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,14 +6,14 @@ on:
       - labeled
 
 permissions:
-  actions: write
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   backport:
     name: Backport
     runs-on: ubuntu-latest
+    environment:
+      name: Backport
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
@@ -27,4 +27,4 @@ jobs:
     steps:
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BACKPORT_TOKEN }}


### PR DESCRIPTION
Followup to #10269

Noticed recently with #10388 that the backport to `.github/workflows` files still fails with the same error. After investigation and testing on my fork I found a solution that would work. For the backport to work we need the `workflows` permission. However that one isn't available for CI workflows. Instead we'd need to create a personal access token with the following permissions:
- `contents: write` -> push new branches to Github
- `pull-requests: write` -> create PR or add comment for manual backport
- `workflows: write` -> modify files in .github/workflows

_The `actions: write` permission I added in #10388 isn't necessary after all._

A side effect would be that we won't need to close / reopen PRs anymore before the workflow would run. By scoping the secret to an environment, we would also be able to enforce additional checks (like requiring sign-off) if we want to.

Is this something we want to do? If so, I can setup the PAT and environment.