### PR TITLE
Add workflow_dispatch trigger [ci]

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - "maintenance/**"
+  workflow_dispatch:
 
 env:
   CACHE_VERSION: 3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - "maintenance/**"
+  workflow_dispatch:
 
 env:
   CACHE_VERSION: 5


### PR DESCRIPTION
Sometimes it's useful to trigger CI runs manually via `workflow_dispatch` events. I often use it if I quickly want to check something against all Python version.

_Non-members will be able to run CI checks on their own forks if they want to._