### PR TITLE
Sync requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,17 +75,16 @@ dev = [
 ]
 
 test = [
-  "coverage~=7.8",
-  "pytest-cov~=6.0",
-  "pytest-xdist~=3.6",
+  "coverage~=7.10",
+  "pytest-cov~=6.2",
+  "pytest-xdist~=3.8",
   "six",
   "tox>=3",
-  "types-setuptools==78.1.0.20250329",
   { include-group = "test-min" },
 ]
 
 docs = [
-  "furo==2024.8.6",
+  "furo==2025.7.19",
   "sphinx==8.2.3",
   "sphinx-reredirects<1",
   "towncrier~=24.8",
@@ -94,15 +93,15 @@ docs = [
 # Configuration for the build system
 test-min = [
   # Base test dependencies
-  "astroid==4.0.0a0",                   # Pinned to a specific version for tests
+  "astroid==4.0.0b2",                   # Pinned to a specific version for tests
   "py~=1.11.0",
-  "pytest~=8.3",
+  "pytest~=8.4",
   "pytest-benchmark~=5.1",
-  "pytest-timeout~=2.3",
+  "pytest-timeout~=2.4",
   "requests",
   "setuptools; python_version>='3.12'",
   "towncrier~=24.8",
-  "typing-extensions~=4.12",
+  "typing-extensions~=4.15",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Description
Followup to #10523

The dependency versions changed since the initial PR was committed. Make sure versions in `pyproject.toml` match those in the requirement files.