### PR TITLE
Add actions permission for stale job [ci]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,11 +9,14 @@ jobs:
     if: github.repository_owner == 'pylint-dev'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       issues: write
       pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:
+          operations-per-run: 100
+
           days-before-issue-stale: 28
           days-before-issue-close: 7
           any-of-issue-labels:


### PR DESCRIPTION
## Description
With v9 `actions/stale` introduced caching if not all issues could be handled during one run. That requires the `actions: write` permission.

Also increased the `operations-per-run` from 30 (default) to 100. During the last run the job only updated a few issues and PRs but was already at 21 operations. 100 should give us some more headroom. If more actions are needed, the caching will apply and the job will continue during the next scheduled run where it last stopped.

https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions
https://github.com/actions/stale?tab=readme-ov-file#operations-per-run