### PR TITLE
docs: explain conflict between C0209 and W1203

### DIFF
--- a/doc/data/messages/c/consider-using-f-string/details.rst
+++ b/doc/data/messages/c/consider-using-f-string/details.rst
@@ -6,7 +6,10 @@ F-strings also perform better than alternatives; see
 `this tweet <https://twitter.com/raymondh/status/1205969258800275456>`_ for
 a simple example.
 
-When using the ``logging`` module, prefer lazy parameter passing
-(``logging.debug("msg %s", arg)``) over f-strings, to avoid conflicting
-with ``logging-fstring-interpolation``. See
-`issue 5286 <https://github.com/pylint-dev/pylint/issues/5286>`_.
+Inside ``logging`` calls, applying this message would trigger
+``logging-fstring-interpolation`` instead. Passing the arguments to the
+logger (``logging.debug("msg %s", arg)``) avoids both messages and lets
+the logger skip formatting entirely when the record is filtered out by
+level. This matters when the arguments have an expensive ``__str__`` or
+``__repr__``. See `issue 5286
+<https://github.com/pylint-dev/pylint/issues/5286>`_ for the discussion.

--- a/doc/data/messages/c/consider-using-f-string/details.rst
+++ b/doc/data/messages/c/consider-using-f-string/details.rst
@@ -5,3 +5,8 @@ that can replace most use cases for the ``%`` formatting operator,
 F-strings also perform better than alternatives; see
 `this tweet <https://twitter.com/raymondh/status/1205969258800275456>`_ for
 a simple example.
+
+When using the ``logging`` module, prefer lazy parameter passing
+(``logging.debug("msg %s", arg)``) over f-strings, to avoid conflicting
+with ``logging-fstring-interpolation``. See
+`issue 5286 <https://github.com/pylint-dev/pylint/issues/5286>`_.

--- a/doc/data/messages/l/logging-fstring-interpolation/details.rst
+++ b/doc/data/messages/l/logging-fstring-interpolation/details.rst
@@ -1,6 +1,10 @@
 This message permits to allow f-string in logging and still be warned of
 ``logging-format-interpolation``.
 
-When ``consider-using-f-string`` is also enabled, use lazy parameter
-passing (``logging.debug("msg %s", arg)``) which silences both. See
-`issue 5286 <https://github.com/pylint-dev/pylint/issues/5286>`_.
+When ``consider-using-f-string`` is also enabled, the two messages
+conflict inside ``logging`` calls. Passing the arguments to the logger
+(``logging.debug("msg %s", arg)``) avoids both and lets the logger skip
+formatting entirely when the record is filtered out by level. This
+matters when the arguments have an expensive ``__str__`` or
+``__repr__``. See `issue 5286
+<https://github.com/pylint-dev/pylint/issues/5286>`_ for the discussion.

--- a/doc/data/messages/l/logging-fstring-interpolation/details.rst
+++ b/doc/data/messages/l/logging-fstring-interpolation/details.rst
@@ -1,2 +1,6 @@
 This message permits to allow f-string in logging and still be warned of
 ``logging-format-interpolation``.
+
+When ``consider-using-f-string`` is also enabled, use lazy parameter
+passing (``logging.debug("msg %s", arg)``) which silences both. See
+`issue 5286 <https://github.com/pylint-dev/pylint/issues/5286>`_.

--- a/doc/user_guide/messages/message_control.rst
+++ b/doc/user_guide/messages/message_control.rst
@@ -220,7 +220,7 @@ This causes a conflict if both are enabled. You can resolve it by choosing one o
       [MESSAGES CONTROL]
       disable=C0209
 
-      
+
 Detecting useless disables
 --------------------------
 

--- a/doc/user_guide/messages/message_control.rst
+++ b/doc/user_guide/messages/message_control.rst
@@ -194,6 +194,33 @@ Here's an example with all these rules in a single place:
             print(self.blop)
 
 
+.. _conflict-c0209-w1203:
+
+C0209 and W1203 conflict
+------------------------
+
+These two messages are mutually exclusive when working with logging:
+
+- **C0209** (`consider-using-f-string`) recommends using f-strings
+- **W1203** (`logging-fstring-interpolation`) recommends using `%` formatting for performance reasons
+
+This causes a conflict if both are enabled. You can resolve it by choosing one of the following:
+
+- **Option 1:** Disable W1203 to allow f-strings in logging:
+
+  .. code-block:: ini
+
+      [MESSAGES CONTROL]
+      disable=W1203
+
+- **Option 2:** Disable C0209 to prefer `%` formatting in logging:
+
+  .. code-block:: ini
+
+      [MESSAGES CONTROL]
+      disable=C0209
+
+      
 Detecting useless disables
 --------------------------
 

--- a/doc/user_guide/messages/message_control.rst
+++ b/doc/user_guide/messages/message_control.rst
@@ -194,33 +194,6 @@ Here's an example with all these rules in a single place:
             print(self.blop)
 
 
-.. _conflict-c0209-w1203:
-
-C0209 and W1203 conflict
-------------------------
-
-These two messages are mutually exclusive when working with logging:
-
-- **C0209** (`consider-using-f-string`) recommends using f-strings
-- **W1203** (`logging-fstring-interpolation`) recommends using `%` formatting for performance reasons
-
-This causes a conflict if both are enabled. You can resolve it by choosing one of the following:
-
-- **Option 1:** Disable W1203 to allow f-strings in logging:
-
-  .. code-block:: ini
-
-      [MESSAGES CONTROL]
-      disable=W1203
-
-- **Option 2:** Disable C0209 to prefer `%` formatting in logging:
-
-  .. code-block:: ini
-
-      [MESSAGES CONTROL]
-      disable=C0209
-
-
 Detecting useless disables
 --------------------------
 


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description
This adds documentation to clarify the conflict between the `C0209` (consider-using-f-string) and `W1203` (logging-fstring-interpolation) messages.

It explains why the conflict occurs and provides options to resolve it using message control in the pylintrc file.

Refs #5286 