### PR TITLE
Better approach in 'unnecessary-list-index-lookup' to avoid crashes

### DIFF
--- a/doc/whatsnew/fragments/10510.bugfix
+++ b/doc/whatsnew/fragments/10510.bugfix
@@ -1,0 +1,7 @@
+Fixed crash in 'unnecessary-list-index-lookup' when starting an enumeration using
+minus the length of an iterable inside a dict comprehension when the len call was only
+made in this dict comprehension, and not elsewhere. Also changed the approach,
+to use inference in all cases but the simple ones, so we don't have to fix crashes
+one by one for arbitrarily complex expressions in enumerate.
+
+Closes #10510

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2450,17 +2450,20 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return False, confidence
 
     def _get_start_value(self, node: nodes.NodeNG) -> tuple[int | None, Confidence]:
-        if isinstance(node, (nodes.Name, nodes.Call, nodes.Attribute)) or (
-            isinstance(node, nodes.UnaryOp)
-            and isinstance(node.operand, (nodes.Attribute, nodes.Name))
-        ):
-            inferred = utils.safe_infer(node)
-            # inferred can be an astroid.base.Instance as in 'enumerate(x, int(y))' or
-            # not correctly inferred (None)
-            start_val = inferred.value if isinstance(inferred, nodes.Const) else None
-            return start_val, INFERENCE
-        if isinstance(node, nodes.UnaryOp):
-            return node.operand.value, HIGH
+        # Most common use cases are a constant integer or minus a constant integer. We
+        # don't need inference for that. If that's not the case, we assume arbitrary
+        # complexity and we use inference.
         if isinstance(node, nodes.Const):
             return node.value, HIGH
-        return None, HIGH
+        if isinstance(node, nodes.UnaryOp) and isinstance(node.operand, nodes.Const):
+            return node.operand.value, HIGH
+        inferred = utils.safe_infer(node)
+        if isinstance(inferred, nodes.Const):
+            return inferred.value, INFERENCE
+        # inferred can be an 'astroid.base.Instance' in 'enumerate(x, int(y))',
+        # for example. We're doing nothing in this case for now, as extracting
+        # the value is costly.
+
+        # At this point the most likely cases is that the node is uninferable
+        # But we don't have to check if it's actually uninferable.
+        return None, INFERENCE

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -167,3 +167,7 @@ def random_uninferrable_start(pears):
 
     for _, _ in enumerate(pears, random.choice([5, 42])):
         ...
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/10510
+xs = [1, 2, 3]
+test_dict = {j: i for i, j in enumerate(xs, -len(xs))}


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Got real tired of the crashes in enumerate when inferring the value of start following #7821, #7963, #8069, #8207, #9074, #9078, #9272, so inference most of the time it is.

Closes #10510
