### PR TITLE
Fix false negative for `deprecated-module` when a `__import__` method is used instead of `import` sentence

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -91,6 +91,7 @@ contributors:
   * Fix consider-using-ternary for 'True and True and True or True' case
   * Add bad-docstring-quotes and docstring-first-line-empty
   * Add missing-timeout
+  * Fix false negative for `deprecated-module` when a `__import__` method is used instead of `import` sentence
 - Frank Harrison <frank@doublethefish.com> (doublethefish)
 - Zen Lee <53538590+zenlyj@users.noreply.github.com>
 - Pierre-Yves David <pierre-yves.david@logilab.fr>

--- a/doc/whatsnew/fragments/10453.false_negative
+++ b/doc/whatsnew/fragments/10453.false_negative
@@ -1,0 +1,3 @@
+Fix false negative for `deprecated-module` when a `__import__` method is used instead of `import` sentence.
+
+Refs #10453

--- a/pylint/checkers/deprecated.py
+++ b/pylint/checkers/deprecated.py
@@ -97,6 +97,7 @@ class DeprecatedMixin(BaseChecker):
         "deprecated-method",
         "deprecated-argument",
         "deprecated-class",
+        "deprecated-module",
     )
     def visit_call(self, node: nodes.Call) -> None:
         """Called when a :class:`nodes.Call` node is visited."""
@@ -104,6 +105,15 @@ class DeprecatedMixin(BaseChecker):
         for inferred in infer_all(node.func):
             # Calling entry point for deprecation check logic.
             self.check_deprecated_method(node, inferred)
+
+            if (
+                isinstance(inferred, nodes.FunctionDef)
+                and inferred.qname() == "builtins.__import__"
+                and len(node.args) == 1
+                and (mod_path_node := utils.safe_infer(node.args[0]))
+                and isinstance(mod_path_node, astroid.Const)
+            ):
+                self.check_deprecated_module(node, mod_path_node.value)
 
     @utils.only_required_for_messages(
         "deprecated-module",

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -109,6 +109,10 @@
     "mails": ["62866982+SupImDos@users.noreply.github.com"],
     "name": "Hayden Richards"
   },
+  "6644187+moylop260@users.noreply.github.com": {
+    "mails": ["6644187+moylop260@users.noreply.github.com", "moylop260@vauxoo.com"],
+    "name": "Moisés Lopez"
+  },
   "74228962+tanvimoharir@users.noreply.github.com": {
     "comment": ": Fix for invalid toml config",
     "mails": ["74228962+tanvimoharir@users.noreply.github.com"],

--- a/tests/functional/d/deprecated/deprecated_module__import__.py
+++ b/tests/functional/d/deprecated/deprecated_module__import__.py
@@ -1,0 +1,9 @@
+"""Test deprecated modules using '__import__' builtin method."""
+# pylint: disable=invalid-name
+
+imp = __import__("mypackage")  # [deprecated-module]
+
+imp_meth = __import__("mypackage").meth()  # [deprecated-module]
+
+lib = "mypackage"
+infer_imp = __import__(lib)  # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module__import__.rc
+++ b/tests/functional/d/deprecated/deprecated_module__import__.rc
@@ -1,0 +1,2 @@
+[Imports]
+deprecated-modules=mypackage

--- a/tests/functional/d/deprecated/deprecated_module__import__.txt
+++ b/tests/functional/d/deprecated/deprecated_module__import__.txt
@@ -1,0 +1,3 @@
+deprecated-module:4:6:4:29::Deprecated module 'mypackage':UNDEFINED
+deprecated-module:6:11:6:34::Deprecated module 'mypackage':UNDEFINED
+deprecated-module:9:12:9:27::Deprecated module 'mypackage':UNDEFINED


### PR DESCRIPTION
Using the following python code style

```python
__import__("deprecated_module")
```

The deprecated-module is ignored since that it expects

```python
import deprecated_module
```

This change adds the posibility to process these kind of style too

This style is used from popular auto-code snippets:
 - https://github.com/honza/vim-snippets/blob/f0a3184/snippets/python.snippets#L209

<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|   X | :sparkles: New feature |
|  X  | :hammer: Refactoring   |
| X   | :scroll: Docs          |

## Description

Closes #10453