### PR TITLE
Switch back to upstream setup-python with PyPy fix [ci]

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,8 +47,9 @@ jobs:
         uses: actions/checkout@v5.0.0
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        # Custom with PyPy fix: https://github.com/actions/setup-python/pull/1110
-        uses: cdce8p/setup-python@v5.6.0-c1
+        # Use unreleased version with PyPy fix: https://github.com/actions/setup-python/pull/1110
+        # TODO move back to tagged versions for >5.6.0
+        uses: actions/setup-python@88ffd4d597d830d67a7369dd33dcb72c0958a807
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true


### PR DESCRIPTION
## Description
Followup to https://github.com/pylint-dev/pylint/pull/10392

The upstream PR https://github.com/actions/setup-python/pull/1110 was merged a few weeks ago. Unfortunately there hasn't been a new release in some time now. Guess we could switch back to a sha version for now. Hopefully dependabot will update it as well, otherwise we'll need to remember to do so.