### PR TITLE
[Backport maintenance/3.3.x] Fix used-before-assignment for PEP 695 type aliases + parameters

### DIFF
--- a/doc/whatsnew/fragments/9815.false_positive
+++ b/doc/whatsnew/fragments/9815.false_positive
@@ -1,0 +1,3 @@
+Fix used-before-assignment for PEP 695 type aliases and parameters.
+
+Closes #9815

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1641,6 +1641,13 @@ def is_node_in_type_annotation_context(node: nodes.NodeNG) -> bool:
             return False
 
 
+def is_node_in_pep695_type_context(node: nodes.NodeNG) -> nodes.NodeNG | None:
+    """Check if node is used in a TypeAlias or as part of a type param."""
+    return get_node_first_ancestor_of_type(
+        node, (nodes.TypeAlias, nodes.TypeVar, nodes.ParamSpec, nodes.TypeVarTuple)
+    )
+
+
 def is_subclass_of(child: nodes.ClassDef, parent: nodes.ClassDef) -> bool:
     """Check if first node is a subclass of second node.
 

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1947,22 +1947,21 @@ class VariablesChecker(BaseChecker):
 
                 # Skip postponed evaluation of annotations
                 # and unevaluated annotations inside a function body
+                # as well as TypeAlias nodes.
                 if not (
                     self._postponed_evaluation_enabled
                     and (
                         isinstance(stmt, nodes.AnnAssign)
-                        or (
-                            isinstance(stmt, nodes.FunctionDef)
-                            and node
-                            not in {
-                                *(stmt.args.defaults or ()),
-                                *(stmt.args.kw_defaults or ()),
-                            }
-                        )
+                        or isinstance(stmt, nodes.FunctionDef)
+                        and node
+                        not in {
+                            *(stmt.args.defaults or ()),
+                            *(stmt.args.kw_defaults or ()),
+                        }
                     )
-                ) and not (
-                    isinstance(stmt, nodes.AnnAssign)
+                    or isinstance(stmt, nodes.AnnAssign)
                     and utils.get_node_first_ancestor_of_type(stmt, nodes.FunctionDef)
+                    or isinstance(stmt, nodes.TypeAlias)
                 ):
                     self.add_message(
                         "used-before-assignment",
@@ -2034,7 +2033,7 @@ class VariablesChecker(BaseChecker):
         if (
             self._postponed_evaluation_enabled
             and utils.is_node_in_type_annotation_context(node)
-        ):
+        ) or utils.is_node_in_pep695_type_context(node):
             return
         if self._is_builtin(node.name):
             return

--- a/pylint/testutils/functional/find_functional_tests.py
+++ b/pylint/testutils/functional/find_functional_tests.py
@@ -21,6 +21,7 @@ IGNORED_PARENT_DIRS = {
     "ext",
     "regression",
     "regression_02",
+    "used_02",
 }
 """Direct parent directories that should be ignored."""
 

--- a/tests/functional/u/used/used_before_assignment_py312.py
+++ b/tests/functional/u/used/used_before_assignment_py312.py
@@ -1,6 +1,23 @@
-"""used-before-assignment re: python 3.12 generic typing syntax (PEP 695)"""
+"""Tests for used-before-assignment with Python 3.12 generic typing syntax (PEP 695)"""
+# pylint: disable = invalid-name,missing-docstring,too-few-public-methods,unused-argument
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
+
 type Point[T] = tuple[T, ...]
 type Alias[*Ts] = tuple[*Ts]
-type Alias[**P] = Callable[P]
+type Alias2[**P] = Callable[P, None]
+
+type AliasType = int | X | Y
+
+class X:
+    pass
+
+if TYPE_CHECKING:
+    class Y: ...
+
+class Good[T: Y]: ...
+type OtherAlias[T: Y] = T | None
+
+# https://github.com/pylint-dev/pylint/issues/9884
+def func[T: Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+    ...

--- a/tests/functional/u/used/used_before_assignment_py312.txt
+++ b/tests/functional/u/used/used_before_assignment_py312.txt
@@ -1,0 +1,1 @@
+redefined-outer-name:22:9:22:13:func:Redefining name 'T' from outer scope (line 6):UNDEFINED

--- a/tests/functional/u/used_02/used_before_assignment_py313.py
+++ b/tests/functional/u/used_02/used_before_assignment_py313.py
@@ -1,0 +1,16 @@
+"""Tests for used-before-assignment with Python 3.13 type var defaults (PEP 696)"""
+# pylint: disable=missing-docstring,unused-argument,too-few-public-methods
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    class Y: ...
+
+class Good1[T = Y]: ...
+class Good2[*Ts = tuple[int, Y]]: ...
+class Good3[**P = [int, Y]]: ...
+type Alias[T = Y] = T | None
+
+# https://github.com/pylint-dev/pylint/issues/9884
+def func[T = Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+    ...

--- a/tests/functional/u/used_02/used_before_assignment_py313.rc
+++ b/tests/functional/u/used_02/used_before_assignment_py313.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.13

--- a/tests/functional/u/used_02/used_before_assignment_py313.txt
+++ b/tests/functional/u/used_02/used_before_assignment_py313.txt
@@ -1,0 +1,1 @@
+redefined-outer-name:15:9:15:14:func:Redefining name 'T' from outer scope (line 12):UNDEFINED


### PR DESCRIPTION
Backport https://github.com/pylint-dev/pylint/commit/bbfcb381342c10693bfb8cb38b28e1f91998ea00 from https://github.com/pylint-dev/pylint/pull/10488.