### PR TITLE
Fix Invalid no-name-in-module when shadowing a base module with an alias then calling a method named format on that alias.

### DIFF
--- a/doc/whatsnew/fragments/10193.bugfix
+++ b/doc/whatsnew/fragments/10193.bugfix
@@ -1,0 +1,3 @@
+Fix incorrect `no-name-in-module` when calling methods on shadowed imports (e.g. `import pkg.sub as pkg`).
+
+Closes #10193

--- a/tests/functional/i/import_module_shadowing.py
+++ b/tests/functional/i/import_module_shadowing.py
@@ -1,0 +1,71 @@
+# pylint: disable=missing-docstring,consider-using-with,trailing-whitespace,unused-import
+
+import os
+import tempfile
+import unittest
+from pylint import lint
+from pylint.testutils import GenericTestReporter
+
+class ModuleShadowingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.pkg_dir = os.path.join(self.tempdir.name, "my_module")
+        os.makedirs(self.pkg_dir)
+        
+        with open(os.path.join(self.pkg_dir, "__init__.py"), "w", encoding="utf-8") as f:
+            f.write("")
+        
+        self.utils_file = os.path.join(self.pkg_dir, "utils.py")
+        with open(self.utils_file, "w", encoding="utf-8") as f:
+            f.write("def format():\n    pass\n\ndef other_method():\n    pass\n")
+        
+        self.test_file = os.path.join(self.tempdir.name, "main.py")
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _run_pylint(self, code):
+        with open(self.test_file, "w", encoding="utf-8") as f:
+            f.write(code)
+        
+        reporter = GenericTestReporter()
+        lint.Run(
+            [
+                "--disable=all",
+                "--enable=no-name-in-module",
+                "--persistent=no",
+                "--rcfile=",
+                self.test_file
+            ],
+            reporter=reporter,
+            exit=False
+        )
+        return reporter.messages
+
+    def test_shadowed_format_call(self):
+        code = "import my_module.utils as my_module\nmy_module.format()\n"
+        messages = self._run_pylint(code)
+        errors = [msg for msg in messages if msg.msg_id == "E0611"]
+        self.assertEqual(len(errors), 0)
+
+    def test_shadowed_other_method(self):
+        code = "import my_module.utils as my_module\nmy_module.other_method()\n"
+        messages = self._run_pylint(code)
+        errors = [msg for msg in messages if msg.msg_id == "E0611"]
+        self.assertEqual(len(errors), 0)
+
+    def test_non_shadowed_import(self):
+        code = "import my_module.utils as utils\nutils.format()\n"
+        messages = self._run_pylint(code)
+        errors = [msg for msg in messages if msg.msg_id == "E0611"]
+        self.assertEqual(len(errors), 0)
+
+    def test_shadowed_import_without_call(self):
+        code = "import my_module.utils as my_module\n"
+        messages = self._run_pylint(code)
+        errors = [msg for msg in messages if msg.msg_id == "E0611"]
+        self.assertEqual(len(errors), 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

<!-- If this PR references an issue without fixing it: -->

This PR fixes an issue where Pylint incorrectly raises no-name-in-module (E0611) errors for valid Python code using shadowed imports (e.g., import my_module.utils as my_module).

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #10193 
