### PR TITLE
Use `sorted()` instead of in-place sorting

### DIFF
--- a/pylint/checkers/symilar.py
+++ b/pylint/checkers/symilar.py
@@ -430,8 +430,7 @@ class Symilar:
             cpls: set[LinesChunkLimits_T]
             for cpls in ensembles:
                 sims.append((num, cpls))
-        sims.sort(reverse=True)
-        return sims
+        return sorted(sims, reverse=True)
 
     def _display_sims(
         self, similarities: list[tuple[int, set[LinesChunkLimits_T]]]

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -102,23 +102,21 @@ class MessageIdStore:
     @staticmethod
     def _raise_duplicate_symbol(msgid: str, symbol: str, other_symbol: str) -> NoReturn:
         """Raise an error when a symbol is duplicated."""
-        symbols = [symbol, other_symbol]
-        symbols.sort()
-        error_message = f"Message id '{msgid}' cannot have both "
-        error_message += f"'{symbols[0]}' and '{symbols[1]}' as symbolic name."
-        raise InvalidMessageError(error_message)
+        symbol_a, symbol_b = sorted([symbol, other_symbol])
+        raise InvalidMessageError(
+            f"Message id '{msgid}' cannot have both "
+            f"'{symbol_a}' and '{symbol_b}' as symbolic name."
+        )
 
     @staticmethod
     def _raise_duplicate_msgid(symbol: str, msgid: str, other_msgid: str) -> NoReturn:
         """Raise an error when a msgid is duplicated."""
-        msgids = [msgid, other_msgid]
-        msgids.sort()
-        error_message = (
+        msgid_a, msgid_b = sorted([msgid, other_msgid])
+        raise InvalidMessageError(
             f"Message symbol '{symbol}' cannot be used for "
-            f"'{msgids[0]}' and '{msgids[1]}' at the same time."
+            f"'{msgid_a}' and '{msgid_b}' at the same time."
             f" If you're creating an 'old_names' use 'old-{symbol}' as the old symbol."
         )
-        raise InvalidMessageError(error_message)
 
     def get_active_msgids(self, msgid_or_symbol: str) -> list[str]:
         """Return msgids but the input can be a symbol.


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [x] ~Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``~
- [x] ~Relate your change to an issue in the tracker if such an issue exists~
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] ~If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``~
-->


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

<!-- If this PR references an issue without fixing it: -->

This PR replaces some of the `.sort()` calls to `sorted(...)`, in places where it _makes sense_, which allows to _save few lines_. It also updates the implementation of `_raise_duplicate_symbol` and `_raise_duplicate_msgid` to make them more uniform.