### PR TITLE
Use match statement in checkers (1)

### DIFF
--- a/pylint/checkers/match_statements_checker.py
+++ b/pylint/checkers/match_statements_checker.py
@@ -37,13 +37,13 @@ class MatchStatementChecker(BaseChecker):
         """
         for idx, case in enumerate(node.cases):
             match case.pattern:
-                case nodes.MatchAs(pattern=None, name=nodes.AssignName()) if (
+                case nodes.MatchAs(pattern=None, name=nodes.AssignName(name=n)) if (
                     idx < len(node.cases) - 1
                 ):
                     self.add_message(
                         "bare-name-capture-pattern",
                         node=case.pattern,
-                        args=case.pattern.name.name,
+                        args=n,
                         confidence=HIGH,
                     )
 

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -133,23 +133,24 @@ def possible_exc_types(node: nodes.NodeNG) -> set[nodes.ClassDef]:
             except astroid.InferenceError:
                 pass
     else:
-        target = _get_raise_target(node)
-        if isinstance(target, nodes.ClassDef):
-            exceptions = [target]
-        elif isinstance(target, nodes.FunctionDef):
-            for ret in target.nodes_of_class(nodes.Return):
-                if ret.value is None:
-                    continue
-                if ret.frame() != target:
-                    # return from inner function - ignore it
-                    continue
+        match target := _get_raise_target(node):
+            case nodes.ClassDef():
+                exceptions = [target]
+            case nodes.FunctionDef():
+                for ret in target.nodes_of_class(nodes.Return):
+                    if ret.value is None:
+                        continue
+                    if ret.frame() != target:
+                        # return from inner function - ignore it
+                        continue
 
-                val = utils.safe_infer(ret.value)
-                if val and utils.inherit_from_std_ex(val):
-                    if isinstance(val, nodes.ClassDef):
-                        exceptions.append(val)
-                    elif isinstance(val, astroid.Instance):
-                        exceptions.append(val.getattr("__class__")[0])
+                    val = utils.safe_infer(ret.value)
+                    if val and utils.inherit_from_std_ex(val):
+                        match val:
+                            case nodes.ClassDef():
+                                exceptions.append(val)
+                            case astroid.Instance():
+                                exceptions.append(val.getattr("__class__")[0])
 
     try:
         return {

--- a/pylint/extensions/code_style.py
+++ b/pylint/extensions/code_style.py
@@ -309,12 +309,13 @@ class CodeStyleChecker(BaseChecker):
         if isinstance(node.test, nodes.Compare):
             next_if_node: nodes.If | None = None
             next_sibling = node.next_sibling()
-            if len(node.orelse) == 1 and isinstance(node.orelse[0], nodes.If):
-                # elif block
-                next_if_node = node.orelse[0]
-            elif isinstance(next_sibling, nodes.If):
-                # separate if block
-                next_if_node = next_sibling
+            match (node.orelse, next_sibling):
+                case [[nodes.If() as next_if_node], _]:
+                    # elif block
+                    pass
+                case [_, nodes.If() as next_if_node]:
+                    # separate if block
+                    pass
 
             if (  # pylint: disable=too-many-boolean-expressions
                 next_if_node is not None

--- a/pylint/extensions/for_any_all.py
+++ b/pylint/extensions/for_any_all.py
@@ -147,12 +147,13 @@ class ConsiderUsingAnyOrAllChecker(BaseChecker):
         loop_iter = node.iter.as_string()
         test_node = next(node.body[0].get_children())
 
-        if isinstance(test_node, nodes.UnaryOp) and test_node.op == "not":
-            # The condition is negated. Advance the node to the operand and modify the suggestion
-            test_node = test_node.operand
-            suggested_function = "all" if final_return_bool else "not all"
-        else:
-            suggested_function = "not any" if final_return_bool else "any"
+        match test_node:
+            case nodes.UnaryOp(op="not"):
+                # The condition is negated. Advance the node to the operand and modify the suggestion
+                test_node = test_node.operand
+                suggested_function = "all" if final_return_bool else "not all"
+            case _:
+                suggested_function = "not any" if final_return_bool else "any"
 
         test = test_node.as_string()
         return f"{suggested_function}({test} for {loop_var} in {loop_iter})"

--- a/pylint/extensions/private_import.py
+++ b/pylint/extensions/private_import.py
@@ -147,14 +147,15 @@ class PrivateImportChecker(BaseChecker):
                 if isinstance(usage_node, nodes.AssignName) and isinstance(
                     usage_node.parent, (nodes.AnnAssign, nodes.Assign)
                 ):
-                    assign_parent = usage_node.parent
-                    if isinstance(assign_parent, nodes.AnnAssign):
-                        name_assignments.append(assign_parent)
-                        private_name = self._populate_type_annotations_annotation(
-                            usage_node.parent.annotation, all_used_type_annotations
-                        )
-                    elif isinstance(assign_parent, nodes.Assign):
-                        name_assignments.append(assign_parent)
+                    match assign_parent := usage_node.parent:
+                        case nodes.AnnAssign():
+                            name_assignments.append(assign_parent)
+                            private_name = self._populate_type_annotations_annotation(
+                                assign_parent.annotation,
+                                all_used_type_annotations,
+                            )
+                        case nodes.Assign():
+                            name_assignments.append(assign_parent)
 
                 if isinstance(usage_node, nodes.FunctionDef):
                     self._populate_type_annotations_function(
@@ -194,24 +195,23 @@ class PrivateImportChecker(BaseChecker):
         """Handles the possibility of an annotation either being a Name, i.e. just type,
         or a Subscript e.g. `Optional[type]` or an Attribute, e.g. `pylint.lint.linter`.
         """
-        if isinstance(node, nodes.Name) and node.name not in all_used_type_annotations:
-            all_used_type_annotations[node.name] = True
-            return node.name  # type: ignore[no-any-return]
-        if isinstance(node, nodes.Subscript):  # e.g. Optional[List[str]]
-            # slice is the next nested type
-            self._populate_type_annotations_annotation(
-                node.slice, all_used_type_annotations
-            )
-            # value is the current type name: could be a Name or Attribute
-            return self._populate_type_annotations_annotation(
-                node.value, all_used_type_annotations
-            )
-        if isinstance(node, nodes.Attribute):
-            # An attribute is a type like `pylint.lint.pylinter`. node.expr is the next level
-            # up, could be another attribute
-            return self._populate_type_annotations_annotation(
-                node.expr, all_used_type_annotations
-            )
+        match node:
+            case nodes.Name(name=n) if n not in all_used_type_annotations:
+                all_used_type_annotations[n] = True
+                return n  # type: ignore[no-any-return]
+            case nodes.Subscript(slice=s, value=v):
+                # slice is the next nested type
+                self._populate_type_annotations_annotation(s, all_used_type_annotations)
+                # value is the current type name: could be a Name or Attribute
+                return self._populate_type_annotations_annotation(
+                    v, all_used_type_annotations
+                )
+            case nodes.Attribute(expr=e):
+                # An attribute is a type like `pylint.lint.pylinter`. node.expr is the next level
+                # up, could be another attribute
+                return self._populate_type_annotations_annotation(
+                    e, all_used_type_annotations
+                )
         return None
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,11 @@ scripts_are_modules = true
 warn_unused_ignores = true
 show_error_codes = true
 enable_error_code = "ignore-without-code"
+disable_error_code = [
+  # TODO: remove once match false-positives are fixed, probably in v1.18
+  # https://github.com/python/mypy/pull/19708
+  "has-type",
+]
 strict = true
 # TODO: Remove this once pytest has annotations
 disallow_untyped_decorators = false


### PR DESCRIPTION
After we added the first match statement in https://github.com/pylint-dev/pylint/pull/10424#discussion_r2264723128, I checked a few other files to see which checks can be converted. There are actually quite a lot. Before we go ahead with it though, I think we should decide on some design choices and good practices first. _I'll create comments for the specific sections. Feel free to add new ones as well in case I missed anything._

There are also mypy issues as astroid isn't fully typed yet. Opened PRs for it upstream already but those will be included in `v1.18` at the earliest. Until then it might be best to just disable the offending error code(s) or add type ignores.
- https://github.com/python/mypy/pull/19708
- https://github.com/python/mypy/pull/19709