### PR TITLE
Add a ``add_message_at_node`` and ``add_message_at_location`` API in ``BaseChecker``

### DIFF
--- a/doc/whatsnew/fragments/10894.feature
+++ b/doc/whatsnew/fragments/10894.feature
@@ -1,0 +1,3 @@
+A new ``BaseChecker.add_message_at_location`` method lets checkers emit a message at an explicit location (``module``, ``filepath``, ``line``, ``col_offset``, ...) instead of deriving it from an AST node. This is useful for cross-module findings like ``duplicate-code``.
+
+Refs #10894

--- a/doc/whatsnew/fragments/10894.feature
+++ b/doc/whatsnew/fragments/10894.feature
@@ -1,3 +1,15 @@
-A new ``BaseChecker.add_message_at_location`` method lets checkers emit a message at an explicit location (``module``, ``filepath``, ``line``, ``col_offset``, ...) instead of deriving it from an AST node. This is useful for cross-module findings like ``duplicate-code``.
+Two new ``BaseChecker`` methods supplement ``add_message``:
+
+* ``add_message_at_node(msgid, node, args=None, confidence=UNDEFINED)``, a faster path
+  for the common case using an AST node. Avoids doing check on optional parameters like
+  ``line``/``col_offset``/``end_lineno``/``end_col_offset`` that ``add_message`` carries
+  for non-AST callers.
+
+* ``add_message_at_location(msgid, *, module: str, filepath = None, line = None,
+  col_offset = None, end_lineno = None, end_col_offset = None,  args = None,
+  confidence = UNDEFINED)`` emits a message at an explicit location instead of
+  deriving it from a node. This is the only way to define module and filepath as
+  ``add_message`` didn't provide them. Useful for cross-module findings like
+  ``duplicate-code``.
 
 Refs #10894

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -154,6 +154,38 @@ class BaseChecker(_ArgumentsProvider):
             msgid, line, node, args, confidence, col_offset, end_lineno, end_col_offset
         )
 
+    def add_message_at_location(
+        self,
+        msgid: str,
+        *,
+        module: str,
+        filepath: str | None = None,
+        line: int | None = None,
+        col_offset: int | None = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
+        args: Any = None,
+        confidence: Confidence = UNDEFINED,
+    ) -> None:
+        """Add a message at an explicit location, instead of deriving the
+        location from an AST node.
+
+        Use this when the message logically belongs to a module/position
+        other than the one currently being processed (e.g. cross-module
+        findings like duplicate-code).
+        """
+        self.linter.add_message_at_location(
+            msgid,
+            module=module,
+            filepath=filepath,
+            line=line,
+            col_offset=col_offset,
+            end_lineno=end_lineno,
+            end_col_offset=end_col_offset,
+            args=args,
+            confidence=confidence,
+        )
+
     def check_consistency(self) -> None:
         """Check the consistency of msgid.
 

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -154,6 +154,21 @@ class BaseChecker(_ArgumentsProvider):
             msgid, line, node, args, confidence, col_offset, end_lineno, end_col_offset
         )
 
+    def add_message_at_node(
+        self,
+        msgid: str,
+        node: nodes.NodeNG,
+        args: Any = None,
+        confidence: Confidence = UNDEFINED,
+    ) -> None:
+        """Fast path for the common case: emit a message located at ``node``.
+
+        Use :meth:`add_message` if you need to override
+        ``line``/``col_offset``, or :meth:`add_message_at_location` for
+        cross-module messages.
+        """
+        self.linter.add_message_at_node(msgid, node, args, confidence)
+
     def add_message_at_location(
         self,
         msgid: str,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1253,17 +1253,6 @@ class PyLinter(
                 if end_col_offset is None:
                     end_col_offset = node.end_col_offset
 
-        # should this message be displayed
-        if not self.is_message_enabled(message_definition.msgid, line, confidence):
-            self.file_state.handle_ignored_message(
-                self._get_message_state_scope(
-                    message_definition.msgid, line, confidence
-                ),
-                message_definition.msgid,
-                line,
-            )
-            return
-
         # get module and object
         if node is None:
             module, obj = self.current_name, ""
@@ -1271,25 +1260,18 @@ class PyLinter(
         else:
             module, obj = utils.get_module_and_frameid(node)
             abspath = node.root().file
-        if abspath is not None:
-            path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
-        else:
-            path = "configuration"
 
-        self._emit_message(
+        self._filter_and_emit_at_location(
             message_definition,
             args,
             confidence,
-            MessageLocationTuple(
-                abspath or "",
-                path,
-                module or "",
-                obj,
-                line or 1,
-                col_offset or 0,
-                end_lineno,
-                end_col_offset,
-            ),
+            module or "",
+            obj,
+            abspath,
+            line or 1,
+            col_offset,
+            end_lineno,
+            end_col_offset,
         )
 
     def _emit_message(
@@ -1371,8 +1353,9 @@ class PyLinter(
         non-AST callers, and skips ``_add_one_message`` entirely so a
         disabled message pays for nothing beyond the filter check.
         """
-        # Derive location once — same for every message_definition this
-        # msgid maps to (matters only for the rare ``old_names`` aliases).
+        # Derive location once. These are the same for every message_definition
+        # this msgid maps to (multiple definitions only happen for the rare
+        # ``old_names`` aliases).
         pos = node.position
         if pos is not None:
             line = pos.lineno
@@ -1384,36 +1367,20 @@ class PyLinter(
             col_offset = node.col_offset
             end_lineno = node.end_lineno
             end_col_offset = node.end_col_offset
+        module, obj = utils.get_module_and_frameid(node)
+        abspath = node.root().file
         for message_definition in self.msgs_store.get_message_definitions(msgid):
-            if not self.is_message_enabled(message_definition.msgid, line, confidence):
-                self.file_state.handle_ignored_message(
-                    self._get_message_state_scope(
-                        message_definition.msgid, line, confidence
-                    ),
-                    message_definition.msgid,
-                    line,
-                )
-                continue
-            module, obj = utils.get_module_and_frameid(node)
-            abspath = node.root().file
-            if abspath is not None:
-                path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
-            else:
-                path = "configuration"
-            self._emit_message(
+            self._filter_and_emit_at_location(
                 message_definition,
                 args,
                 confidence,
-                MessageLocationTuple(
-                    abspath or "",
-                    path,
-                    module or "",
-                    obj,
-                    line,
-                    col_offset or 0,
-                    end_lineno,
-                    end_col_offset,
-                ),
+                module or "",
+                obj,
+                abspath,
+                line,
+                col_offset,
+                end_lineno,
+                end_col_offset,
             )
 
     def add_message_at_location(
@@ -1436,36 +1403,69 @@ class PyLinter(
         other than the one currently being processed (e.g. cross-module
         findings like duplicate-code).
         """
+        abspath = filepath if filepath is not None else self.current_file
         for message_definition in self.msgs_store.get_message_definitions(msgid):
-            if not self.is_message_enabled(message_definition.msgid, line, confidence):
-                self.file_state.handle_ignored_message(
-                    self._get_message_state_scope(
-                        message_definition.msgid, line, confidence
-                    ),
-                    message_definition.msgid,
-                    line,
-                )
-                continue
-            abspath = filepath if filepath is not None else self.current_file
-            if abspath is not None:
-                path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
-            else:
-                path = "configuration"
-            self._emit_message(
+            self._filter_and_emit_at_location(
                 message_definition,
                 args,
                 confidence,
-                MessageLocationTuple(
-                    abspath or "",
-                    path,
-                    module,
-                    "",
-                    line or 1,
-                    col_offset or 0,
-                    end_lineno,
-                    end_col_offset,
-                ),
+                module,
+                "",
+                abspath,
+                line or 1,
+                col_offset,
+                end_lineno,
+                end_col_offset,
             )
+
+    # pylint: disable-next=too-many-arguments
+    def _filter_and_emit_at_location(
+        self,
+        message_definition: MessageDefinition,
+        args: Any | None,
+        confidence: interfaces.Confidence,
+        module: str,
+        obj: str,
+        abspath: str | None,
+        line: int,
+        col_offset: int | None,
+        end_lineno: int | None,
+        end_col_offset: int | None,
+    ) -> None:
+        """Filter and emit one message at an already-resolved location.
+
+        ``module``/``obj``/``abspath`` are loop-invariant across the
+        ``msgs_store.get_message_definitions(msgid)`` loop in the public
+        callers, so they're derived once and passed in.
+        """
+        if not self.is_message_enabled(message_definition.msgid, line, confidence):
+            self.file_state.handle_ignored_message(
+                self._get_message_state_scope(
+                    message_definition.msgid, line, confidence
+                ),
+                message_definition.msgid,
+                line,
+            )
+            return
+        if abspath is not None:
+            path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
+        else:
+            path = "configuration"
+        self._emit_message(
+            message_definition,
+            args,
+            confidence,
+            MessageLocationTuple(
+                abspath or "",
+                path,
+                module,
+                obj,
+                line,
+                col_offset or 0,
+                end_lineno,
+                end_col_offset,
+            ),
+        )
 
     def add_ignored_message(
         self,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1264,19 +1264,6 @@ class PyLinter(
             )
             return
 
-        # update stats
-        msg_cat = MSG_TYPES[message_definition.msgid[0]]
-        self.msg_status |= MSG_TYPES_STATUS[message_definition.msgid[0]]
-        self.stats.increase_single_message_count(msg_cat, 1)
-        self.stats.increase_single_module_message_count(self.current_name, msg_cat, 1)
-        try:
-            self.stats.by_msg[message_definition.symbol] += 1
-        except KeyError:
-            self.stats.by_msg[message_definition.symbol] = 1
-        # Interpolate arguments into message string
-        msg = message_definition.msg
-        if args is not None:
-            msg %= args
         # get module and object
         if node is None:
             module, obj = self.current_name, ""
@@ -1288,21 +1275,51 @@ class PyLinter(
             path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
         else:
             path = "configuration"
-        # add the message
+
+        self._emit_message(
+            message_definition,
+            args,
+            confidence,
+            MessageLocationTuple(
+                abspath or "",
+                path,
+                module or "",
+                obj,
+                line or 1,
+                col_offset or 0,
+                end_lineno,
+                end_col_offset,
+            ),
+        )
+
+    def _emit_message(
+        self,
+        message_definition: MessageDefinition,
+        args: Any | None,
+        confidence: interfaces.Confidence | None,
+        location: MessageLocationTuple,
+    ) -> None:
+        """Dispatch a fully-resolved :class:`Message` to the reporter.
+
+        Callers are responsible for filtering disabled messages out *before*
+        calling this.
+        """
+        msg_cat = MSG_TYPES[message_definition.msgid[0]]
+        self.msg_status |= MSG_TYPES_STATUS[message_definition.msgid[0]]
+        self.stats.increase_single_message_count(msg_cat, 1)
+        self.stats.increase_single_module_message_count(self.current_name, msg_cat, 1)
+        try:
+            self.stats.by_msg[message_definition.symbol] += 1
+        except KeyError:
+            self.stats.by_msg[message_definition.symbol] = 1
+        msg = message_definition.msg
+        if args is not None:
+            msg %= args
         self.reporter.handle_message(
             Message(
                 message_definition.msgid,
                 message_definition.symbol,
-                MessageLocationTuple(
-                    abspath or "",
-                    path,
-                    module or "",
-                    obj,
-                    line or 1,
-                    col_offset or 0,
-                    end_lineno,
-                    end_col_offset,
-                ),
+                location,
                 msg,
                 confidence,
             )
@@ -1338,6 +1355,57 @@ class PyLinter(
                 col_offset,
                 end_lineno,
                 end_col_offset,
+            )
+
+    def add_message_at_location(
+        self,
+        msgid: str,
+        *,
+        module: str,
+        filepath: str | None = None,
+        line: int | None = None,
+        col_offset: int | None = None,
+        end_lineno: int | None = None,
+        end_col_offset: int | None = None,
+        args: Any | None = None,
+        confidence: interfaces.Confidence = interfaces.UNDEFINED,
+    ) -> None:
+        """Add a message at an explicit location, instead of deriving the
+        location from an AST node.
+
+        Use this when the message logically belongs to a module/position
+        other than the one currently being processed (e.g. cross-module
+        findings like duplicate-code).
+        """
+        for message_definition in self.msgs_store.get_message_definitions(msgid):
+            if not self.is_message_enabled(message_definition.msgid, line, confidence):
+                self.file_state.handle_ignored_message(
+                    self._get_message_state_scope(
+                        message_definition.msgid, line, confidence
+                    ),
+                    message_definition.msgid,
+                    line,
+                )
+                continue
+            abspath = filepath if filepath is not None else self.current_file
+            if abspath is not None:
+                path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
+            else:
+                path = "configuration"
+            self._emit_message(
+                message_definition,
+                args,
+                confidence,
+                MessageLocationTuple(
+                    abspath or "",
+                    path,
+                    module,
+                    "",
+                    line or 1,
+                    col_offset or 0,
+                    end_lineno,
+                    end_col_offset,
+                ),
             )
 
     def add_ignored_message(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1357,6 +1357,65 @@ class PyLinter(
                 end_col_offset,
             )
 
+    def add_message_at_node(
+        self,
+        msgid: str,
+        node: nodes.NodeNG,
+        args: Any | None = None,
+        confidence: interfaces.Confidence = interfaces.UNDEFINED,
+    ) -> None:
+        """Fast path for emitting a message at an AST node.
+
+        Avoids binding the ``line``/``col_offset``/``end_lineno``/
+        ``end_col_offset`` parameters that ``add_message`` carries for
+        non-AST callers, and skips ``_add_one_message`` entirely so a
+        disabled message pays for nothing beyond the filter check.
+        """
+        # Derive location once — same for every message_definition this
+        # msgid maps to (matters only for the rare ``old_names`` aliases).
+        pos = node.position
+        if pos is not None:
+            line = pos.lineno
+            col_offset = pos.col_offset
+            end_lineno = pos.end_lineno
+            end_col_offset = pos.end_col_offset
+        else:
+            line = node.fromlineno
+            col_offset = node.col_offset
+            end_lineno = node.end_lineno
+            end_col_offset = node.end_col_offset
+        for message_definition in self.msgs_store.get_message_definitions(msgid):
+            if not self.is_message_enabled(message_definition.msgid, line, confidence):
+                self.file_state.handle_ignored_message(
+                    self._get_message_state_scope(
+                        message_definition.msgid, line, confidence
+                    ),
+                    message_definition.msgid,
+                    line,
+                )
+                continue
+            module, obj = utils.get_module_and_frameid(node)
+            abspath = node.root().file
+            if abspath is not None:
+                path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
+            else:
+                path = "configuration"
+            self._emit_message(
+                message_definition,
+                args,
+                confidence,
+                MessageLocationTuple(
+                    abspath or "",
+                    path,
+                    module or "",
+                    obj,
+                    line,
+                    col_offset or 0,
+                    end_lineno,
+                    end_col_offset,
+                ),
+            )
+
     def add_message_at_location(
         self,
         msgid: str,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1261,18 +1261,16 @@ class PyLinter(
             module, obj = utils.get_module_and_frameid(node)
             abspath = node.root().file
 
-        self._filter_and_emit_at_location(
-            message_definition,
-            args,
-            confidence,
+        location = self._build_location(
+            abspath,
             module or "",
             obj,
-            abspath,
             line or 1,
             col_offset,
             end_lineno,
             end_col_offset,
         )
+        self._filter_and_emit(message_definition, args, confidence, location)
 
     def _emit_message(
         self,
@@ -1369,19 +1367,11 @@ class PyLinter(
             end_col_offset = node.end_col_offset
         module, obj = utils.get_module_and_frameid(node)
         abspath = node.root().file
+        location = self._build_location(
+            abspath, module or "", obj, line, col_offset, end_lineno, end_col_offset
+        )
         for message_definition in self.msgs_store.get_message_definitions(msgid):
-            self._filter_and_emit_at_location(
-                message_definition,
-                args,
-                confidence,
-                module or "",
-                obj,
-                abspath,
-                line,
-                col_offset,
-                end_lineno,
-                end_col_offset,
-            )
+            self._filter_and_emit(message_definition, args, confidence, location)
 
     def add_message_at_location(
         self,
@@ -1404,68 +1394,58 @@ class PyLinter(
         findings like duplicate-code).
         """
         abspath = filepath if filepath is not None else self.current_file
+        location = self._build_location(
+            abspath, module, "", line or 1, col_offset, end_lineno, end_col_offset
+        )
         for message_definition in self.msgs_store.get_message_definitions(msgid):
-            self._filter_and_emit_at_location(
-                message_definition,
-                args,
-                confidence,
-                module,
-                "",
-                abspath,
-                line or 1,
-                col_offset,
-                end_lineno,
-                end_col_offset,
-            )
+            self._filter_and_emit(message_definition, args, confidence, location)
 
-    # pylint: disable-next=too-many-arguments
-    def _filter_and_emit_at_location(
+    def _build_location(
         self,
-        message_definition: MessageDefinition,
-        args: Any | None,
-        confidence: interfaces.Confidence,
+        abspath: str | None,
         module: str,
         obj: str,
-        abspath: str | None,
         line: int,
         col_offset: int | None,
         end_lineno: int | None,
         end_col_offset: int | None,
-    ) -> None:
-        """Filter and emit one message at an already-resolved location.
-
-        ``module``/``obj``/``abspath`` are loop-invariant across the
-        ``msgs_store.get_message_definitions(msgid)`` loop in the public
-        callers, so they're derived once and passed in.
-        """
-        if not self.is_message_enabled(message_definition.msgid, line, confidence):
-            self.file_state.handle_ignored_message(
-                self._get_message_state_scope(
-                    message_definition.msgid, line, confidence
-                ),
-                message_definition.msgid,
-                line,
-            )
-            return
+    ) -> MessageLocationTuple:
+        """Assemble a :class:`MessageLocationTuple`, deriving ``path`` from ``abspath``."""
         if abspath is not None:
             path = abspath.replace(self.reporter.path_strip_prefix, "", 1)
         else:
             path = "configuration"
-        self._emit_message(
-            message_definition,
-            args,
-            confidence,
-            MessageLocationTuple(
-                abspath or "",
-                path,
-                module,
-                obj,
-                line,
-                col_offset or 0,
-                end_lineno,
-                end_col_offset,
-            ),
+        return MessageLocationTuple(
+            abspath or "",
+            path,
+            module,
+            obj,
+            line,
+            col_offset or 0,
+            end_lineno,
+            end_col_offset,
         )
+
+    def _filter_and_emit(
+        self,
+        message_definition: MessageDefinition,
+        args: Any | None,
+        confidence: interfaces.Confidence,
+        location: MessageLocationTuple,
+    ) -> None:
+        """Filter and emit one message at an already-built ``location``."""
+        if not self.is_message_enabled(
+            message_definition.msgid, location.line, confidence
+        ):
+            self.file_state.handle_ignored_message(
+                self._get_message_state_scope(
+                    message_definition.msgid, location.line, confidence
+                ),
+                message_definition.msgid,
+                location.line,
+            )
+            return
+        self._emit_message(message_definition, args, confidence, location)
 
     def add_ignored_message(
         self,

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1296,7 +1296,7 @@ class PyLinter(
         self,
         message_definition: MessageDefinition,
         args: Any | None,
-        confidence: interfaces.Confidence | None,
+        confidence: interfaces.Confidence,
         location: MessageLocationTuple,
     ) -> None:
         """Dispatch a fully-resolved :class:`Message` to the reporter.

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -81,7 +81,7 @@ class UnittestLinter(PyLinter):
         self,
         message_definition: MessageDefinition,
         args: Any | None,
-        confidence: Confidence | None,
+        confidence: Confidence,
         location: MessageLocationTuple,
     ) -> None:
         """Capture into ``_messages`` instead of dispatching to a reporter.

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -12,7 +12,9 @@ from astroid import nodes
 
 from pylint.interfaces import UNDEFINED, Confidence
 from pylint.lint import PyLinter
+from pylint.message.message_definition import MessageDefinition
 from pylint.testutils.output_line import MessageTest
+from pylint.typing import MessageLocationTuple
 
 
 class UnittestLinter(PyLinter):
@@ -72,6 +74,33 @@ class UnittestLinter(PyLinter):
                 col_offset,
                 end_lineno,
                 end_col_offset,
+            )
+        )
+
+    def _emit_message(
+        self,
+        message_definition: MessageDefinition,
+        args: Any | None,
+        confidence: Confidence | None,
+        location: MessageLocationTuple,
+    ) -> None:
+        """Capture into ``_messages`` instead of dispatching to a reporter.
+
+        This catches calls coming through ``add_message_at_location`` (and
+        ``add_message_at_node``). The legacy ``add_message`` is overridden
+        separately so it can preserve the original ``node`` reference in
+        :class:`MessageTest`.
+        """
+        self._messages.append(
+            MessageTest(
+                message_definition.msgid,
+                location.line,
+                None,
+                args,
+                confidence,
+                location.column,
+                location.end_line,
+                location.end_column,
             )
         )
 

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -12,7 +12,9 @@ from pylint.checkers.typecheck import TypeChecker
 from pylint.exceptions import InvalidMessageError
 from pylint.extensions.broad_try_clause import BroadTryClauseChecker
 from pylint.extensions.while_used import WhileChecker
+from pylint.interfaces import HIGH
 from pylint.lint.pylinter import PyLinter
+from pylint.testutils import UnittestLinter
 
 
 class OtherBasicChecker(BaseChecker):
@@ -183,3 +185,40 @@ def test_base_checker_consistent_hash() -> None:
 
     assert hash(checker) == original_hash
     assert checker in some_set
+
+
+class _DelegationChecker(BaseChecker):
+    """Minimal checker used to exercise ``add_message_at_*`` delegation."""
+
+    name = "delegation-checker"
+    msgs = {
+        "W9999": (
+            "Delegation test %s",
+            "delegation-test",
+            "Used in tests to exercise add_message_at_* delegation.",
+        ),
+    }
+
+
+def test_base_checker_add_message_at_location_delegates() -> None:
+    """``BaseChecker.add_message_at_location`` forwards to the linter and captures."""
+    linter = UnittestLinter()
+    checker = _DelegationChecker(linter)
+    linter.register_checker(checker)
+
+    checker.add_message_at_location(
+        "W9999",
+        module="other_module",
+        filepath="other.py",
+        line=42,
+        col_offset=3,
+        args=("world",),
+        confidence=HIGH,
+    )
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].msg_id == "W9999"
+    assert messages[0].line == 42
+    assert messages[0].col_offset == 3
+    assert messages[0].args == ("world",)

--- a/tests/checkers/unittest_base_checker.py
+++ b/tests/checkers/unittest_base_checker.py
@@ -4,6 +4,7 @@
 
 """Unittest for the BaseChecker class."""
 
+import astroid
 import pytest
 
 from pylint.checkers import BaseChecker
@@ -198,6 +199,23 @@ class _DelegationChecker(BaseChecker):
             "Used in tests to exercise add_message_at_* delegation.",
         ),
     }
+
+
+def test_base_checker_add_message_at_node_delegates() -> None:
+    """``BaseChecker.add_message_at_node`` forwards to the linter and captures."""
+    linter = UnittestLinter()
+    checker = _DelegationChecker(linter)
+    linter.register_checker(checker)
+
+    module_node = astroid.parse("def foo(): pass", module_name="m")
+    node = module_node.body[0]
+    checker.add_message_at_node("W9999", node, args=("hello",), confidence=HIGH)
+
+    messages = linter.release_messages()
+    assert len(messages) == 1
+    assert messages[0].msg_id == "W9999"
+    assert messages[0].args == ("hello",)
+    assert messages[0].confidence == HIGH
 
 
 def test_base_checker_add_message_at_location_delegates() -> None:

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -537,6 +537,87 @@ def test_addmessage_preserves_explicit_zero_col_offset(linter: PyLinter) -> None
     assert linter.reporter.messages[0].location.column == 0
 
 
+def test_add_message_at_location_override(linter: PyLinter) -> None:
+    """``add_message_at_location`` overrides module/filepath in the message location."""
+    linter.set_reporter(testutils.GenericTestReporter())
+    linter.open()
+    linter.set_current_module("current_module")
+    linter.add_message_at_location(
+        "C0301",
+        module="overridden_module",
+        filepath="/fake/path.py",
+        line=1,
+        args=(1, 2),
+    )
+    assert len(linter.reporter.messages) == 1
+    msg = linter.reporter.messages[0]
+    assert msg.location.module == "overridden_module"
+    assert msg.location.abspath == "/fake/path.py"
+    assert msg.location.path == "/fake/path.py"
+
+
+def test_add_message_at_location_forwards_line_and_col(linter: PyLinter) -> None:
+    """Line/column overrides land in the emitted message location tuple."""
+    linter.set_reporter(testutils.GenericTestReporter())
+    linter.open()
+    linter.set_current_module("current_module")
+    linter.add_message_at_location(
+        "C0301",
+        module="overridden_module",
+        filepath="/fake/path.py",
+        line=10,
+        col_offset=5,
+        end_lineno=12,
+        end_col_offset=20,
+        args=(1, 2),
+    )
+    msg = linter.reporter.messages[0]
+    assert msg.location.line == 10
+    assert msg.location.column == 5
+    assert msg.location.end_line == 12
+    assert msg.location.end_column == 20
+
+
+def test_add_message_at_location_requires_module_kwarg(linter: PyLinter) -> None:
+    """``module`` is keyword-only and required."""
+    linter.set_reporter(testutils.GenericTestReporter())
+    linter.open()
+    linter.set_current_module("current_module")
+    with pytest.raises(TypeError):
+        linter.add_message_at_location(  # type: ignore[call-arg]
+            "C0301", line=1, args=(1, 2)
+        )
+
+
+def test_add_message_at_location_skips_disabled(linter: PyLinter) -> None:
+    """Disabled messages are filtered before reaching the reporter."""
+    linter.set_reporter(testutils.GenericTestReporter())
+    linter.open()
+    linter.set_current_module("current_module")
+    linter.disable("C0301")
+    linter.add_message_at_location(
+        "C0301",
+        module="other_module",
+        filepath="/fake/path.py",
+        line=1,
+        args=(1, 2),
+    )
+    assert linter.reporter.messages == []
+
+
+def test_add_message_at_location_without_filepath(linter: PyLinter) -> None:
+    """With no ``filepath`` and no ``current_file``, path falls back to ``"configuration"``."""
+    linter.set_reporter(testutils.GenericTestReporter())
+    linter.open()
+    linter.set_current_module("current_module")
+    linter.current_file = None
+    linter.add_message_at_location("C0301", module="other_module", line=1, args=(1, 2))
+    assert len(linter.reporter.messages) == 1
+    location = linter.reporter.messages[0].location
+    assert location.abspath == ""
+    assert location.path == "configuration"
+
+
 def test_addmessage_invalid(linter: PyLinter) -> None:
     linter.set_reporter(testutils.GenericTestReporter())
     linter.open()

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -618,6 +618,21 @@ def test_add_message_at_location_without_filepath(linter: PyLinter) -> None:
     assert location.path == "configuration"
 
 
+def test_add_message_at_node(linter: PyLinter) -> None:
+    """Fast path: location is derived from the node."""
+    linter.set_reporter(testutils.GenericTestReporter())
+    linter.open()
+    linter.set_current_module("0123")
+    module_node = astroid.parse("\n\nx = 1; y = 2", module_name="my_module")
+    node = module_node.body[0]
+    linter.add_message_at_node("C0321", node)
+    assert len(linter.reporter.messages) == 1
+    msg = linter.reporter.messages[0]
+    assert msg.msg_id == "C0321"
+    assert msg.location.line == node.fromlineno
+    assert msg.location.module == "my_module"
+
+
 def test_addmessage_invalid(linter: PyLinter) -> None:
     linter.set_reporter(testutils.GenericTestReporter())
     linter.open()


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

Required for a cleaner #10880. Allows checkers to override the reported module name and file path in message location, instead of relying on the current file context or node.

Two new ``BaseChecker`` methods supplement ``add_message``:

* ``add_message_at_node(msgid, node, args=None, confidence=UNDEFINED)``, a faster path for the common case using an AST node. Avoids doing check on optional parameters like ``line``/``col_offset``/``end_lineno``/``end_col_offset`` that ``add_message`` carries for non-AST callers.

* ``add_message_at_location(msgid, *, module: str, filepath = None, line = None, col_offset = None, end_lineno = None, end_col_offset = None,  args = None, confidence = UNDEFINED)`` emits a message at an explicit location instead of deriving it from a node. This is the only way to define module and filepath as ``add_message`` didn't provide them. 

``add_message``stays the same and module, and filepath can only be provided through the new API.