### PR TITLE
[primer]  Mimick what we actually have when we upgrade messages in test cases

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -16,6 +16,8 @@ env:
   # This needs to be the SAME as in the Main and PR job
   CACHE_VERSION: 4
   KEY_PREFIX: venv-primer
+  # If you change this, also change PRIMER_CURRENT_INTERPRETER in
+  # tests/testutils/_primer/test_primer.py
   DEFAULT_PYTHON: "3.13"
 
 permissions:

--- a/tests/testutils/_primer/fixtures/new_message/expected.txt
+++ b/tests/testutils/_primer/fixtures/new_message/expected.txt
@@ -1,0 +1,19 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+The following messages are now emitted:
+
+<details>
+
+1) locally-disabled:
+*Locally disabling redefined-builtin [we added some text in the message] (W0622)*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
+
+</details>
+
+
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/fixtures/new_message/main.json
+++ b/tests/testutils/_primer/fixtures/new_message/main.json
@@ -1,0 +1,6 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": []
+  }
+}

--- a/tests/testutils/_primer/fixtures/new_message/pr.json
+++ b/tests/testutils/_primer/fixtures/new_message/pr.json
@@ -1,0 +1,20 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "info",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "locally-disabled",
+        "message": "Locally disabling redefined-builtin [we added some text in the message] (W0622)",
+        "message-id": "I0011"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/fixtures/removed_message/expected.txt
+++ b/tests/testutils/_primer/fixtures/removed_message/expected.txt
@@ -1,0 +1,16 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+The following messages are no longer emitted:
+
+<details>
+
+1) unknown-option-value:
+*Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/__init__.py#L91
+
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/fixtures/removed_message/main.json
+++ b/tests/testutils/_primer/fixtures/removed_message/main.json
@@ -1,0 +1,33 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "info",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "locally-disabled",
+        "message": "Locally disabling redefined-builtin (W0622)",
+        "message-id": "I0011"
+      },
+      {
+        "type": "warning",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "unknown-option-value",
+        "message": "Unknown option value for 'disable', expected a valid pylint message and got 'Ellipsis'",
+        "message-id": "W0012"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/fixtures/removed_message/pr.json
+++ b/tests/testutils/_primer/fixtures/removed_message/pr.json
@@ -1,0 +1,20 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "info",
+        "module": "astroid",
+        "obj": "",
+        "line": 91,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/__init__.py",
+        "symbol": "locally-disabled",
+        "message": "Locally disabling redefined-builtin (W0622)",
+        "message-id": "I0011"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/test_primer.py
+++ b/tests/testutils/_primer/test_primer.py
@@ -21,7 +21,9 @@ PRIMER_DIRECTORY = TEST_DIR_ROOT / ".pylint_primer_tests/"
 PACKAGES_TO_PRIME_PATH = TEST_DIR_ROOT / "primer/packages_to_prime.json"
 FIXTURES_PATH = HERE / "fixtures"
 
-PRIMER_CURRENT_INTERPRETER = (3, 11)
+# If you change this, also change DEFAULT_PYTHON in
+# ``.github/workflows/primer_comment.yaml``
+PRIMER_CURRENT_INTERPRETER = (3, 13)
 
 DEFAULT_ARGS = ["python tests/primer/__main__.py", "compare", "--commit=v2.14.2"]
 

--- a/tests/testutils/_primer/test_primer.py
+++ b/tests/testutils/_primer/test_primer.py
@@ -39,10 +39,12 @@ def test_primer_launch_bad_args(args: list[str], capsys: CaptureFixture) -> None
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] != PRIMER_CURRENT_INTERPRETER or IS_PYPY,
+    sys.platform != "linux"
+    or sys.version_info[:2] != PRIMER_CURRENT_INTERPRETER
+    or IS_PYPY,
     reason=(
         "Primers are internal and will always be run for only one interpreter (currently"
-        f" {PRIMER_CURRENT_INTERPRETER})"
+        f" {PRIMER_CURRENT_INTERPRETER}, on linux)"
     ),
 )
 class TestPrimer:


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Added some test cases with similar looking messages mimicking what we actually have when we upgrade messages later on. 
