### PR TITLE
Fix `unused-variable` false positive when using same name for multiple exceptions 

### DIFF
--- a/doc/whatsnew/fragments/10426.false_positive
+++ b/doc/whatsnew/fragments/10426.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``unused-variable`` when multiple except handlers bind the same name under a try block.
+
+Closes #10426

--- a/tests/functional/u/unused/unused_global_variable2.py
+++ b/tests/functional/u/unused/unused_global_variable2.py
@@ -9,3 +9,11 @@ if TYPE_CHECKING:
 
 
 VAR = 'pylint'  # [unused-variable]
+
+
+try:
+    pass
+except TypeError as exc:
+    print(exc)
+except ValueError as exc:
+    print(exc)

--- a/tests/functional/u/unused/unused_variable.py
+++ b/tests/functional/u/unused/unused_variable.py
@@ -187,6 +187,17 @@ def sibling_except_handlers():
     except ValueError as e:
         print(e)
 
+
+def test_multiple_except_handlers_under_try():
+    try:
+        pass
+    except TypeError as exc:
+        print(exc)
+    except ValueError as exc:
+        print(exc)
+    except ArithmeticError as exc:
+        print(exc)
+
 def func6():
     a = 1
 

--- a/tests/functional/u/unused/unused_variable.txt
+++ b/tests/functional/u/unused/unused_variable.txt
@@ -26,4 +26,4 @@ unused-variable:150:4:154:26:func4:Unused variable 'error':UNDEFINED
 redefined-outer-name:153:8:154:26:func4:Redefining name 'error' from outer scope (line 150):UNDEFINED
 unused-variable:161:4:162:12:main:Unused variable 'e':UNDEFINED
 undefined-loop-variable:168:10:168:11:main:Using possibly undefined loop variable 'e':UNDEFINED
-unused-variable:217:8:218:16:test_regression_8595:Unused variable 'e':UNDEFINED
+unused-variable:228:8:229:16:test_regression_8595:Unused variable 'e':UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Somewhat related to #4791. When investigating the issue, I noticed that the false positive is only emitted when checking for global unused variables. It is fine when the try block is nested within a function like:
```
def foo():
    try:
        pass
    except TypeError as exc:
        print(exc)
    except ValueError as exc:
        print(exc)
```

There seems to be existing logic handling this as a special case, so I extracted it into a function and reused it for the global unused variable check.

Closes #10426 
