### PR TITLE
Fix `possibly-used-before-assignment` false negative for type-annotated assignation

### DIFF
--- a/doc/whatsnew/fragments/10421.false_negative
+++ b/doc/whatsnew/fragments/10421.false_negative
@@ -1,0 +1,4 @@
+Fix a false negative for `possibly-used-before-assignment` when a variable is conditionally defined
+and later assigned to a type-annotated variable.
+
+Closes #10421

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2541,12 +2541,12 @@ class VariablesChecker(BaseChecker):
         return False
 
     @staticmethod
-    def _is_variable_annotation_in_function(node: nodes.NodeNG) -> bool:
-        is_annotation = utils.get_node_first_ancestor_of_type(node, nodes.AnnAssign)
+    def _is_variable_annotation_in_function(node: nodes.Name) -> bool:
         return (
-            is_annotation
+            isinstance(node.parent, nodes.AnnAssign)
+            and node is node.parent.annotation
             and utils.get_node_first_ancestor_of_type(  # type: ignore[return-value]
-                is_annotation, nodes.FunctionDef
+                node.parent, nodes.FunctionDef
             )
         )
 

--- a/tests/functional/u/used/used_before_assignment_type_annotations.py
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.py
@@ -88,3 +88,22 @@ def nested_class_as_return_annotation():
             pass
 
     print(MyObject)
+
+
+def conditional_annotated_assignment():
+    """Variable is conditionally defined but later used in a type-annotated assignment."""
+    if object() is None:
+        data={"cat": "harf"}
+    token: str = data.get("cat")  # [possibly-used-before-assignment]
+    print(token)
+
+
+def loop_conditional_annotated_assignment():
+    """Variable is conditionally defined inside a for-loop but later used
+    in a type-annotated assignment.
+    """
+    for _ in range(3):
+        if object() is None:
+            data={"cat": "harf"}
+    token: str = data.get("cat")  # [possibly-used-before-assignment]
+    print(token)

--- a/tests/functional/u/used/used_before_assignment_type_annotations.txt
+++ b/tests/functional/u/used/used_before_assignment_type_annotations.txt
@@ -1,3 +1,5 @@
 used-before-assignment:15:10:15:18:only_type_assignment:Using variable 'variable' before assignment:HIGH
 used-before-assignment:28:10:28:18:value_assignment_after_access:Using variable 'variable' before assignment:HIGH
 undefined-variable:62:14:62:17:decorator_returning_incorrect_function.wrapper_with_type_and_no_value:Undefined variable 'var':HIGH
+possibly-used-before-assignment:97:17:97:21:conditional_annotated_assignment:Possibly using variable 'data' before assignment:CONTROL_FLOW
+possibly-used-before-assignment:108:17:108:21:loop_conditional_annotated_assignment:Possibly using variable 'data' before assignment:CONTROL_FLOW


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->


<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

The issue lies in the predicate for variable annotations. It currently checks whether a `Name` node is a child of an `AnnAssign` node, but it should also check whether the `Name` node is used as type annotation.

Closes #10421 
