### PR TITLE
Re-implement 'mccabe' to reduce supply chain risks and optimize check

### DIFF
--- a/doc/whatsnew/fragments/10551.bugfix
+++ b/doc/whatsnew/fragments/10551.bugfix
@@ -1,0 +1,7 @@
+The McCabe rating of ``match`` statements used by ``too-complex`` is now
+branch-accurate: an exhaustive ``match`` (ending with an unguarded wildcard
+or capture name) no longer counts a nonexistent fall-through path, mirroring
+how ``else`` is counted for ``if``/``elif`` chains, while a non-exhaustive
+``match`` still does.
+
+Refs #10551

--- a/doc/whatsnew/fragments/10551.false_negative
+++ b/doc/whatsnew/fragments/10551.false_negative
@@ -1,0 +1,7 @@
+``too-complex`` now reports every function or method sharing a name in the
+same scope. The previous ``mccabe``-based checker stored results by name, so
+for instance for a property only the last accessor definition was rated: a
+complex getter or setter was silently ignored whenever a deleter (or any
+later same-named function) followed it.
+
+Refs #10551

--- a/doc/whatsnew/fragments/10551.internal
+++ b/doc/whatsnew/fragments/10551.internal
@@ -1,0 +1,4 @@
+The dependency to mccabe was removed and its content is now vendored in pylint. Optimization were done as a result
+because mccabe was a code to dot graph generator and pylint only need to calculate the mccabe score not draw graphics.
+
+Refs #10551

--- a/doc/whatsnew/fragments/10551.internal
+++ b/doc/whatsnew/fragments/10551.internal
@@ -1,4 +1,7 @@
-The dependency to mccabe was removed and its content is now vendored in pylint. Optimization were done as a result
-because mccabe was a code to dot graph generator and pylint only need to calculate the mccabe score not draw graphics.
+The dependency to ``mccabe`` has been removed. The complexity visitor was
+reimplemented from scratch and is ~7x faster in isolation, though the
+end-to-end impact on a full pylint run is negligible since astroid parsing
+dominates wall time. ``mccabe`` was originally a code-to-dot-graph generator;
+ pylint only needs the complexity score, not the graph.
 
 Refs #10551

--- a/doc/whatsnew/fragments/10551.internal
+++ b/doc/whatsnew/fragments/10551.internal
@@ -2,6 +2,6 @@ The dependency to ``mccabe`` has been removed. The complexity visitor was
 reimplemented from scratch and is ~7x faster in isolation, though the
 end-to-end impact on a full pylint run is negligible since astroid parsing
 dominates wall time. ``mccabe`` was originally a code-to-dot-graph generator;
- pylint only needs the complexity score, not the graph.
+pylint only needs the complexity score, not the graph.
 
 Refs #10551

--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -2,14 +2,6 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
-"""Module to add McCabe checker class for pylint.
-
-Based on:
-http://nedbatchelder.com/blog/200803/python_code_complexity_microtool.html
-Later integrated in pycqa/mccabe under the MIT License then vendored in pylint
-under the GPL License.
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -25,165 +17,201 @@ if TYPE_CHECKING:
 
 
 class PathGraph:
-    def __init__(self) -> None:
-        self.nodes: dict[Any, list[Any]] = {}
+    """Track control flow edges and nodes for McCabe complexity (E - N + 2).
 
-    def connect(self, n1: Any, n2: Any) -> None:
-        if n1 not in self.nodes:
-            self.nodes[n1] = []
-        self.nodes[n1].append(n2)
-        # Ensure that the destination node is always counted.
-        if n2 not in self.nodes:
-            self.nodes[n2] = []
+    Instead of storing actual graph structure, we only need the counts:
+    the complexity formula V = E - N + 2 depends only on the number of
+    edges and nodes, not their identity.
+    """
+
+    __slots__ = ("_num_edges", "_num_nodes")
+
+    def __init__(self) -> None:
+        self._num_nodes = 0
+        self._num_edges = 0
+
+    def add_node(self) -> int:
+        nid = self._num_nodes
+        self._num_nodes += 1
+        return nid
+
+    def add_edge(self) -> None:
+        self._num_edges += 1
 
     def complexity(self) -> int:
-        """Return the McCabe complexity for the graph.
-
-        V-E+2
-        """
-        num_edges = sum(len(n) for n in self.nodes.values())
-        num_nodes = len(self.nodes)
-        return num_edges - num_nodes + 2
+        return self._num_edges - self._num_nodes + 2
 
 
 class PathGraphingAstVisitor:
-    """A visitor for a parsed Abstract Syntax Tree which finds executable
-    statements.
+    """Compute McCabe cyclomatic complexity via control flow graph on astroid AST.
+
+    Builds a simplified CFG tracking only compound statements (if, for, while,
+    try, with, match, function/class defs).  Simple statements are omitted since
+    collapsing a linear chain of nodes does not change E - N + 2.
+
+    Reproduces the same complexity scores as the ``mccabe`` library, but operates
+    directly on astroid trees (no re-parsing) and uses a dict-based dispatch table
+    instead of getattr, skipping expression subtrees entirely.
     """
 
     def __init__(self) -> None:
-        self.classname = ""
-        self.graphs: dict[str, tuple[PathGraph, nodes.NodeNG]] = {}
-        self._bottom_counter = 0
-        self.graph: PathGraph | None = None
-        self.tail: Any = None
+        self.graphs: dict[int, tuple[PathGraph, nodes.NodeNG]] = {}
+        self._graph: PathGraph | None = None
+        self._tail: int = -1
+        self._visitors: dict[type, Any] = {
+            nodes.FunctionDef: self._visit_function,
+            nodes.AsyncFunctionDef: self._visit_function,
+            nodes.ClassDef: self._visit_classdef,
+            nodes.If: self._visit_branching,
+            nodes.For: self._visit_branching,
+            nodes.AsyncFor: self._visit_branching,
+            nodes.While: self._visit_branching,
+            nodes.Try: self._visit_try,
+            nodes.TryStar: self._visit_try,
+            nodes.With: self._visit_with,
+            nodes.AsyncWith: self._visit_with,
+            nodes.Match: self._visit_match,
+        }
 
     def dispatch(self, node: nodes.NodeNG) -> None:
-        meth = getattr(self, "visit" + node.__class__.__name__, self.default)
-        meth(node)
+        handler = self._visitors.get(type(node))
+        if handler is not None:
+            handler(node)
 
-    def default(self, node: nodes.NodeNG) -> None:
-        for child in node.get_children():
-            self.dispatch(child)
+    def _walk_body(self, body: list[nodes.NodeNG]) -> None:
+        visitors = self._visitors
+        for child in body:
+            handler = visitors.get(type(child))
+            if handler is not None:
+                handler(child)
 
-    def visitClassDef(self, node: nodes.ClassDef) -> None:
-        old_classname = self.classname
-        self.classname += node.name + "."
-        self.default(node)
-        self.classname = old_classname
+    def _append_node(self) -> int:
+        """Create a new graph node, add an edge from tail, update tail."""
+        graph = self._graph
+        assert graph is not None
+        nid = graph.add_node()
+        graph.add_edge()
+        self._tail = nid
+        return nid
 
-    def visitFunctionDef(self, node: nodes.FunctionDef) -> None:
-        if self.graph is not None:
-            # closure
-            self.graph.connect(self.tail, node)
-            self.tail = node
-            for child in node.body:
-                self.dispatch(child)
-            bottom = f"{self._bottom_counter}"
-            self._bottom_counter += 1
-            self.graph.connect(self.tail, bottom)
-            self.graph.connect(node, bottom)
-            self.tail = bottom
-        else:
-            self.graph = PathGraph()
-            self.tail = node
-            for child in node.body:
-                self.dispatch(child)
-            self.graphs[f"{self.classname}{node.name}"] = (self.graph, node)
-            self.graph = None
-            self.tail = None
+    # -- Visitors ------------------------------------------------------------
 
-    visitAsyncFunctionDef = visitFunctionDef
+    def _visit_function(self, node: nodes.FunctionDef) -> None:
+        if self._graph is not None:
+            # Closure: modelled as a decision point (enter body or skip).
+            self._append_node()
+            self._walk_body(node.body)
+            merge = self._graph.add_node()
+            self._graph.add_edge()  # body end → merge
+            self._graph.add_edge()  # pathnode → merge (skip edge)
+            self._tail = merge
+            return
+        # Top-level function/method: start a new graph.
+        graph = PathGraph()
+        self._graph = graph
+        self.graphs[id(node)] = (graph, node)
+        self._tail = graph.add_node()
+        self._walk_body(node.body)
+        self._graph = None
+        self._tail = -1
 
-    def visitAssert(self, node: nodes.NodeNG) -> None:
-        if self.tail and self.graph:
-            self.graph.connect(self.tail, node)
-            self.tail = node
+    def _visit_classdef(self, node: nodes.ClassDef) -> None:
+        # Don't reset the graph: in the original mccabe, a class body is walked
+        # with the enclosing graph still set. Methods inside a nested class
+        # (within a function) are thus treated as closures of the enclosing
+        # function, adding +1 each. At module level, graph is already None.
+        self._walk_body(node.body)
 
-    visitAssign = visitAugAssign = visitDelete = visitRaise = visitYield = (
-        visitImport
-    ) = visitCall = visitSubscript = visitPass = visitContinue = visitBreak = (
-        visitGlobal
-    ) = visitReturn = visitExpr = visitAwait = visitAssert
+    def _visit_branching(self, node: nodes.NodeNG) -> None:
+        """Handle if / for / while — same subgraph logic, no extra blocks."""
+        self._subgraph(node)
 
-    def visitWith(self, node: nodes.With) -> None:
-        if self.tail and self.graph:
-            self.graph.connect(self.tail, node)
-            self.tail = node
-        for child in node.body:
-            self.dispatch(child)
-
-    visitAsyncWith = visitWith
-
-    def visitFor(self, node: nodes.For | nodes.While) -> None:
-        self._subgraph(node, node.handlers if isinstance(node, nodes.Try) else [])
-
-    visitAsyncFor = visitWhile = visitIf = visitFor
-
-    def visitTry(self, node: nodes.Try) -> None:
-        self._subgraph(node, node.handlers)
-
-    def visitMatch(self, node: nodes.Match) -> None:
-        self._subgraph(node, node.cases)
-
-    def _append_node(self, node: _AppendableNodeT) -> _AppendableNodeT | None:
-        if not (self.tail and self.graph):
-            return None
-        self.graph.connect(self.tail, node)
-        self.tail = node
-        return node
+    def _visit_try(self, node: nodes.Try) -> None:
+        """Handle try/except — except handlers are extra branching blocks."""
+        self._subgraph(node, extra_blocks=node.handlers)
 
     def _subgraph(
-        self, node: nodes.NodeNG, extra_blocks: list[nodes.NodeNG] | None = None
+        self,
+        node: nodes.NodeNG,
+        extra_blocks: tuple[()] | list[nodes.NodeNG] = (),
     ) -> None:
-        if extra_blocks is None:
-            extra_blocks = []
-        if self.graph is None:
-            self.graph = PathGraph()
-            self._parse(node, extra_blocks)
-            self.graphs[f"loop_{id(node)}"] = (self.graph, node)
-            self.graph = None
-            self.tail = None
+        if self._graph is None:
+            # Top-level construct (module-level if/for/try): own graph.
+            graph = PathGraph()
+            self._graph = graph
+            self.graphs[id(node)] = (graph, node)
+            pathnode = graph.add_node()
+            self._tail = pathnode
+            self._subgraph_parse(node, pathnode, extra_blocks)
+            self._graph = None
+            self._tail = -1
         else:
-            if self.tail:
-                self.graph.connect(self.tail, node)
-                self.tail = node
-            self._parse(node, extra_blocks)
+            pathnode = self._append_node()
+            self._subgraph_parse(node, pathnode, extra_blocks)
 
-    def _parse(self, node: nodes.NodeNG, extra_blocks: list[nodes.NodeNG]) -> None:
-        loose_ends = []
-        if isinstance(node, nodes.Match):
-            for case in extra_blocks:
-                if isinstance(case, nodes.MatchCase):
-                    self.tail = node
-                    for child in case.body:
-                        self.dispatch(child)
-                    loose_ends.append(self.tail)
-            loose_ends.append(node)
+    def _subgraph_parse(
+        self,
+        node: nodes.NodeNG,
+        pathnode: int,
+        extra_blocks: tuple[()] | list[nodes.NodeNG],
+    ) -> None:
+        """Build the branching subgraph: body, extra blocks, orelse, merge."""
+        graph = self._graph
+        assert graph is not None
+        num_loose_ends = 0
+
+        # Main body
+        self._tail = pathnode
+        self._walk_body(node.body)
+        num_loose_ends += 1
+
+        # Extra blocks (except handlers for try)
+        for extra in extra_blocks:
+            self._tail = pathnode
+            self._walk_body(extra.body)
+            num_loose_ends += 1
+
+        # Else branch
+        if node.orelse:
+            self._tail = pathnode
+            self._walk_body(node.orelse)
+            num_loose_ends += 1
         else:
-            self.tail = node
-            for child in node.body:
-                self.dispatch(child)
-            loose_ends.append(self.tail)
-            for extra in extra_blocks:
-                self.tail = node
-                for child in extra.body:
-                    self.dispatch(child)
-                loose_ends.append(self.tail)
-            if hasattr(node, "orelse") and node.orelse:
-                self.tail = node
-                for child in node.orelse:
-                    self.dispatch(child)
-                loose_ends.append(self.tail)
-            else:
-                loose_ends.append(node)
+            # No else: the pathnode itself is a loose end (fall-through path).
+            num_loose_ends += 1
 
-        if self.graph:
-            bottom = f"{self._bottom_counter}"
-            self._bottom_counter += 1
-            for end in loose_ends:
-                self.graph.connect(end, bottom)
-            self.tail = bottom
+        # Merge all loose ends into a single bottom node.
+        merge = graph.add_node()
+        for _ in range(num_loose_ends):
+            graph.add_edge()
+        self._tail = merge
+
+    def _visit_with(self, node: nodes.With) -> None:
+        self._walk_body(node.body)
+
+    def _visit_match(self, node: nodes.Match) -> None:
+        is_toplevel = self._graph is None
+        if is_toplevel:
+            # Module-level match: own graph.
+            graph = PathGraph()
+            self._graph = graph
+            self.graphs[id(node)] = (graph, node)
+            pathnode = graph.add_node()
+        else:
+            graph = self._graph
+            pathnode = self._append_node()
+        num_cases = 0
+        for case in node.cases:
+            self._tail = pathnode
+            self._walk_body(case.body)
+            num_cases += 1
+        merge = graph.add_node()
+        for _ in range(num_cases):
+            graph.add_edge()
+        self._tail = merge
+        if is_toplevel:
+            self._graph = None
+            self._tail = -1
 
 
 class McCabeMethodChecker(checkers.BaseChecker):
@@ -223,12 +251,12 @@ class McCabeMethodChecker(checkers.BaseChecker):
             visitor.dispatch(child)
         for graph, checked_node in visitor.graphs.values():
             complexity = graph.complexity()
+            if complexity <= self.linter.config.max_complexity:
+                continue
             if hasattr(checked_node, "name"):
                 node_name = f"'{checked_node.name}'"
             else:
                 node_name = f"This '{checked_node.__class__.__name__.lower()}'"
-            if complexity <= self.linter.config.max_complexity:
-                continue
             self.add_message(
                 "too-complex",
                 node=checked_node,

--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -16,32 +16,6 @@ if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
 
-class PathGraph:
-    """Track control flow edges and nodes for McCabe complexity (E - N + 2).
-
-    Instead of storing actual graph structure, we only need the counts:
-    the complexity formula V = E - N + 2 depends only on the number of
-    edges and nodes, not their identity.
-    """
-
-    __slots__ = ("_num_edges", "_num_nodes")
-
-    def __init__(self) -> None:
-        self._num_nodes = 0
-        self._num_edges = 0
-
-    def add_node(self) -> int:
-        nid = self._num_nodes
-        self._num_nodes += 1
-        return nid
-
-    def add_edge(self) -> None:
-        self._num_edges += 1
-
-    def complexity(self) -> int:
-        return self._num_edges - self._num_nodes + 2
-
-
 class PathGraphingAstVisitor:
     """Compute McCabe cyclomatic complexity via control flow graph on astroid AST.
 
@@ -52,166 +26,210 @@ class PathGraphingAstVisitor:
     Reproduces the same complexity scores as the ``mccabe`` library, but operates
     directly on astroid trees (no re-parsing) and uses a dict-based dispatch table
     instead of getattr, skipping expression subtrees entirely.
+
+    Edge and node counts are kept as visitor instance variables to avoid per-
+    increment method-call overhead (~1 M calls eliminated on ansible).
     """
 
-    def __init__(self) -> None:
-        self.graphs: dict[int, tuple[PathGraph, nodes.NodeNG]] = {}
-        self._graph: PathGraph | None = None
-        self._tail: int = -1
-        self._visitors: dict[type, Any] = {
-            nodes.FunctionDef: self._visit_function,
-            nodes.AsyncFunctionDef: self._visit_function,
-            nodes.ClassDef: self._visit_classdef,
-            nodes.If: self._visit_branching,
-            nodes.For: self._visit_branching,
-            nodes.AsyncFor: self._visit_branching,
-            nodes.While: self._visit_branching,
-            nodes.Try: self._visit_try,
-            nodes.TryStar: self._visit_try,
-            nodes.With: self._visit_with,
-            nodes.AsyncWith: self._visit_with,
-            nodes.Match: self._visit_match,
-        }
+    __slots__ = ("_active", "_num_edges", "_num_nodes", "_tail", "graphs")
 
-    def dispatch(self, node: nodes.NodeNG) -> None:
-        handler = self._visitors.get(type(node))
-        if handler is not None:
-            handler(node)
+    # Dispatch table mapping node types to unbound visitor methods.
+    # Created once at class level to avoid rebuilding per instance.
+    _VISITORS: dict[type, Any] = {}
+
+    def __init__(self) -> None:
+        # Maps each scope node to its computed complexity (int).
+        self.graphs: dict[nodes.NodeNG, int] = {}
+        # Graph counters - modified in-place, snapshotted when a scope closes.
+        self._num_nodes = 0
+        self._num_edges = 0
+        self._active = False  # True while inside a graph scope
+        self._tail = 0
 
     def _walk_body(self, body: list[nodes.NodeNG]) -> None:
-        visitors = self._visitors
+        visitors = _VISITORS
         for child in body:
             handler = visitors.get(type(child))
             if handler is not None:
-                handler(child)
-
-    def _append_node(self) -> int:
-        """Create a new graph node, add an edge from tail, update tail."""
-        graph = self._graph
-        assert graph is not None
-        nid = graph.add_node()
-        graph.add_edge()
-        self._tail = nid
-        return nid
+                handler(self, child)
 
     # -- Visitors ------------------------------------------------------------
 
     def _visit_function(self, node: nodes.FunctionDef) -> None:
-        if self._graph is not None:
+        if self._active:
             # Closure: modelled as a decision point (enter body or skip).
-            self._append_node()
+            n = self._num_nodes
+            self._num_nodes = n + 1
+            self._num_edges += 1
+            self._tail = n
             self._walk_body(node.body)
-            merge = self._graph.add_node()
-            self._graph.add_edge()  # body end → merge
-            self._graph.add_edge()  # pathnode → merge (skip edge)
+            # Merge node: body-end -> merge + pathnode -> merge (skip edge).
+            merge = n + 1 if self._num_nodes == n + 1 else self._num_nodes
+            self._num_nodes = merge + 1
+            self._num_edges += 2
             self._tail = merge
             return
-        # Top-level function/method: start a new graph.
-        graph = PathGraph()
-        self._graph = graph
-        self.graphs[id(node)] = (graph, node)
-        self._tail = graph.add_node()
+        # Top-level function/method: save state, start fresh graph.
+        old_n, old_e, old_tail = self._num_nodes, self._num_edges, self._tail
+        self._num_nodes = 1  # entry node (id 0)
+        self._num_edges = 0
+        self._active = True
+        self._tail = 0
         self._walk_body(node.body)
-        self._graph = None
-        self._tail = -1
+        self.graphs[node] = self._num_edges - self._num_nodes + 2
+        self._num_nodes, self._num_edges, self._tail = old_n, old_e, old_tail
+        self._active = False
 
-    def _visit_classdef(self, node: nodes.ClassDef) -> None:
-        # Don't reset the graph: in the original mccabe, a class body is walked
-        # with the enclosing graph still set. Methods inside a nested class
-        # (within a function) are thus treated as closures of the enclosing
-        # function, adding +1 each. At module level, graph is already None.
+    def _visit_body(self, node: nodes.NodeNG) -> None:
+        # ClassDef and With both just recurse into the body.
+        # ClassDef: don't reset the graph -- methods inside a nested class
+        # (within a function) are treated as closures of the enclosing function.
+        # With: no complexity added, but body may contain compound statements.
         self._walk_body(node.body)
 
-    def _visit_branching(self, node: nodes.NodeNG) -> None:
-        """Handle if / for / while — same subgraph logic, no extra blocks."""
-        self._subgraph(node)
-
-    def _visit_try(self, node: nodes.Try) -> None:
-        """Handle try/except — except handlers are extra branching blocks."""
-        self._subgraph(node, extra_blocks=node.handlers)
-
-    def _subgraph(
-        self,
-        node: nodes.NodeNG,
-        extra_blocks: tuple[()] | list[nodes.NodeNG] = (),
-    ) -> None:
-        if self._graph is None:
-            # Top-level construct (module-level if/for/try): own graph.
-            graph = PathGraph()
-            self._graph = graph
-            self.graphs[id(node)] = (graph, node)
-            pathnode = graph.add_node()
-            self._tail = pathnode
-            self._subgraph_parse(node, pathnode, extra_blocks)
-            self._graph = None
-            self._tail = -1
+    def _visit_subgraph(self, node: nodes.NodeNG) -> None:
+        """Handle if / for / while as branching subgraphs."""
+        is_toplevel = not self._active
+        if is_toplevel:
+            old_n, old_e, old_tail = (
+                self._num_nodes,
+                self._num_edges,
+                self._tail,
+            )
+            self._num_nodes = 1  # pathnode (id 0)
+            self._num_edges = 0
+            self._active = True
+            pathnode = 0
         else:
-            pathnode = self._append_node()
-            self._subgraph_parse(node, pathnode, extra_blocks)
+            pathnode = self._num_nodes
+            self._num_nodes = pathnode + 1
+            self._num_edges += 1
 
-    def _subgraph_parse(
-        self,
-        node: nodes.NodeNG,
-        pathnode: int,
-        extra_blocks: tuple[()] | list[nodes.NodeNG],
-    ) -> None:
-        """Build the branching subgraph: body, extra blocks, orelse, merge."""
-        graph = self._graph
-        assert graph is not None
-        num_loose_ends = 0
-
-        # Main body
+        # -- inlined subgraph parse (no extra_blocks for if/for/while) --
+        walk = self._walk_body
         self._tail = pathnode
-        self._walk_body(node.body)
-        num_loose_ends += 1
-
-        # Extra blocks (except handlers for try)
-        for extra in extra_blocks:
-            self._tail = pathnode
-            self._walk_body(extra.body)
-            num_loose_ends += 1
-
-        # Else branch
+        walk(node.body)
         if node.orelse:
             self._tail = pathnode
-            self._walk_body(node.orelse)
-            num_loose_ends += 1
-        else:
-            # No else: the pathnode itself is a loose end (fall-through path).
-            num_loose_ends += 1
-
-        # Merge all loose ends into a single bottom node.
-        merge = graph.add_node()
-        for _ in range(num_loose_ends):
-            graph.add_edge()
+            walk(node.orelse)
+        # Always 2 loose ends: body + (orelse or fall-through pathnode).
+        merge = self._num_nodes
+        self._num_nodes = merge + 1
+        self._num_edges += 2
         self._tail = merge
 
-    def _visit_with(self, node: nodes.With) -> None:
-        self._walk_body(node.body)
+        if is_toplevel:
+            self.graphs[node] = self._num_edges - self._num_nodes + 2
+            self._num_nodes, self._num_edges, self._tail = (
+                old_n,
+                old_e,
+                old_tail,
+            )
+            self._active = False
+
+    def _visit_try(self, node: nodes.Try) -> None:
+        """Handle try/except as branching subgraphs with except handlers."""
+        is_toplevel = not self._active
+        if is_toplevel:
+            old_n, old_e, old_tail = (
+                self._num_nodes,
+                self._num_edges,
+                self._tail,
+            )
+            self._num_nodes = 1
+            self._num_edges = 0
+            self._active = True
+            pathnode = 0
+        else:
+            pathnode = self._num_nodes
+            self._num_nodes = pathnode + 1
+            self._num_edges += 1
+
+        # -- inlined subgraph parse with extra_blocks = node.handlers --
+        walk = self._walk_body
+        num_loose_ends = 1  # main body
+        self._tail = pathnode
+        walk(node.body)
+        for handler in node.handlers:
+            self._tail = pathnode
+            walk(handler.body)
+            num_loose_ends += 1
+        if node.orelse:
+            self._tail = pathnode
+            walk(node.orelse)
+            num_loose_ends += 1
+        else:
+            num_loose_ends += 1  # fall-through
+        merge = self._num_nodes
+        self._num_nodes = merge + 1
+        self._num_edges += num_loose_ends
+        self._tail = merge
+
+        if is_toplevel:
+            self.graphs[node] = self._num_edges - self._num_nodes + 2
+            self._num_nodes, self._num_edges, self._tail = (
+                old_n,
+                old_e,
+                old_tail,
+            )
+            self._active = False
 
     def _visit_match(self, node: nodes.Match) -> None:
-        is_toplevel = self._graph is None
+        is_toplevel = not self._active
         if is_toplevel:
-            # Module-level match: own graph.
-            graph = PathGraph()
-            self._graph = graph
-            self.graphs[id(node)] = (graph, node)
-            pathnode = graph.add_node()
+            old_n, old_e, old_tail = (
+                self._num_nodes,
+                self._num_edges,
+                self._tail,
+            )
+            self._num_nodes = 1
+            self._num_edges = 0
+            self._active = True
+            pathnode = 0
         else:
-            graph = self._graph
-            pathnode = self._append_node()
+            pathnode = self._num_nodes
+            self._num_nodes = pathnode + 1
+            self._num_edges += 1
+
+        self._tail = pathnode
+        walk = self._walk_body
         num_cases = 0
         for case in node.cases:
             self._tail = pathnode
-            self._walk_body(case.body)
+            walk(case.body)
             num_cases += 1
-        merge = graph.add_node()
-        for _ in range(num_cases):
-            graph.add_edge()
+        merge = self._num_nodes
+        self._num_nodes = merge + 1
+        self._num_edges += num_cases
         self._tail = merge
+
         if is_toplevel:
-            self._graph = None
-            self._tail = -1
+            self.graphs[node] = self._num_edges - self._num_nodes + 2
+            self._num_nodes, self._num_edges, self._tail = (
+                old_n,
+                old_e,
+                old_tail,
+            )
+            self._active = False
+
+
+# Module-level dispatch table - built once, shared by all visitor instances.
+# Uses unbound methods; callers pass ``self`` explicitly.
+_VISITORS: dict[type, Any] = {
+    nodes.FunctionDef: PathGraphingAstVisitor._visit_function,
+    nodes.AsyncFunctionDef: PathGraphingAstVisitor._visit_function,
+    nodes.ClassDef: PathGraphingAstVisitor._visit_body,
+    nodes.If: PathGraphingAstVisitor._visit_subgraph,
+    nodes.For: PathGraphingAstVisitor._visit_subgraph,
+    nodes.AsyncFor: PathGraphingAstVisitor._visit_subgraph,
+    nodes.While: PathGraphingAstVisitor._visit_subgraph,
+    nodes.Try: PathGraphingAstVisitor._visit_try,
+    nodes.TryStar: PathGraphingAstVisitor._visit_try,
+    nodes.With: PathGraphingAstVisitor._visit_body,
+    nodes.AsyncWith: PathGraphingAstVisitor._visit_body,
+    nodes.Match: PathGraphingAstVisitor._visit_match,
+}
+PathGraphingAstVisitor._VISITORS = _VISITORS
 
 
 class McCabeMethodChecker(checkers.BaseChecker):
@@ -247,11 +265,10 @@ class McCabeMethodChecker(checkers.BaseChecker):
         add message if is greater than max_complexity stored from options.
         """
         visitor = PathGraphingAstVisitor()
-        for child in node.body:
-            visitor.dispatch(child)
-        for graph, checked_node in visitor.graphs.values():
-            complexity = graph.complexity()
-            if complexity <= self.linter.config.max_complexity:
+        visitor._walk_body(node.body)
+        max_complexity = self.linter.config.max_complexity
+        for checked_node, complexity in visitor.graphs.items():
+            if complexity <= max_complexity:
                 continue
             if hasattr(checked_node, "name"):
                 node_name = f"'{checked_node.name}'"

--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -2,16 +2,19 @@
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
-"""Module to add McCabe checker class for pylint."""
+"""Module to add McCabe checker class for pylint.
+
+Based on:
+http://nedbatchelder.com/blog/200803/python_code_complexity_microtool.html
+Later integrated in pycqa/mccabe under the MIT License then vendored in pylint
+under the GPL License.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from astroid import nodes
-from mccabe import PathGraph as Mccabe_PathGraph
-from mccabe import PathGraphingAstVisitor as Mccabe_PathGraphingAstVisitor
 
 from pylint import checkers
 from pylint.checkers.utils import only_required_for_messages
@@ -20,94 +23,108 @@ from pylint.interfaces import HIGH
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
-_StatementNodes: TypeAlias = (
-    nodes.Assert
-    | nodes.Assign
-    | nodes.AugAssign
-    | nodes.Delete
-    | nodes.Raise
-    | nodes.Yield
-    | nodes.Import
-    | nodes.Call
-    | nodes.Subscript
-    | nodes.Pass
-    | nodes.Continue
-    | nodes.Break
-    | nodes.Global
-    | nodes.Return
-    | nodes.Expr
-    | nodes.Await
-)
 
-_SubGraphNodes: TypeAlias = nodes.If | nodes.Try | nodes.For | nodes.While | nodes.Match
-_AppendableNodeT = TypeVar(
-    "_AppendableNodeT", bound=_StatementNodes | nodes.While | nodes.FunctionDef
-)
-
-
-class PathGraph(Mccabe_PathGraph):  # type: ignore[misc]
-    def __init__(self, node: _SubGraphNodes | nodes.FunctionDef):
-        super().__init__(name="", entity="", lineno=1)
-        self.root = node
-
-
-class PathGraphingAstVisitor(Mccabe_PathGraphingAstVisitor):  # type: ignore[misc]
+class PathGraph:
     def __init__(self) -> None:
-        super().__init__()
+        self.nodes: dict[Any, list[Any]] = {}
+
+    def connect(self, n1: Any, n2: Any) -> None:
+        if n1 not in self.nodes:
+            self.nodes[n1] = []
+        self.nodes[n1].append(n2)
+        # Ensure that the destination node is always counted.
+        if n2 not in self.nodes:
+            self.nodes[n2] = []
+
+    def complexity(self) -> int:
+        """Return the McCabe complexity for the graph.
+
+        V-E+2
+        """
+        num_edges = sum(len(n) for n in self.nodes.values())
+        num_nodes = len(self.nodes)
+        return num_edges - num_nodes + 2
+
+
+class PathGraphingAstVisitor:
+    """A visitor for a parsed Abstract Syntax Tree which finds executable
+    statements.
+    """
+
+    def __init__(self) -> None:
+        self.classname = ""
+        self.graphs: dict[str, tuple[PathGraph, nodes.NodeNG]] = {}
         self._bottom_counter = 0
         self.graph: PathGraph | None = None
+        self.tail: Any = None
 
-    def default(self, node: nodes.NodeNG, *args: Any) -> None:
+    def dispatch(self, node: nodes.NodeNG) -> None:
+        meth = getattr(self, "visit" + node.__class__.__name__, self.default)
+        meth(node)
+
+    def default(self, node: nodes.NodeNG) -> None:
         for child in node.get_children():
-            self.dispatch(child, *args)
+            self.dispatch(child)
 
-    def dispatch(self, node: nodes.NodeNG, *args: Any) -> Any:
-        self.node = node
-        klass = node.__class__
-        meth = self._cache.get(klass)
-        if meth is None:
-            class_name = klass.__name__
-            meth = getattr(self.visitor, "visit" + class_name, self.default)
-            self._cache[klass] = meth
-        return meth(node, *args)
+    def visitClassDef(self, node: nodes.ClassDef) -> None:
+        old_classname = self.classname
+        self.classname += node.name + "."
+        self.default(node)
+        self.classname = old_classname
 
     def visitFunctionDef(self, node: nodes.FunctionDef) -> None:
         if self.graph is not None:
             # closure
-            pathnode = self._append_node(node)
-            self.tail = pathnode
-            self.dispatch_list(node.body)
+            self.graph.connect(self.tail, node)
+            self.tail = node
+            for child in node.body:
+                self.dispatch(child)
             bottom = f"{self._bottom_counter}"
             self._bottom_counter += 1
             self.graph.connect(self.tail, bottom)
             self.graph.connect(node, bottom)
             self.tail = bottom
         else:
-            self.graph = PathGraph(node)
+            self.graph = PathGraph()
             self.tail = node
-            self.dispatch_list(node.body)
-            self.graphs[f"{self.classname}{node.name}"] = self.graph
-            self.reset()
+            for child in node.body:
+                self.dispatch(child)
+            self.graphs[f"{self.classname}{node.name}"] = (self.graph, node)
+            self.graph = None
+            self.tail = None
 
     visitAsyncFunctionDef = visitFunctionDef
 
-    def visitSimpleStatement(self, node: _StatementNodes) -> None:
-        self._append_node(node)
+    def visitAssert(self, node: nodes.NodeNG) -> None:
+        if self.tail and self.graph:
+            self.graph.connect(self.tail, node)
+            self.tail = node
 
-    visitAssert = visitAssign = visitAugAssign = visitDelete = visitRaise = (
-        visitYield
-    ) = visitImport = visitCall = visitSubscript = visitPass = visitContinue = (
-        visitBreak
-    ) = visitGlobal = visitReturn = visitExpr = visitAwait = visitSimpleStatement
+    visitAssign = visitAugAssign = visitDelete = visitRaise = visitYield = (
+        visitImport
+    ) = visitCall = visitSubscript = visitPass = visitContinue = visitBreak = (
+        visitGlobal
+    ) = visitReturn = visitExpr = visitAwait = visitAssert
 
     def visitWith(self, node: nodes.With) -> None:
-        self._append_node(node)
-        self.dispatch_list(node.body)
+        if self.tail and self.graph:
+            self.graph.connect(self.tail, node)
+            self.tail = node
+        for child in node.body:
+            self.dispatch(child)
 
     visitAsyncWith = visitWith
 
+    def visitFor(self, node: nodes.For | nodes.While) -> None:
+        self._subgraph(node, node.handlers if isinstance(node, nodes.Try) else [])
+
+    visitAsyncFor = visitWhile = visitIf = visitFor
+
+    def visitTry(self, node: nodes.Try) -> None:
+        self._subgraph(node, node.handlers)
+
     def visitMatch(self, node: nodes.Match) -> None:
-        self._subgraph(node, f"match_{id(node)}", node.cases)
+        self._subgraph(node, node.cases)
 
     def _append_node(self, node: _AppendableNodeT) -> _AppendableNodeT | None:
         if not (self.tail and self.graph):
@@ -117,55 +134,51 @@ class PathGraphingAstVisitor(Mccabe_PathGraphingAstVisitor):  # type: ignore[mis
         return node
 
     def _subgraph(
-        self,
-        node: _SubGraphNodes,
-        name: str,
-        extra_blocks: Sequence[nodes.ExceptHandler | nodes.MatchCase] = (),
+        self, node: nodes.NodeNG, extra_blocks: list[nodes.NodeNG] | None = None
     ) -> None:
-        """Create the subgraphs representing any `if`, `for` or `match` statements."""
+        if extra_blocks is None:
+            extra_blocks = []
         if self.graph is None:
-            # global loop
-            self.graph = PathGraph(node)
-            self._subgraph_parse(node, node, extra_blocks)
-            self.graphs[f"{self.classname}{name}"] = self.graph
-            self.reset()
+            self.graph = PathGraph()
+            self._parse(node, extra_blocks)
+            self.graphs[f"loop_{id(node)}"] = (self.graph, node)
+            self.graph = None
+            self.tail = None
         else:
-            self._append_node(node)
-            self._subgraph_parse(node, node, extra_blocks)
+            if self.tail:
+                self.graph.connect(self.tail, node)
+                self.tail = node
+            self._parse(node, extra_blocks)
 
-    def _subgraph_parse(
-        self,
-        node: _SubGraphNodes,
-        pathnode: _SubGraphNodes,
-        extra_blocks: Sequence[nodes.ExceptHandler | nodes.MatchCase],
-    ) -> None:
-        """Parse `match`/`case` blocks, or the body and `else` block of `if`/`for`
-        statements.
-        """
+    def _parse(self, node: nodes.NodeNG, extra_blocks: list[nodes.NodeNG]) -> None:
         loose_ends = []
         if isinstance(node, nodes.Match):
             for case in extra_blocks:
                 if isinstance(case, nodes.MatchCase):
                     self.tail = node
-                    self.dispatch_list(case.body)
+                    for child in case.body:
+                        self.dispatch(child)
                     loose_ends.append(self.tail)
             loose_ends.append(node)
         else:
             self.tail = node
-            self.dispatch_list(node.body)
+            for child in node.body:
+                self.dispatch(child)
             loose_ends.append(self.tail)
             for extra in extra_blocks:
                 self.tail = node
-                self.dispatch_list(extra.body)
+                for child in extra.body:
+                    self.dispatch(child)
                 loose_ends.append(self.tail)
-            if node.orelse:
+            if hasattr(node, "orelse") and node.orelse:
                 self.tail = node
-                self.dispatch_list(node.orelse)
+                for child in node.orelse:
+                    self.dispatch(child)
                 loose_ends.append(self.tail)
             else:
                 loose_ends.append(node)
 
-        if node and self.graph:
+        if self.graph:
             bottom = f"{self._bottom_counter}"
             self._bottom_counter += 1
             for end in loose_ends:
@@ -207,18 +220,20 @@ class McCabeMethodChecker(checkers.BaseChecker):
         """
         visitor = PathGraphingAstVisitor()
         for child in node.body:
-            visitor.preorder(child, visitor)
-        for graph in visitor.graphs.values():
+            visitor.dispatch(child)
+        for graph, checked_node in visitor.graphs.values():
             complexity = graph.complexity()
-            node = graph.root
-            if hasattr(node, "name"):
-                node_name = f"'{node.name}'"
+            if hasattr(checked_node, "name"):
+                node_name = f"'{checked_node.name}'"
             else:
-                node_name = f"This '{node.__class__.__name__.lower()}'"
+                node_name = f"This '{checked_node.__class__.__name__.lower()}'"
             if complexity <= self.linter.config.max_complexity:
                 continue
             self.add_message(
-                "too-complex", node=node, confidence=HIGH, args=(node_name, complexity)
+                "too-complex",
+                node=checked_node,
+                confidence=HIGH,
+                args=(node_name, complexity),
             )
 
 

--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -16,6 +16,20 @@ if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
 
+def _is_irrefutable(pattern: nodes.Pattern) -> bool:
+    """Return True if the pattern always matches (wildcard or capture name).
+
+    Mirrors the grammar: an as-pattern is irrefutable if it has no
+    sub-pattern (wildcard ``_`` or bare capture name) or its sub-pattern is
+    irrefutable; an or-pattern is irrefutable if its last alternative is.
+    """
+    if isinstance(pattern, nodes.MatchAs):
+        return pattern.pattern is None or _is_irrefutable(pattern.pattern)
+    if isinstance(pattern, nodes.MatchOr):
+        return _is_irrefutable(pattern.patterns[-1])
+    return False
+
+
 class PathGraphingAstVisitor:
     """Compute McCabe cyclomatic complexity via control flow graph on astroid AST.
 
@@ -26,6 +40,20 @@ class PathGraphingAstVisitor:
     Reproduces the same complexity scores as the ``mccabe`` library, but
     operates directly on astroid trees (no re-parsing) and uses a dict-based
     dispatch table instead of getattr, skipping expression sub-trees entirely.
+
+    Intentional divergences from the previous ``mccabe``-based checker:
+
+    - Results are keyed by node instead of by name, so same-named siblings
+      (e.g. property getter/setter/deleter) no longer overwrite each other
+      and are all reported (the old checker only kept the last one).
+    - An exhaustive ``match`` (last case is an unguarded wildcard or capture
+      name) no longer counts a fall-through path, mirroring how ``else``
+      is counted for ``if``/``elif`` chains.
+    - Straight-line functions are always rated 1: the old checker rated
+      functions whose body holds no statement it tracked (docstring only,
+      annotated assignments only, ...) at 2 because their graph stayed empty.
+    - ``try``/``except*`` counts like ``try``/``except``; the ``mccabe``
+      library predates ``except*`` and ignored it.
 
     Edge and node counts are kept as visitor instance variables to avoid
     per-increment method-call overhead (~1 M calls eliminated on
@@ -194,14 +222,19 @@ class PathGraphingAstVisitor:
 
         self._tail = pathnode
         walk = self._walk_body
-        num_cases = 0
+        num_loose_ends = 0
         for case in node.cases:
             self._tail = pathnode
             walk(case.body)
-            num_cases += 1
+            num_loose_ends += 1
+        last_case = node.cases[-1]
+        if last_case.guard is not None or not _is_irrefutable(last_case.pattern):
+            # Non-exhaustive match: no case may apply, count the
+            # fall-through path (equivalent to an if/elif without else).
+            num_loose_ends += 1
         merge = self._num_nodes
         self._num_nodes = merge + 1
-        self._num_edges += num_cases
+        self._num_edges += num_loose_ends
         self._tail = merge
 
         if is_toplevel:

--- a/pylint/extensions/mccabe.py
+++ b/pylint/extensions/mccabe.py
@@ -20,15 +20,16 @@ class PathGraphingAstVisitor:
     """Compute McCabe cyclomatic complexity via control flow graph on astroid AST.
 
     Builds a simplified CFG tracking only compound statements (if, for, while,
-    try, with, match, function/class defs).  Simple statements are omitted since
-    collapsing a linear chain of nodes does not change E - N + 2.
+    try, with, match, function/class definitions).  Simple statements are
+    omitted since collapsing a linear chain of nodes does not change E - N + 2.
 
-    Reproduces the same complexity scores as the ``mccabe`` library, but operates
-    directly on astroid trees (no re-parsing) and uses a dict-based dispatch table
-    instead of getattr, skipping expression subtrees entirely.
+    Reproduces the same complexity scores as the ``mccabe`` library, but
+    operates directly on astroid trees (no re-parsing) and uses a dict-based
+    dispatch table instead of getattr, skipping expression sub-trees entirely.
 
-    Edge and node counts are kept as visitor instance variables to avoid per-
-    increment method-call overhead (~1 M calls eliminated on ansible).
+    Edge and node counts are kept as visitor instance variables to avoid
+    per-increment method-call overhead (~1 M calls eliminated on
+    repositories with ~2000 files).
     """
 
     __slots__ = ("_active", "_num_edges", "_num_nodes", "_tail", "graphs")
@@ -40,7 +41,7 @@ class PathGraphingAstVisitor:
     def __init__(self) -> None:
         # Maps each scope node to its computed complexity (int).
         self.graphs: dict[nodes.NodeNG, int] = {}
-        # Graph counters - modified in-place, snapshotted when a scope closes.
+        # Graph counters - modified in-place, saved when a scope closes.
         self._num_nodes = 0
         self._num_edges = 0
         self._active = False  # True while inside a graph scope
@@ -57,13 +58,13 @@ class PathGraphingAstVisitor:
 
     def _visit_function(self, node: nodes.FunctionDef) -> None:
         if self._active:
-            # Closure: modelled as a decision point (enter body or skip).
+            # Closure: modeled as a decision point (enter body or skip).
             n = self._num_nodes
             self._num_nodes = n + 1
             self._num_edges += 1
             self._tail = n
             self._walk_body(node.body)
-            # Merge node: body-end -> merge + pathnode -> merge (skip edge).
+            # Merge node: body-end -> merge + path-node -> merge (skip edge).
             merge = n + 1 if self._num_nodes == n + 1 else self._num_nodes
             self._num_nodes = merge + 1
             self._num_edges += 2
@@ -96,7 +97,7 @@ class PathGraphingAstVisitor:
                 self._num_edges,
                 self._tail,
             )
-            self._num_nodes = 1  # pathnode (id 0)
+            self._num_nodes = 1  # path-node (id 0)
             self._num_edges = 0
             self._active = True
             pathnode = 0
@@ -105,14 +106,14 @@ class PathGraphingAstVisitor:
             self._num_nodes = pathnode + 1
             self._num_edges += 1
 
-        # -- inlined subgraph parse (no extra_blocks for if/for/while) --
+        # -- inline sub-graph parse (no extra_blocks for if/for/while) --
         walk = self._walk_body
         self._tail = pathnode
         walk(node.body)
         if node.orelse:
             self._tail = pathnode
             walk(node.orelse)
-        # Always 2 loose ends: body + (orelse or fall-through pathnode).
+        # Always 2 loose ends: body + (orelse or fall-through path-node).
         merge = self._num_nodes
         self._num_nodes = merge + 1
         self._num_edges += 2
@@ -145,7 +146,7 @@ class PathGraphingAstVisitor:
             self._num_nodes = pathnode + 1
             self._num_edges += 1
 
-        # -- inlined subgraph parse with extra_blocks = node.handlers --
+        # -- inline sub-graph parse with extra_blocks = node.handlers --
         walk = self._walk_body
         num_loose_ends = 1  # main body
         self._tail = pathnode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
   "dill>=0.3.6; python_version>='3.11'",
   "dill>=0.3.7; python_version>='3.12'",
   "isort>=5,!=5.13,<9",
-  "mccabe>=0.6,<0.8",
   "platformdirs>=2.2",
   "tomli>=1.1; python_version<'3.11'",
   "tomlkit>=0.10.1",

--- a/tests/functional/ext/mccabe/mccabe.py
+++ b/tests/functional/ext/mccabe/mccabe.py
@@ -306,7 +306,7 @@ def try_finally_with_nested_ifs():  # [too-complex]
 
 
 def match_case(avg):  # [too-complex]
-    """McCabe rating: 4
+    """McCabe rating: 3
     See https://github.com/astral-sh/ruff/issues/11421
     """
     # pylint: disable=bare-name-capture-pattern
@@ -321,7 +321,7 @@ def match_case(avg):  # [too-complex]
 
 
 def nested_match_case(data):  # [too-complex]
-    """McCabe rating: 8
+    """McCabe rating: 6
 
     Nested match statements."""
     match data:
@@ -365,7 +365,7 @@ except TypeB:
 
 
 match avg:  # [too-complex]
-    # McCabe rating: 4
+    # McCabe rating: 3
     # pylint: disable=bare-name-capture-pattern
     case avg if avg < 0.3:
         avg_grade = "F"
@@ -376,9 +376,9 @@ match avg:  # [too-complex]
 
 
 def non_exhaustive_match(value):  # [too-complex]
-    """McCabe rating: 3
+    """McCabe rating: should be 3 but is 2 (known false negative ?)
 
-    No case may apply: the fall-through path counts, as an if/elif would."""
+    No case may apply, but the fall-through path is not counted."""
     match value:
         case 1:
             result = "one"
@@ -388,7 +388,7 @@ def non_exhaustive_match(value):  # [too-complex]
 
 
 def match_capture_name(value):  # [too-complex]
-    """McCabe rating: 3
+    """McCabe rating: 2
 
     An unguarded capture name always matches, no other case is tried."""
     # pylint: disable=bare-name-capture-pattern
@@ -401,9 +401,10 @@ def match_capture_name(value):  # [too-complex]
 
 
 def match_guarded_wildcard(value):  # [too-complex]
-    """McCabe rating: 3
+    """McCabe rating: should be 3 but is 2 (known false negative ?)
 
-    A guarded wildcard can fail to match: the fall-through path counts."""
+    A guarded wildcard can fail to match, but the fall-through path is
+    not counted."""
     match value:
         case 1:
             result = "one"
@@ -413,19 +414,20 @@ def match_guarded_wildcard(value):  # [too-complex]
 
 
 class PropertyAccessors:  # pylint: disable=too-few-public-methods
-    """Only the last definition of a given name is rated: the deleter
-    hides the more complex getter and setter."""
+    """Same-named accessors each get their own score (the mccabe library
+    only kept the last definition of a given name, hiding the getter and
+    setter behind the deleter)."""
 
     @property
-    def attribute(self):
-        """McCabe rating: 2 (not reported: hidden by the deleter)"""
+    def attribute(self):  # [too-complex]
+        """McCabe rating: 2"""
         if self._attribute is None:
             raise ValueError("not set")
         return self._attribute
 
     @attribute.setter
-    def attribute(self, value):
-        """McCabe rating: 3 (not reported: hidden by the deleter)"""
+    def attribute(self, value):  # [too-complex]
+        """McCabe rating: 3"""
         if value is None:
             raise ValueError("cannot unset")
         if not isinstance(value, int):

--- a/tests/functional/ext/mccabe/mccabe.py
+++ b/tests/functional/ext/mccabe/mccabe.py
@@ -350,3 +350,89 @@ def yield_in_for_loop(a=None, b=None, c=None):  # [too-complex]
             yield elt
     if c is not None:
         yield c
+
+
+try:  # [too-complex]
+    # McCabe rating: 5
+    if True:
+        pass
+    else:
+        pass
+except TypeA:
+    pass
+except TypeB:
+    pass
+
+
+match avg:  # [too-complex]
+    # McCabe rating: 4
+    # pylint: disable=bare-name-capture-pattern
+    case avg if avg < 0.3:
+        avg_grade = "F"
+    case avg if avg < 0.7:
+        avg_grade = "E+"
+    case _:
+        avg_grade = "A"
+
+
+def non_exhaustive_match(value):  # [too-complex]
+    """McCabe rating: 3
+
+    No case may apply: the fall-through path counts, as an if/elif would."""
+    match value:
+        case 1:
+            result = "one"
+        case 2:
+            result = "two"
+    return result
+
+
+def match_capture_name(value):  # [too-complex]
+    """McCabe rating: 3
+
+    An unguarded capture name always matches, no other case is tried."""
+    # pylint: disable=bare-name-capture-pattern
+    match value:
+        case 1:
+            result = "one"
+        case something_else:
+            result = str(something_else)
+    return result
+
+
+def match_guarded_wildcard(value):  # [too-complex]
+    """McCabe rating: 3
+
+    A guarded wildcard can fail to match: the fall-through path counts."""
+    match value:
+        case 1:
+            result = "one"
+        case _ if value > 0:
+            result = "positive"
+    return result
+
+
+class PropertyAccessors:  # pylint: disable=too-few-public-methods
+    """Only the last definition of a given name is rated: the deleter
+    hides the more complex getter and setter."""
+
+    @property
+    def attribute(self):
+        """McCabe rating: 2 (not reported: hidden by the deleter)"""
+        if self._attribute is None:
+            raise ValueError("not set")
+        return self._attribute
+
+    @attribute.setter
+    def attribute(self, value):
+        """McCabe rating: 3 (not reported: hidden by the deleter)"""
+        if value is None:
+            raise ValueError("cannot unset")
+        if not isinstance(value, int):
+            value = int(value)
+        self._attribute = value
+
+    @attribute.deleter
+    def attribute(self):  # [too-complex]
+        """McCabe rating: 1"""
+        self._attribute = None

--- a/tests/functional/ext/mccabe/mccabe.py
+++ b/tests/functional/ext/mccabe/mccabe.py
@@ -376,9 +376,9 @@ match avg:  # [too-complex]
 
 
 def non_exhaustive_match(value):  # [too-complex]
-    """McCabe rating: should be 3 but is 2 (known false negative ?)
+    """McCabe rating: 3
 
-    No case may apply, but the fall-through path is not counted."""
+    No case may apply: the fall-through path counts, as an if/elif would."""
     match value:
         case 1:
             result = "one"
@@ -390,7 +390,7 @@ def non_exhaustive_match(value):  # [too-complex]
 def match_capture_name(value):  # [too-complex]
     """McCabe rating: 2
 
-    An unguarded capture name always matches, no other case is tried."""
+    An unguarded capture name is irrefutable, like a wildcard or an else."""
     # pylint: disable=bare-name-capture-pattern
     match value:
         case 1:
@@ -401,10 +401,9 @@ def match_capture_name(value):  # [too-complex]
 
 
 def match_guarded_wildcard(value):  # [too-complex]
-    """McCabe rating: should be 3 but is 2 (known false negative ?)
+    """McCabe rating: 3
 
-    A guarded wildcard can fail to match, but the fall-through path is
-    not counted."""
+    A guarded wildcard can fail to match: the fall-through path counts."""
     match value:
         case 1:
             result = "one"
@@ -414,9 +413,8 @@ def match_guarded_wildcard(value):  # [too-complex]
 
 
 class PropertyAccessors:  # pylint: disable=too-few-public-methods
-    """Same-named accessors each get their own score (the mccabe library
-    only kept the last definition of a given name, hiding the getter and
-    setter behind the deleter)."""
+    """Same-named accessors each get their own score (old checker only kept
+    the last definition of a given name, hiding the getter and setter)."""
 
     @property
     def attribute(self):  # [too-complex]

--- a/tests/functional/ext/mccabe/mccabe.txt
+++ b/tests/functional/ext/mccabe/mccabe.txt
@@ -24,12 +24,14 @@ too-complex:233:4:233:22:ExampleComplexityClass.highly_complex:'highly_complex' 
 too-many-branches:233:4:233:22:ExampleComplexityClass.highly_complex:Too many branches (19/12):UNDEFINED
 too-complex:286:0:293:15::This 'for' is too complex. The McCabe rating is 4:HIGH
 too-complex:296:0:296:31:try_finally_with_nested_ifs:'try_finally_with_nested_ifs' is too complex. The McCabe rating is 3:HIGH
-too-complex:308:0:308:14:match_case:'match_case' is too complex. The McCabe rating is 4:HIGH
-too-complex:323:0:323:21:nested_match_case:'nested_match_case' is too complex. The McCabe rating is 8:HIGH
+too-complex:308:0:308:14:match_case:'match_case' is too complex. The McCabe rating is 3:HIGH
+too-complex:323:0:323:21:nested_match_case:'nested_match_case' is too complex. The McCabe rating is 6:HIGH
 too-complex:345:0:345:21:yield_in_for_loop:'yield_in_for_loop' is too complex. The McCabe rating is 4:HIGH
 too-complex:355:0:364:8::This 'try' is too complex. The McCabe rating is 5:HIGH
-too-complex:367:0:375:23::This 'match' is too complex. The McCabe rating is 4:HIGH
-too-complex:378:0:378:24:non_exhaustive_match:'non_exhaustive_match' is too complex. The McCabe rating is 3:HIGH
-too-complex:390:0:390:22:match_capture_name:'match_capture_name' is too complex. The McCabe rating is 3:HIGH
-too-complex:403:0:403:26:match_guarded_wildcard:'match_guarded_wildcard' is too complex. The McCabe rating is 3:HIGH
-too-complex:436:4:436:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 1:HIGH
+too-complex:367:0:375:23::This 'match' is too complex. The McCabe rating is 3:HIGH
+too-complex:378:0:378:24:non_exhaustive_match:'non_exhaustive_match' is too complex. The McCabe rating is 2:HIGH
+too-complex:390:0:390:22:match_capture_name:'match_capture_name' is too complex. The McCabe rating is 2:HIGH
+too-complex:403:0:403:26:match_guarded_wildcard:'match_guarded_wildcard' is too complex. The McCabe rating is 2:HIGH
+too-complex:422:4:422:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 2:HIGH
+too-complex:429:4:429:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 3:HIGH
+too-complex:438:4:438:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 1:HIGH

--- a/tests/functional/ext/mccabe/mccabe.txt
+++ b/tests/functional/ext/mccabe/mccabe.txt
@@ -29,9 +29,9 @@ too-complex:323:0:323:21:nested_match_case:'nested_match_case' is too complex. T
 too-complex:345:0:345:21:yield_in_for_loop:'yield_in_for_loop' is too complex. The McCabe rating is 4:HIGH
 too-complex:355:0:364:8::This 'try' is too complex. The McCabe rating is 5:HIGH
 too-complex:367:0:375:23::This 'match' is too complex. The McCabe rating is 3:HIGH
-too-complex:378:0:378:24:non_exhaustive_match:'non_exhaustive_match' is too complex. The McCabe rating is 2:HIGH
+too-complex:378:0:378:24:non_exhaustive_match:'non_exhaustive_match' is too complex. The McCabe rating is 3:HIGH
 too-complex:390:0:390:22:match_capture_name:'match_capture_name' is too complex. The McCabe rating is 2:HIGH
-too-complex:403:0:403:26:match_guarded_wildcard:'match_guarded_wildcard' is too complex. The McCabe rating is 2:HIGH
-too-complex:422:4:422:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 2:HIGH
-too-complex:429:4:429:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 3:HIGH
-too-complex:438:4:438:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 1:HIGH
+too-complex:403:0:403:26:match_guarded_wildcard:'match_guarded_wildcard' is too complex. The McCabe rating is 3:HIGH
+too-complex:420:4:420:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 2:HIGH
+too-complex:427:4:427:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 3:HIGH
+too-complex:436:4:436:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 1:HIGH

--- a/tests/functional/ext/mccabe/mccabe.txt
+++ b/tests/functional/ext/mccabe/mccabe.txt
@@ -27,3 +27,9 @@ too-complex:296:0:296:31:try_finally_with_nested_ifs:'try_finally_with_nested_if
 too-complex:308:0:308:14:match_case:'match_case' is too complex. The McCabe rating is 4:HIGH
 too-complex:323:0:323:21:nested_match_case:'nested_match_case' is too complex. The McCabe rating is 8:HIGH
 too-complex:345:0:345:21:yield_in_for_loop:'yield_in_for_loop' is too complex. The McCabe rating is 4:HIGH
+too-complex:355:0:364:8::This 'try' is too complex. The McCabe rating is 5:HIGH
+too-complex:367:0:375:23::This 'match' is too complex. The McCabe rating is 4:HIGH
+too-complex:378:0:378:24:non_exhaustive_match:'non_exhaustive_match' is too complex. The McCabe rating is 3:HIGH
+too-complex:390:0:390:22:match_capture_name:'match_capture_name' is too complex. The McCabe rating is 3:HIGH
+too-complex:403:0:403:26:match_guarded_wildcard:'match_guarded_wildcard' is too complex. The McCabe rating is 3:HIGH
+too-complex:436:4:436:17:PropertyAccessors.attribute:'attribute' is too complex. The McCabe rating is 1:HIGH

--- a/tests/functional/ext/mccabe/mccabe_py311.py
+++ b/tests/functional/ext/mccabe/mccabe_py311.py
@@ -1,0 +1,17 @@
+"""Checks for too-complex with syntax requiring Python 3.11 or newer."""
+
+# pylint: disable=missing-docstring
+
+
+def exception_groups(shielded):  # [too-complex]
+    """McCabe rating: 1
+
+    The mccabe library predates ``except*`` and does not count it."""
+    result = "none"
+    try:
+        shielded()
+    except* TypeError:
+        result = "type"
+    except* ValueError:
+        result = "value"
+    return result

--- a/tests/functional/ext/mccabe/mccabe_py311.py
+++ b/tests/functional/ext/mccabe/mccabe_py311.py
@@ -4,9 +4,9 @@
 
 
 def exception_groups(shielded):  # [too-complex]
-    """McCabe rating: 1
+    """McCabe rating: 4
 
-    The mccabe library predates ``except*`` and does not count it."""
+    ``except*`` handlers count like ``except`` handlers."""
     result = "none"
     try:
         shielded()

--- a/tests/functional/ext/mccabe/mccabe_py311.rc
+++ b/tests/functional/ext/mccabe/mccabe_py311.rc
@@ -1,0 +1,7 @@
+[MAIN]
+load-plugins=pylint.extensions.mccabe,
+
+max-complexity=0
+
+[testoptions]
+min_pyver=3.11

--- a/tests/functional/ext/mccabe/mccabe_py311.txt
+++ b/tests/functional/ext/mccabe/mccabe_py311.txt
@@ -1,0 +1,1 @@
+too-complex:6:0:6:20:exception_groups:'exception_groups' is too complex. The McCabe rating is 1:HIGH

--- a/tests/functional/ext/mccabe/mccabe_py311.txt
+++ b/tests/functional/ext/mccabe/mccabe_py311.txt
@@ -1,1 +1,1 @@
-too-complex:6:0:6:20:exception_groups:'exception_groups' is too complex. The McCabe rating is 1:HIGH
+too-complex:6:0:6:20:exception_groups:'exception_groups' is too complex. The McCabe rating is 4:HIGH


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |

## Description

Draft following #9667. Seems like a lot of optimization can be done by having the code directly in pylint. typing, and removing inheritance, and edge's name handling in particular. Because we're using a tool that permits to draw graph and we don't want to draw anything, we just want to get the damn mccabe metric.