### PR TITLE
[doc]Update custom_checkers.rst to specify the safe range that a custom checker may use

### DIFF
--- a/doc/development_guide/how_tos/custom_checkers.rst
+++ b/doc/development_guide/how_tos/custom_checkers.rst
@@ -271,6 +271,7 @@ The message is then formatted using the ``args`` parameter from ``add_message`` 
   standing for ``Convention``, ``Warning``, ``Error``, ``Fatal`` and ``Refactoring``.
   The 4 digits should not conflict with existing checkers
   and the first 2 digits should consistent across the checker (except shared messages).
+  It is safe to use 51-99 as the first 2 digits for custom checkers because this range is reserved for them.
 
 * The ``displayed-message`` is used for displaying the message to the user,
   once it is emitted.


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Move information from

https://github.com/pylint-dev/pylint/blob/13743cdd035765292d5f5f58274a21fb9aaafcf3/pylint/checkers/__init__.py#L5-L41

to

https://github.com/pylint-dev/pylint/blob/13743cdd035765292d5f5f58274a21fb9aaafcf3/doc/development_guide/how_tos/custom_checkers.rst?plain=1#L267-L273

as described [here](https://github.com/pylint-dev/pylint/issues/10341#issuecomment-2798947513).

Closes #10341.
