### PR TITLE
Fix false-negative for used-before-assignment with postponed evaluation in function defs

### DIFF
--- a/doc/whatsnew/fragments/10482.false_negative
+++ b/doc/whatsnew/fragments/10482.false_negative
@@ -1,0 +1,3 @@
+Fix false-negative for ``used-before-assignment`` with ``from __future__ import annotations`` in function definitions.
+
+Refs #10482

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1929,7 +1929,17 @@ class VariablesChecker(BaseChecker):
                 # and unevaluated annotations inside a function body
                 if not (
                     self._postponed_evaluation_enabled
-                    and isinstance(stmt, (nodes.AnnAssign, nodes.FunctionDef))
+                    and (
+                        isinstance(stmt, nodes.AnnAssign)
+                        or (
+                            isinstance(stmt, nodes.FunctionDef)
+                            and node
+                            not in {
+                                *(stmt.args.defaults or ()),
+                                *(stmt.args.kw_defaults or ()),
+                            }
+                        )
+                    )
                 ) and not (
                     isinstance(stmt, nodes.AnnAssign)
                     and utils.get_node_first_ancestor_of_type(stmt, nodes.FunctionDef)


### PR DESCRIPTION
## Description

`used-before-assignment` errors should still be emitted for function arg defaults even with postponed evaluation of type annotations enabled.
```py
from __future__ import annotations

def func(var = A):  # should emit 'used-before-assignment'
    ...

class A: ...
```

Didn't add a test case for it since the test suite already includes examples for it. These will be tested with Python 3.14 where the deferred evaluation of type annotations will be the default.
https://github.com/pylint-dev/pylint/blob/9e72867c1ac46cb0a2f88abf6f596530c2fa1708/tests/functional/u/undefined/undefined_variable.py#L91-L96

https://github.com/pylint-dev/pylint/blob/9e72867c1ac46cb0a2f88abf6f596530c2fa1708/tests/functional/u/undefined/undefined_variable.py#L142-L147

--
This does address some of the issues in #10467. In particular
```py
FAILED tests/test_functional.py::test_functional[undefined_variable]
    - AssertionError: Wrong message(s) raised for "undefined_variable.py":

Expected in testdata:
  91: used-before-assignment (times 1)
 146: used-before-assignment (times 1)
```
