### PR TITLE
Deprecate PyLinter pylintrc argument

### DIFF
--- a/doc/whatsnew/fragments/6052.breaking
+++ b/doc/whatsnew/fragments/6052.breaking
@@ -1,0 +1,4 @@
+The unused ``pylintrc`` argument to ``PyLinter.__init__()`` is deprecated
+and will be removed.
+
+Refs #6052

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -12,6 +12,7 @@ import os
 import sys
 import tokenize
 import traceback
+import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from io import TextIOWrapper
@@ -291,11 +292,17 @@ class PyLinter(
         options: Options = (),
         reporter: reporters.BaseReporter | reporters.MultiReporter | None = None,
         option_groups: tuple[tuple[str, str], ...] = (),
-        # TODO: Deprecate passing the pylintrc parameter
-        pylintrc: str | None = None,  # pylint: disable=unused-argument
+        pylintrc: str | None = None,
     ) -> None:
         _ArgumentsManager.__init__(self, prog="pylint")
         _MessageStateHandler.__init__(self, self)
+
+        if pylintrc is not None:
+            warnings.warn(
+                "The pylintrc argument will be removed.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Some stuff has to be done before initialization of other ancestors...
         # messages store / checkers / reporter / astroid manager

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -299,7 +299,7 @@ class PyLinter(
 
         if pylintrc is not None:
             warnings.warn(
-                "The pylintrc argument will be removed.",
+                "The pylintrc argument will be removed in pylint 5.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -172,7 +172,6 @@ group are mutually exclusive.",
         self.linter = linter = self.LinterClass(
             _make_run_options(self),
             option_groups=self.option_groups,
-            pylintrc=self._rcfile,
         )
         # register standard checkers
         linter.load_default_plugins()


### PR DESCRIPTION
This was unused.