### PR TITLE
Fix pre-commit checks on Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,7 +128,9 @@ repos:
       - id: rstcheck
         args: ["--report-level=warning"]
         files: ^(doc/(.*/)*.*\.rst)
-        additional_dependencies: [Sphinx==7.4.3]
+        # TODO remove pydantic once 2.12.0 is released
+        additional_dependencies:
+          ["Sphinx==7.4.3", "pydantic>=2.12.0a1;python_version>='3.14'"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.1
     hooks:

--- a/tests/test_check_parallel.py
+++ b/tests/test_check_parallel.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures.process import BrokenProcessPool
+from concurrent.futures.process import BrokenProcessPool, ProcessPoolExecutor
 from pathlib import Path
 from pickle import PickleError
 from typing import TYPE_CHECKING


### PR DESCRIPTION
## Description
The `rstcheck` pre-commit job requires pydantic which fails on Python 3.14 currently. The first compatible version will be `3.12.0`(not released yet). Make sure we can install the alpha release for 3.14.

Also update an import to fix pylint on 3.14.