### PR TITLE
Bump pylint to 3.3.8, update changelog

### DIFF
--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -14,6 +14,53 @@ Summary -- Release highlights
 
 .. towncrier release notes start
 
+What's new in Pylint 3.3.8?
+---------------------------
+Release date: 2025-08-09
+
+This patch release includes an exceptional fix for a false negative issue.
+For details, see: https://github.com/pylint-dev/pylint/pull/10482#issuecomment-3164514082
+
+False Positives Fixed
+---------------------
+
+- Fix false positives for `possibly-used-before-assignment` when variables are exhaustively
+  assigned within a `match` block.
+
+  Closes #9668 (`#9668 <https://github.com/pylint-dev/pylint/issues/9668>`_)
+
+- Fix false positive for `missing-raises-doc` and `missing-yield-doc` when the method length is less than docstring-min-length.
+
+  Refs #10104 (`#10104 <https://github.com/pylint-dev/pylint/issues/10104>`_)
+
+- Fix a false positive for ``unused-variable`` when multiple except handlers bind the same name under a try block.
+
+  Closes #10426 (`#10426 <https://github.com/pylint-dev/pylint/issues/10426>`_)
+
+
+
+False Negatives Fixed
+---------------------
+
+- Fix false-negative for ``used-before-assignment`` with ``from __future__ import annotations`` in function definitions.
+
+  Refs #10482 (`#10482 <https://github.com/pylint-dev/pylint/issues/10482>`_)
+
+
+
+Other Bug Fixes
+---------------
+
+- Fix a bug in Pyreverse where aggregations and associations were included in diagrams regardless of the selected --filter-mode (such as PUB_ONLY, ALL, etc.).
+
+  Closes #10373 (`#10373 <https://github.com/pylint-dev/pylint/issues/10373>`_)
+
+- Fix double underscores erroneously rendering as bold in pyreverse's Mermaid output.
+
+  Closes #10402 (`#10402 <https://github.com/pylint-dev/pylint/issues/10402>`_)
+
+
+
 What's new in Pylint 3.3.7?
 ---------------------------
 Release date: 2025-05-04

--- a/doc/whatsnew/fragments/10104.false_positive
+++ b/doc/whatsnew/fragments/10104.false_positive
@@ -1,3 +1,0 @@
-Fix false positive for `missing-raises-doc` and `missing-yield-doc` when the method length is less than docstring-min-length.
-
-Refs #10104

--- a/doc/whatsnew/fragments/10373.bugfix
+++ b/doc/whatsnew/fragments/10373.bugfix
@@ -1,3 +1,0 @@
-Fix a bug in Pyreverse where aggregations and associations were included in diagrams regardless of the selected --filter-mode (such as PUB_ONLY, ALL, etc.).
-
-Closes #10373

--- a/doc/whatsnew/fragments/10402.bugfix
+++ b/doc/whatsnew/fragments/10402.bugfix
@@ -1,3 +1,0 @@
-Fix double underscores erroneously rendering as bold in pyreverse's Mermaid output.
-
-Closes #10402

--- a/doc/whatsnew/fragments/10426.false_positive
+++ b/doc/whatsnew/fragments/10426.false_positive
@@ -1,3 +1,0 @@
-Fix a false positive for ``unused-variable`` when multiple except handlers bind the same name under a try block.
-
-Closes #10426

--- a/doc/whatsnew/fragments/10482.false_negative
+++ b/doc/whatsnew/fragments/10482.false_negative
@@ -1,3 +1,0 @@
-Fix false-negative for ``used-before-assignment`` with ``from __future__ import annotations`` in function definitions.
-
-Refs #10482

--- a/doc/whatsnew/fragments/9668.false_positive
+++ b/doc/whatsnew/fragments/9668.false_positive
@@ -1,4 +1,0 @@
-Fix false positives for `possibly-used-before-assignment` when variables are exhaustively
-assigned within a `match` block.
-
-Closes #9668

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -9,7 +9,7 @@ It's updated via tbump, do not modify.
 
 from __future__ import annotations
 
-__version__ = "3.3.7"
+__version__ = "3.3.8"
 
 
 def get_numversion_from_version(v: str) -> tuple[int, int, int]:

--- a/script/.contributors_aliases.json
+++ b/script/.contributors_aliases.json
@@ -273,6 +273,7 @@
     "mails": [
       "66853113+pre-commit-ci[bot]@users.noreply.github.com",
       "49699333+dependabot[bot]@users.noreply.github.com",
+      "212256041+pylint-backport-bot[bot]@users.noreply.github.com",
       "41898282+github-actions[bot]@users.noreply.github.com"
     ],
     "name": "bot"

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,7 +1,7 @@
 github_url = "https://github.com/pylint-dev/pylint"
 
 [version]
-current = "3.3.7"
+current = "3.3.8"
 regex = '''
 ^(?P<major>0|[1-9]\d*)
 \.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-version = "3.3.7"
+version = "3.3.8"
 directory = "doc/whatsnew/fragments"
 filename = "doc/whatsnew/3/3.3/index.rst"
 template = "doc/whatsnew/fragments/_template.rst"


### PR DESCRIPTION
What's new in Pylint 3.3.8?
---------------------------
Release date: 2025-08-09

This patch release includes an exceptional fix for a false negative issue. For details, see: https://github.com/pylint-dev/pylint/pull/10482#issuecomment-3164514082

False Positives Fixed
---------------------

- Fix false positives for `possibly-used-before-assignment` when variables are exhaustively
  assigned within a `match` block.

  Closes #9668 

- Fix false positive for `missing-raises-doc` and `missing-yield-doc` when the method length is less than docstring-min-length.

  Refs #10104 

- Fix a false positive for ``unused-variable`` when multiple except handlers bind the same name under a try block.

  Closes #10426 



False Negatives Fixed
---------------------

- Fix false-negative for ``used-before-assignment`` with ``from __future__ import annotations`` in function definitions.

  Refs #10482 



Other Bug Fixes
---------------

- Fix a bug in Pyreverse where aggregations and associations were included in diagrams regardless of the selected --filter-mode (such as PUB_ONLY, ALL, etc.).

  Closes #10373 

- Fix double underscores erroneously rendering as bold in pyreverse's Mermaid output.

  Closes #10402 


