### PR TITLE
[ci] Disable the benchmarks everywhere except the benchmark job

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -149,7 +149,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip install . --no-deps
-          pytest tests/ -k unittest_spelling
+          pytest tests/ -k unittest_spelling --benchmark-disable
 
   documentation:
     name: documentation

--- a/.github/workflows/primer-test.yaml
+++ b/.github/workflows/primer-test.yaml
@@ -95,4 +95,4 @@ jobs:
         run: |
           . venv/bin/activate
           pip install . --no-deps
-          pytest -m primer_stdlib --primer-stdlib -n auto -vv
+          pytest -m primer_stdlib --primer-stdlib -n auto -vv --benchmark-disable

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,7 +86,7 @@ jobs:
         run: |
           . venv/bin/activate
           pip list | grep 'astroid\|pylint'
-          python -m pytest -vv --minimal-messages-config tests/test_functional.py
+          python -m pytest -vv --minimal-messages-config tests/test_functional.py --benchmark-disable
       - name: Upload coverage artifact
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4.6.2


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

I don't see any downside of doing this. We're never checking the benchmark result either, but we need to add a comment like the primer if we really want to use the result from the benchmark job. (I don't know why the default is not 'no benchmark' each pytest call is taking longer because of this locally). 
