### PR TITLE
Refactor pyerverse Association Logic

### DIFF
--- a/pylint/pyreverse/diagrams.py
+++ b/pylint/pyreverse/diagrams.py
@@ -226,6 +226,7 @@ class ClassDiagram(Figure, FilterMixIn):
             obj.attrs = self.get_attrs(node)
             obj.methods = self.get_methods(node)
             obj.shape = "class"
+
             # inheritance link
             for par_node in node.ancestors(recurs=False):
                 try:
@@ -234,19 +235,25 @@ class ClassDiagram(Figure, FilterMixIn):
                 except KeyError:
                     continue
 
+            # Track processed attributes to avoid duplicates
+            processed_attrs = set()
+
             # Composition links
             for name, values in list(node.compositions_type.items()):
                 for value in values:
                     self.assign_association_relationship(
                         value, obj, name, "composition"
                     )
+                    processed_attrs.add(name)
 
             # Aggregation links
             for name, values in list(node.aggregations_type.items()):
-                for value in values:
-                    self.assign_association_relationship(
-                        value, obj, name, "aggregation"
-                    )
+                if name not in processed_attrs:
+                    for value in values:
+                        self.assign_association_relationship(
+                            value, obj, name, "aggregation"
+                        )
+                        processed_attrs.add(name)
 
             # Association links
             associations = node.associations_type.copy()
@@ -255,10 +262,11 @@ class ClassDiagram(Figure, FilterMixIn):
                     associations[name] = values
 
             for name, values in associations.items():
-                for value in values:
-                    self.assign_association_relationship(
-                        value, obj, name, "association"
-                    )
+                if name not in processed_attrs:
+                    for value in values:
+                        self.assign_association_relationship(
+                            value, obj, name, "association"
+                        )
 
     def assign_association_relationship(
         self, value: astroid.NodeNG, obj: ClassEntity, name: str, type_relationship: str

--- a/pylint/pyreverse/diagrams.py
+++ b/pylint/pyreverse/diagrams.py
@@ -234,15 +234,22 @@ class ClassDiagram(Figure, FilterMixIn):
                 except KeyError:
                     continue
 
-            # associations & aggregations links
+            # Composition links
+            for name, values in list(node.compositions_type.items()):
+                for value in values:
+                    self.assign_association_relationship(
+                        value, obj, name, "composition"
+                    )
+
+            # Aggregation links
             for name, values in list(node.aggregations_type.items()):
                 for value in values:
                     self.assign_association_relationship(
                         value, obj, name, "aggregation"
                     )
 
+            # Association links
             associations = node.associations_type.copy()
-
             for name, values in node.locals_type.items():
                 if name not in associations:
                     associations[name] = values

--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -30,10 +30,16 @@ SHAPES: dict[NodeType, str] = {
 # pylint: disable-next=consider-using-namedtuple-or-dataclass
 ARROWS: dict[EdgeType, dict[str, str]] = {
     EdgeType.INHERITS: {"arrowtail": "none", "arrowhead": "empty"},
-    EdgeType.ASSOCIATION: {
+    EdgeType.COMPOSITION: {
         "fontcolor": "green",
         "arrowtail": "none",
         "arrowhead": "diamond",
+        "style": "solid",
+    },
+    EdgeType.ASSOCIATION: {
+        "fontcolor": "green",
+        "arrowtail": "none",
+        "arrowhead": "none",
         "style": "solid",
     },
     EdgeType.AGGREGATION: {

--- a/pylint/pyreverse/dot_printer.py
+++ b/pylint/pyreverse/dot_printer.py
@@ -39,7 +39,7 @@ ARROWS: dict[EdgeType, dict[str, str]] = {
     EdgeType.ASSOCIATION: {
         "fontcolor": "green",
         "arrowtail": "none",
-        "arrowhead": "none",
+        "arrowhead": "normal",
         "style": "solid",
     },
     EdgeType.AGGREGATION: {

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -122,8 +122,14 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         self.tag = tag
         # visited project
         self.project = project
-        self.associations_handler = AggregationsHandler()
-        self.associations_handler.set_next(OtherAssociationsHandler())
+
+        # Chain: Composition → Aggregation → Association
+        self.associations_handler = CompositionsHandler()
+        aggregation_handler = AggregationsHandler()
+        association_handler = AssociationsHandler()
+
+        self.associations_handler.set_next(aggregation_handler)
+        aggregation_handler.set_next(association_handler)
 
     def visit_project(self, node: Project) -> None:
         """Visit a pyreverse.utils.Project node.
@@ -167,6 +173,7 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
             specializations.append(node)
             baseobj.specializations = specializations
         # resolve instance attributes
+        node.compositions_type = collections.defaultdict(list)
         node.instance_attrs_type = collections.defaultdict(list)
         node.aggregations_type = collections.defaultdict(list)
         node.associations_type = collections.defaultdict(list)
@@ -327,16 +334,39 @@ class AbstractAssociationHandler(AssociationHandlerInterface):
             self._next_handler.handle(node, parent)
 
 
-class AggregationsHandler(AbstractAssociationHandler):
+class CompositionsHandler(AbstractAssociationHandler):
+    """Handle composition relationships where parent creates child objects."""
+
     def handle(self, node: nodes.AssignAttr, parent: nodes.ClassDef) -> None:
-        # Check if we're not in an assignment context
         if not isinstance(node.parent, (nodes.AnnAssign, nodes.Assign)):
             super().handle(node, parent)
             return
 
         value = node.parent.value
 
-        # Handle direct name assignments
+        # Composition: parent creates child (self.x = P())
+        if isinstance(value, nodes.Call):
+            current = set(parent.compositions_type[node.attrname])
+            parent.compositions_type[node.attrname] = list(
+                current | utils.infer_node(node)
+            )
+            return
+
+        # Not a composition, pass to next handler
+        super().handle(node, parent)
+
+
+class AggregationsHandler(AbstractAssociationHandler):
+    """Handle aggregation relationships where parent receives child objects."""
+
+    def handle(self, node: nodes.AssignAttr, parent: nodes.ClassDef) -> None:
+        if not isinstance(node.parent, (nodes.AnnAssign, nodes.Assign)):
+            super().handle(node, parent)
+            return
+
+        value = node.parent.value
+
+        # Aggregation: parent receives child (self.x = x)
         if isinstance(value, astroid.node_classes.Name):
             current = set(parent.aggregations_type[node.attrname])
             parent.aggregations_type[node.attrname] = list(
@@ -344,11 +374,10 @@ class AggregationsHandler(AbstractAssociationHandler):
             )
             return
 
-        # Handle comprehensions
+        # Aggregation: comprehensions (self.x = [P() for ...])
         if isinstance(
             value, (nodes.ListComp, nodes.DictComp, nodes.SetComp, nodes.GeneratorExp)
         ):
-            # Determine the type of the element in the comprehension
             if isinstance(value, nodes.DictComp):
                 element_type = safe_infer(value.value)
             else:
@@ -358,12 +387,23 @@ class AggregationsHandler(AbstractAssociationHandler):
                 parent.aggregations_type[node.attrname] = list(current | {element_type})
                 return
 
-        # Fallback to parent handler
+        # Type annotation only (x: P) defaults to aggregation
+        if isinstance(node.parent, nodes.AnnAssign) and node.parent.value is None:
+            current = set(parent.aggregations_type[node.attrname])
+            parent.aggregations_type[node.attrname] = list(
+                current | utils.infer_node(node)
+            )
+            return
+
+        # Not an aggregation, pass to next handler
         super().handle(node, parent)
 
 
-class OtherAssociationsHandler(AbstractAssociationHandler):
+class AssociationsHandler(AbstractAssociationHandler):
+    """Handle regular association relationships."""
+
     def handle(self, node: nodes.AssignAttr, parent: nodes.ClassDef) -> None:
+        # Everything else is a regular association
         current = set(parent.associations_type[node.attrname])
         parent.associations_type[node.attrname] = list(current | utils.infer_node(node))
 

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -113,6 +113,9 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
 
     * aggregations_type
       as instance_attrs_type but for aggregations relationships
+
+    * compositions_type
+      as instance_attrs_type but for compositions relationships
     """
 
     def __init__(self, project: Project, tag: bool = False) -> None:

--- a/pylint/pyreverse/mermaidjs_printer.py
+++ b/pylint/pyreverse/mermaidjs_printer.py
@@ -21,7 +21,8 @@ class MermaidJSPrinter(Printer):
     }
     ARROWS: dict[EdgeType, str] = {
         EdgeType.INHERITS: "--|>",
-        EdgeType.ASSOCIATION: "--*",
+        EdgeType.COMPOSITION: "--*",
+        EdgeType.ASSOCIATION: "-->",
         EdgeType.AGGREGATION: "--o",
         EdgeType.USES: "-->",
         EdgeType.TYPE_DEPENDENCY: "..>",

--- a/pylint/pyreverse/plantuml_printer.py
+++ b/pylint/pyreverse/plantuml_printer.py
@@ -21,7 +21,8 @@ class PlantUmlPrinter(Printer):
     }
     ARROWS: dict[EdgeType, str] = {
         EdgeType.INHERITS: "--|>",
-        EdgeType.ASSOCIATION: "--*",
+        EdgeType.ASSOCIATION: "-->",
+        EdgeType.COMPOSITION: "--*",
         EdgeType.AGGREGATION: "--o",
         EdgeType.USES: "-->",
         EdgeType.TYPE_DEPENDENCY: "..>",

--- a/pylint/pyreverse/printer.py
+++ b/pylint/pyreverse/printer.py
@@ -22,6 +22,7 @@ class NodeType(Enum):
 
 class EdgeType(Enum):
     INHERITS = "inherits"
+    COMPOSITION = "composition"
     ASSOCIATION = "association"
     AGGREGATION = "aggregation"
     USES = "uses"

--- a/pylint/pyreverse/writer.py
+++ b/pylint/pyreverse/writer.py
@@ -146,6 +146,14 @@ class DiagramWriter:
                 label=rel.name,
                 type_=EdgeType.ASSOCIATION,
             )
+        # generate compositions
+        for rel in diagram.get_relationships("composition"):
+            self.printer.emit_edge(
+                rel.from_object.fig_id,
+                rel.to_object.fig_id,
+                label=rel.name,
+                type_=EdgeType.COMPOSITION,
+            )
         # generate aggregations
         for rel in diagram.get_relationships("aggregation"):
             if rel.to_object.fig_id in associations[rel.from_object.fig_id]:

--- a/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
+++ b/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
@@ -1,23 +1,23 @@
 classDiagram
   class A {
-    x
+    x : P
   }
   class B {
-    x
+    x : P
   }
   class C {
-    x
+    x : P
   }
   class D {
-    x
+    x : P
   }
   class E {
-    x
+    x : P
   }
   class P {
   }
-  P --* A : x
-  P --* C : x
+  P --o A : x
+  P --o B : x
+  P --o C : x
   P --* D : x
   P --* E : x
-  P --o B : x

--- a/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
+++ b/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
@@ -1,18 +1,18 @@
 classDiagram
   class A {
-    x : P
+    x
   }
   class B {
-    x : P
+    x
   }
   class C {
-    x : P
+    x
   }
   class D {
-    x : P
+    x
   }
   class E {
-    x : P
+    x
   }
   class P {
   }

--- a/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
+++ b/tests/pyreverse/functional/class_diagrams/aggregation/fields.mmd
@@ -16,8 +16,8 @@ classDiagram
   }
   class P {
   }
-  P --o A : x
-  P --o B : x
-  P --o C : x
+  P --> A : x
   P --* D : x
   P --* E : x
+  P --o B : x
+  P --o C : x

--- a/tests/pyreverse/functional/class_diagrams/aggregation/fields.py
+++ b/tests/pyreverse/functional/class_diagrams/aggregation/fields.py
@@ -4,24 +4,24 @@ class P:
     pass
 
 class A:
-    x: P
+    x: P  # can't tell, so default to aggregation
 
 class B:
     def __init__(self, x: P):
-        self.x = x
+        self.x = x  # not instantiated, so aggregation
 
 class C:
     x: P
 
     def __init__(self, x: P):
-        self.x = x
+        self.x = x  # not instantiated, so aggregation
 
 class D:
     x: P
 
     def __init__(self):
-        self.x = P()
+        self.x = P()  # instantiated, so composition
 
 class E:
     def __init__(self):
-        self.x = P()
+        self.x = P()  # instantiated, so composition

--- a/tests/pyreverse/functional/class_diagrams/aggregation/fields.py
+++ b/tests/pyreverse/functional/class_diagrams/aggregation/fields.py
@@ -4,7 +4,7 @@ class P:
     pass
 
 class A:
-    x: P  # can't tell, so default to aggregation
+    x: P  # just type hint, no ownership, soassociation
 
 class B:
     def __init__(self, x: P):


### PR DESCRIPTION
## Type of Changes

| ✓   | :bug: Bug fix          |
| ✓   | :hammer: Refactoring   |

## Description

Closes #9045

## Summary

Fixed incorrect UML semantics in pyreverse for aggregation vs composition relationships. The previous implementation had no explicit `CompositionsHandler` class and did not differentiate between Aggregation and Composition properly, treating most relationships as aggregation by default.

## Problem

Pyreverse previously lacked proper UML relationship semantics. So I would proposes the following distinction for Python class relationships:

`fields.py`
```python
# Test for https://github.com/pylint-dev/pylint/issues/9045

class P:
    pass

class A:
    x: P  # just type hint, no ownership → Association

class B:
    def __init__(self, x: P):
        self.x = x  # receives object, not created → Aggregation

class C:
    x: P
    def __init__(self, x: P):
        self.x = x  # receives object, not created → Aggregation

class D:
    x: P
    def __init__(self):
        self.x = P()  # creates object → Composition

class E:
    def __init__(self):
        self.x = P()  # creates object → Composition
```

`fields.mmd`
```mmd
classDiagram
  class A {
    x
  }
  class B {
    x
  }
  class C {
    x
  }
  class D {
    x
  }
  class E {
    x
  }
  class P {
  }
  P --> A : x
  P --* D : x
  P --* E : x
  P --o B : x
  P --o C : x
```


## Changes Made

### 1. Added CompositionsHandler
Created dedicated handler following chain of responsibility pattern:
CompositionsHandler → AggregationsHandler → AssociationsHandler

### 2. Updated Printers
- Added `EdgeType.COMPOSITION` enum value
- Updated MermaidJS and PlantUML printers with correct arrows per [Mermaid docs](https://mermaid.js.org/syntax/classDiagram.html#defining-relationship)
- For the Dot printer I used plain arrows, but I did not manage to find something in the dot language documentation

### 3. Prevented Duplicate Relationships
Modified extract_relationships() to process relationships by priority and avoid duplicates.


Currently I only made the modifications needed to implement the new Associations Logic. If you like the proposed distinction I would work on making the tests pass :)