### PR TITLE
Extend W0236 checker to detect return type mismatches in overridden methods

### DIFF
--- a/doc/whatsnew/fragments/10351.false_negative
+++ b/doc/whatsnew/fragments/10351.false_negative
@@ -1,0 +1,5 @@
+Enhanced `invalid-overridden-method` checker to detect return type mismatches when overriding methods.
+The checker now properly identifies when subclass methods have incompatible return types compared to their parent methods,
+including support for covariant return types and proper `typing.Any` handling.
+
+Closes #10351

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1510,6 +1510,27 @@ a metaclass class method.",
                 node=function_node,
             )
 
+        # Check for return type mismatches
+        parent_returns = parent_function_node.returns
+        current_returns = function_node.returns
+
+        # Only check if both methods have return type annotations
+        if parent_returns is not None and current_returns is not None:
+            parent_return_str = parent_returns.as_string()
+            current_return_str = current_returns.as_string()
+
+            # Compare return type annotations as strings
+            if parent_return_str != current_return_str:
+                self.add_message(
+                    "invalid-overridden-method",
+                    args=(
+                        function_node.name,
+                        f"return type '{parent_return_str}'",
+                        f"return type '{current_return_str}'",
+                    ),
+                    node=function_node,
+                )
+
     def _check_functools_or_not(self, decorator: nodes.Attribute) -> bool:
         if decorator.attrname != "cached_property":
             return False

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2447,7 +2447,7 @@ a metaclass class method.",
         if parent_type.qname() == "typing.Any":
             return True
 
-        # Special case: Hanndle constant Literal types
+        # Special case: Handle constant Literal types
         if current_type.qname() == ".Literal":
             inferred = current_type.values()
             for i in inferred:

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2450,6 +2450,10 @@ a metaclass class method.",
         if is_subclass_of(current_type, parent_type):
             return True
 
+        # Covariant check - current is subtype of parent
+        if current_type.is_subtype_of(parent_type):
+            return True
+
         # For built-in types, also check by qualified name in ancestors
         parent_qname = parent_type.qname()
         current_ancestors = {ancestor.qname() for ancestor in current_type.ancestors()}

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2451,7 +2451,6 @@ a metaclass class method.",
         if current_type.qname() == ".Literal":
             inferred = current_type.values()
             for i in inferred:
-                # print("Inferred value:", i)
                 if isinstance(i, nodes.Const):
                     # If we have a Literal with a class, we can check its qname
                     if i.qname() == parent_type.qname():

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2437,6 +2437,7 @@ a metaclass class method.",
         1. Same type (qname match)
         2. current_type is a subclass of parent_type (covariance)
         3. parent_type is typing.Any (any type is compatible with Any)
+        4. current_type is a Literal containing values compatible with parent_type
         """
         # Same type check
         if current_type.qname() == parent_type.qname():
@@ -2445,6 +2446,16 @@ a metaclass class method.",
         # Special case: Any type accepts anything
         if parent_type.qname() == "typing.Any":
             return True
+
+        # Special case: Hanndle constant Literal types
+        if current_type.qname() == ".Literal":
+            inferred = current_type.values()
+            for i in inferred:
+                # print("Inferred value:", i)
+                if isinstance(i, nodes.Const):
+                    # If we have a Literal with a class, we can check its qname
+                    if i.qname() == parent_type.qname():
+                        return True
 
         # Covariant check - current is subclass of parent
         if is_subclass_of(current_type, parent_type):

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2462,7 +2462,7 @@ a metaclass class method.",
             return True
 
         # Covariant check - current is subtype of parent
-        if current_type.is_subtype_of(parent_type):
+        if current_type.is_subtype_of(parent_type.qname()):
             return True
 
         # For built-in types, also check by qualified name in ancestors

--- a/tests/functional/i/invalid/invalid_overridden_method.py
+++ b/tests/functional/i/invalid/invalid_overridden_method.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring,too-few-public-methods,disallowed-name,invalid-name,unused-argument
 import abc
+from io import TextIOWrapper, BytesIO
 
 
 class SuperClass(metaclass=abc.ABCMeta):
@@ -125,3 +126,16 @@ class B(A):
     @multiple_returns
     def bar2(self):  # [invalid-overridden-method]
         return False
+
+
+# Test case for return type mismatch from the issue
+class BaseClass(abc.ABC):
+    @abc.abstractmethod
+    def read_file(self, path: str) -> TextIOWrapper:
+        """Abstract method that should return a TextIOWrapper."""
+        raise NotImplementedError("Method must be implemented by subclass")
+
+class ChildClass(BaseClass):
+    def read_file(self, path: str) -> BytesIO:  # [invalid-overridden-method]
+        """Implementation returns BytesIO instead of TextIOWrapper."""
+        return BytesIO(b"content")

--- a/tests/functional/i/invalid/invalid_overridden_method.py
+++ b/tests/functional/i/invalid/invalid_overridden_method.py
@@ -128,7 +128,8 @@ class B(A):
         return False
 
 
-# Test case for return type mismatch from the issue
+# https://github.com/pylint-dev/pylint/issues/10351
+# Test case for return type mismatch
 class BaseClass(abc.ABC):
     @abc.abstractmethod
     def read_file(self, path: str) -> TextIOWrapper:

--- a/tests/functional/i/invalid/invalid_overridden_method.py
+++ b/tests/functional/i/invalid/invalid_overridden_method.py
@@ -130,13 +130,21 @@ class B(A):
 
 # https://github.com/pylint-dev/pylint/issues/10351
 # Test case for return type mismatch
+class ReturnType(TextIOWrapper):
+    pass
+
 class BaseClass(abc.ABC):
     @abc.abstractmethod
     def read_file(self, path: str) -> TextIOWrapper:
         """Abstract method that should return a TextIOWrapper."""
         raise NotImplementedError("Method must be implemented by subclass")
 
-class ChildClass(BaseClass):
+class ChildClass1(BaseClass):
     def read_file(self, path: str) -> BytesIO:  # [invalid-overridden-method]
         """Implementation returns BytesIO instead of TextIOWrapper."""
         return BytesIO(b"content")
+
+class ChildClass2(BaseClass):
+    def read_file(self, path: str) -> ReturnType:
+        """Implementation returns BytesIO instead of TextIOWrapper."""
+        return ReturnType(BytesIO(b"content"))

--- a/tests/functional/i/invalid/invalid_overridden_method.txt
+++ b/tests/functional/i/invalid/invalid_overridden_method.txt
@@ -1,6 +1,7 @@
-invalid-overridden-method:38:4:38:12:InvalidDerived.prop:Method 'prop' was expected to be 'property', found it instead as 'method':UNDEFINED
-invalid-overridden-method:41:4:41:20:InvalidDerived.async_method:Method 'async_method' was expected to be 'async', found it instead as 'non-async':UNDEFINED
-invalid-overridden-method:45:4:45:16:InvalidDerived.method_a:Method 'method_a' was expected to be 'method', found it instead as 'property':UNDEFINED
-invalid-overridden-method:48:4:48:22:InvalidDerived.method_b:Method 'method_b' was expected to be 'non-async', found it instead as 'async':UNDEFINED
-invalid-overridden-method:122:4:122:11:B.bar:Method 'bar' was expected to be 'property', found it instead as 'method':UNDEFINED
-invalid-overridden-method:126:4:126:12:B.bar2:Method 'bar2' was expected to be 'property', found it instead as 'method':UNDEFINED
+invalid-overridden-method:39:4:39:12:InvalidDerived.prop:Method 'prop' was expected to be 'property', found it instead as 'method':UNDEFINED
+invalid-overridden-method:42:4:42:20:InvalidDerived.async_method:Method 'async_method' was expected to be 'async', found it instead as 'non-async':UNDEFINED
+invalid-overridden-method:46:4:46:16:InvalidDerived.method_a:Method 'method_a' was expected to be 'method', found it instead as 'property':UNDEFINED
+invalid-overridden-method:49:4:49:22:InvalidDerived.method_b:Method 'method_b' was expected to be 'non-async', found it instead as 'async':UNDEFINED
+invalid-overridden-method:123:4:123:11:B.bar:Method 'bar' was expected to be 'property', found it instead as 'method':UNDEFINED
+invalid-overridden-method:127:4:127:12:B.bar2:Method 'bar2' was expected to be 'property', found it instead as 'method':UNDEFINED
+invalid-overridden-method:139:4:139:17:ChildClass.read_file:Method 'read_file' was expected to be "return type 'TextIOWrapper'", found it instead as "return type 'BytesIO'":UNDEFINED

--- a/tests/functional/i/invalid/invalid_overridden_method.txt
+++ b/tests/functional/i/invalid/invalid_overridden_method.txt
@@ -4,4 +4,4 @@ invalid-overridden-method:46:4:46:16:InvalidDerived.method_a:Method 'method_a' w
 invalid-overridden-method:49:4:49:22:InvalidDerived.method_b:Method 'method_b' was expected to be 'non-async', found it instead as 'async':UNDEFINED
 invalid-overridden-method:123:4:123:11:B.bar:Method 'bar' was expected to be 'property', found it instead as 'method':UNDEFINED
 invalid-overridden-method:127:4:127:12:B.bar2:Method 'bar2' was expected to be 'property', found it instead as 'method':UNDEFINED
-invalid-overridden-method:140:4:140:17:ChildClass.read_file:Method 'read_file' was expected to be "return type 'TextIOWrapper'", found it instead as "return type 'BytesIO'":UNDEFINED
+invalid-overridden-method:143:4:143:17:ChildClass1.read_file:Method 'read_file' was expected to be "return type 'TextIOWrapper'", found it instead as "return type 'BytesIO'":UNDEFINED

--- a/tests/functional/i/invalid/invalid_overridden_method.txt
+++ b/tests/functional/i/invalid/invalid_overridden_method.txt
@@ -4,4 +4,4 @@ invalid-overridden-method:46:4:46:16:InvalidDerived.method_a:Method 'method_a' w
 invalid-overridden-method:49:4:49:22:InvalidDerived.method_b:Method 'method_b' was expected to be 'non-async', found it instead as 'async':UNDEFINED
 invalid-overridden-method:123:4:123:11:B.bar:Method 'bar' was expected to be 'property', found it instead as 'method':UNDEFINED
 invalid-overridden-method:127:4:127:12:B.bar2:Method 'bar2' was expected to be 'property', found it instead as 'method':UNDEFINED
-invalid-overridden-method:139:4:139:17:ChildClass.read_file:Method 'read_file' was expected to be "return type 'TextIOWrapper'", found it instead as "return type 'BytesIO'":UNDEFINED
+invalid-overridden-method:140:4:140:17:ChildClass.read_file:Method 'read_file' was expected to be "return type 'TextIOWrapper'", found it instead as "return type 'BytesIO'":UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue `skip-news` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with `towncrier create 10351.feature` which will be
    included in the changelog. `<type>` can be one of the types defined in ./towncrier.toml.
  - Generating the doc is done with `tox -e docs`
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #10351, Closes #10351)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in `script/.contributors_aliases.json`
-->

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
|  ✓  | :bug: Bug fix          |
|       | :sparkles: New feature |
|       | :hammer: Refactoring   |
|       | :scroll: Docs          |

## Description

Closes #10351

- Enhanced the `invalid-overridden-method` (W0236) checker to detect return type mismatches in overridden methods
- Introduced `_are_return_types_compatible` helper to check compatibility using the following conditions:
    1.) excat match
    2.) subclassing (covariance)
    3.) Special handling for return type  `Any`
- Added test cases covering both valid and invalid return type overrides
- Updated expected test output to reflect new behavior

Had this branch open for while now, so I decided to finish the implementation. Let me know what you think :)