### PR TITLE
Improve coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,10 +7,7 @@ include =
     pylint/*
 omit =
     */test/*
-exclude_lines =
-    # Re-enable default pragma
-    pragma: no cover
-
+exclude_also =
     # Debug-only code
     def __repr__
 
@@ -20,3 +17,6 @@ exclude_lines =
 
     # Abstract methods are not executed during pytest runs
     raise NotImplementedError()
+
+    # Fallback cases which should never be executed
+    raise AssertionError


### PR DESCRIPTION
## Description
Coverage `7.2` added `exclude_also` which extends `exclude_lines` and is now the preferred method to add new exclude patterns. https://coverage.readthedocs.io/en/7.10.6/excluding.html#advanced-exclusion