### PR TITLE
Switch to mypy-dev 1.18.0a6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,16 +131,12 @@ repos:
         # TODO remove pydantic once 2.12.0 is released
         additional_dependencies:
           ["Sphinx==7.4.3", "pydantic>=2.12.0a1;python_version>='3.14'"]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+  - repo: https://github.com/cdce8p/mypy-dev-pre-commit
+    rev: v1.18.0a6
     hooks:
       - id: mypy
         name: mypy
-        entry: mypy
-        language: python
-        types: [python]
         args: []
-        require_serial: true
         additional_dependencies:
           ["isort>=5", "platformdirs==2.2.0", "py==1.11", "tomlkit>=0.10.1"]
         exclude: tests(/\w*)*/functional/|tests/input|tests(/.*)+/conftest.py|doc/data/messages|tests(/\w*)*data/

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -82,9 +82,9 @@ class MultiReporter(BaseReporter):
         self._reporters = reporters
         self.path_strip_prefix = os.getcwd() + os.sep
 
-    def on_set_current_module(self, *args: str, **kwargs: Any) -> None:
+    def on_set_current_module(self, module: str, filepath: str | None) -> None:
         for rep in self._reporters:
-            rep.on_set_current_module(*args, **kwargs)
+            rep.on_set_current_module(module, filepath)
 
     def handle_message(self, msg: Message) -> None:
         for rep in self._reporters:


### PR DESCRIPTION
## Description
Mypy itself has a rather slow release cadences. A while ago I created [mypy-dev](https://github.com/cdce8p/mypy-dev). A repository setup to create development releases of mypy available on PyPI. Initially it was only really intended for use during the Home Assistant development. Today, I also setup a pre-commit mirror at [mypy-dev-pre-commit](https://github.com/cdce8p/mypy-dev-pre-commit) so we could also use it here in pylint.

It wouldn't be worth it here usually, but I recently fixed a few mypy issues with the match statement which would be useful here. Once the next version is released, we could switch back again.

- https://github.com/python/mypy/pull/19708
- https://github.com/python/mypy/pull/19709
- https://github.com/python/mypy/pull/19742

> [!NOTE]
> Due to the increased release frequency and storage limits, I **delete** old versions on PyPI from time to time.
> At most this would probably mean the mypy pre-commit check would fail if an old commit is checked out at some point. For the main branch pre-commit autoupdate should work fine.
> 
> I'd also recommend that the maintenance branch doesn't switch to mypy-dev since autoupdate isn't run there.

Resolves https://github.com/pylint-dev/pylint/pull/10514#discussion_r2294245383