### PR TITLE
Extend catching of ValueError to 3.12.5+

### DIFF
--- a/pylint/__init__.py
+++ b/pylint/__init__.py
@@ -112,7 +112,7 @@ def _catch_valueerror(unraisable: sys.UnraisableHookArgs) -> None:  # pragma: no
     sys.__unraisablehook__(unraisable)
 
 
-if (3, 12, 0) <= sys.version_info[:3] < (3, 12, 3):
+if (3, 12, 0) <= sys.version_info[:3] < (3, 12, 3) or sys.version_info >= (3, 12, 5):
     sys.unraisablehook = _catch_valueerror
 
 


### PR DESCRIPTION
Refs https://github.com/pylint-dev/pylint/issues/9138#issuecomment-2294893830