### PR TITLE
[ci] Fix PyPy venv caching issue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,8 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: actions/setup-python@v5.6.0
+        # Custom with PyPy fix: https://github.com/actions/setup-python/pull/1110
+        uses: cdce8p/setup-python@v5.6.0-c1
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true


### PR DESCRIPTION
The `tests` job uses the `python-version` output from `actions/setup-python` as part of the cache key. That works well for cpython, however is broken for PyPy which doesn't include the Python version itself. Thus the workflow currently restores the first cached venv, e.g. `pypy-3.11` on `pypy-3.10`, and thus no packages are actually available.

The current key prefix for PyPy (3.10 and 3.11): `Linux-pypy7.3.19-venv-...`. Better would be `Linux-pypy3.10.16-7.3.19-venv-...` / `Linux-pypy3.11.11-7.3.19-venv-...`.

_This isn't an issue on our backport branch since PyPy 3.9 was dropped recently and so the PyPy versions are actually different. Nevertheless it might be good to backport it as well._

IMO this is really an issue with the `setup-python` action. Opened an issue and PR upstream.

https://github.com/actions/setup-python/issues/1109
https://github.com/actions/setup-python/pull/1110

To unblock our workflow, I created a custom tag with just the fix.
https://github.com/cdce8p/setup-python/compare/v5.6.0...v5.6.0-c1