### PR TITLE
[Backport maintenance/3.3.x] Resolve possibly-used-before-assignment false positives from `match` block assignments (#10393)

### DIFF
--- a/doc/whatsnew/fragments/9668.false_positive
+++ b/doc/whatsnew/fragments/9668.false_positive
@@ -1,0 +1,4 @@
+Fix false positives for `possibly-used-before-assignment` when variables are exhaustively
+assigned within a `match` block.
+
+Closes #9668

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -720,6 +720,12 @@ scope_type : {self._atomic.scope_type}
         if isinstance(node, (nodes.With, nodes.For, nodes.While)):
             return NamesConsumer._defines_name_raises_or_returns_recursive(name, node)
 
+        if isinstance(node, nodes.Match):
+            return all(
+                NamesConsumer._defines_name_raises_or_returns_recursive(name, case)
+                for case in node.cases
+            )
+
         if not isinstance(node, nodes.If):
             return False
 
@@ -768,6 +774,7 @@ scope_type : {self._atomic.scope_type}
                     nodes.With,
                     nodes.For,
                     nodes.While,
+                    nodes.Match,
                 ),
             )
             and self._inferred_to_define_name_raise_or_return(name, if_body_stmt)
@@ -1010,6 +1017,11 @@ scope_type : {self._atomic.scope_type}
                 and NamesConsumer._defines_name_raises_or_returns_recursive(name, stmt)
             ):
                 return True
+            if isinstance(stmt, nodes.Match):
+                return all(
+                    NamesConsumer._defines_name_raises_or_returns_recursive(name, case)
+                    for case in stmt.cases
+                )
         return False
 
     @staticmethod

--- a/tests/functional/u/used/used_before_assignment_py310.py
+++ b/tests/functional/u/used/used_before_assignment_py310.py
@@ -5,3 +5,104 @@ match ("example", "one"):
         print("x used to cause used-before-assignment!")
     case _:
         print("good thing it doesn't now!")
+
+
+# pylint: disable = missing-function-docstring, redefined-outer-name, missing-class-docstring
+
+# https://github.com/pylint-dev/pylint/issues/9668
+from enum import Enum
+from pylint.constants import PY311_PLUS
+if PY311_PLUS:
+    from typing import assert_never  # pylint: disable=no-name-in-module
+else:
+    from typing_extensions import assert_never
+
+class Example(Enum):
+    FOO = 1
+    BAR = 2
+
+def check_value_if_then_match_return(example: Example, should_check: bool) -> str | None:
+    if should_check:
+        result = None
+    else:
+        match example:
+            case Example.FOO:
+                result = "foo"
+            case Example.BAR:
+                result = "bar"
+            case _:
+                return None
+
+    return result
+
+def check_value_if_then_match_raise(example: Example, should_check: bool) -> str | None:
+    if should_check:
+        result = None
+    else:
+        match example:
+            case Example.FOO:
+                result = "foo"
+            case Example.BAR:
+                result = "bar"
+            case _:
+                raise ValueError("Not a valid enum")
+
+    return result
+
+def check_value_if_then_match_assert_never(example: Example, should_check: bool) -> str | None:
+    if should_check:
+        result = None
+    else:
+        match example:
+            case Example.FOO:
+                result = "foo"
+            case Example.BAR:
+                result = "bar"
+            case _:
+                assert_never(example)
+
+    return result
+
+def g(x):
+    if x is None:
+        y = 0
+    else:
+        match x:
+            case int():
+                y = x
+            case _:
+                raise TypeError(type(x))
+
+    return y
+
+def check_value_if_then_match_nested(
+    example: Example, example_inner: Example, should_check: bool
+) -> str | None:
+    if should_check:
+        result = None
+    else:
+        match example:
+            case Example.FOO:
+                match example_inner:
+                    case Example.BAR:
+                        result = "bar"
+                    case _:
+                        return None
+            case _:
+                return None
+
+    return result
+
+def check_value_if_then_match_non_exhaustive(example: Example, should_check: bool) -> str | None:
+    if should_check:
+        result = None
+    else:
+        match example:
+            case Example.FOO:
+                result = "foo"
+            case Example.BAR:
+                pass
+            case _:
+                return None
+
+    return result  # [possibly-used-before-assignment]

--- a/tests/functional/u/used/used_before_assignment_py310.txt
+++ b/tests/functional/u/used/used_before_assignment_py310.txt
@@ -1,0 +1,1 @@
+possibly-used-before-assignment:108:11:108:17:check_value_if_then_match_non_exhaustive:Possibly using variable 'result' before assignment:CONTROL_FLOW


### PR DESCRIPTION
(cherry picked from commit ad14b5bf9f2eaaf9b69a0daef09d1d944e1b11cf)