### PR TITLE
Use custom Github App to authenticate backport job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,6 +25,14 @@ jobs:
         )
       )
     steps:
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          permission-contents: write # push branch to Github
+          permission-pull-requests: write # create PR / add comment for manual backport
+          permission-workflows: write # modify files in .github/workflows
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
-          github_token: ${{ secrets.BACKPORT_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Followup to #10390

For organizations it's recommended to use custom Github Apps over PAT from bot accounts.
Created https://github.com/apps/pylint-backport-bot for it.

https://github.com/actions/create-github-app-token