### PR TITLE
Use custom backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,11 +28,13 @@ jobs:
       - uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ vars.BACKPORT_APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           permission-contents: write # push branch to Github
           permission-pull-requests: write # create PR / add comment for manual backport
           permission-workflows: write # modify files in .github/workflows
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
+      - uses: pylint-dev/backport@94367840595495e101f9a31415897c05da1f08d9 # v2.1.1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          user_name: ${{ vars.BACKPORT_USER_NAME }}
+          user_email: ${{ vars.BACKPORT_USER_EMAIL }}


### PR DESCRIPTION
## Description
Followup to https://github.com/pylint-dev/pylint/pull/10396

I finally got around to forking and updating the backport action. I can be found here
https://github.com/pylint-dev/backport
https://github.com/tibdex/backport/compare/main...pylint-dev:backport:main

The plan is to due only the bare minimum of maintenance there. So far I've
- Updated node to v24 and the dependencies
- Fixed some workflows
- Added `user_name` and `user_email` options

I've configured the vars in the `pylint-dev` org selected for the `pylint` and `astroid` repos.

### Open question
Should we rename the `pylint-backport-bot[bot]` to just `pylint-backport[bot]`? When I did set it up, I didn't know that Github would add `[bot]` automatically. It's probably just a style thing. At most some commits in the maintenance branch won't be probably attributed to the bot anymore.

I lean slightly towards doing it.

--
Will tag this one for the backport, just so we can see if everything worked out fine.