### PR TITLE
Fix false negative dangerous-default-value for typing.NamedTuple (#3716)

### DIFF
--- a/doc/whatsnew/fragments/3716.bugfix
+++ b/doc/whatsnew/fragments/3716.bugfix
@@ -1,0 +1,3 @@
+``dangerous-default-value`` now detects mutable default values in ``typing.NamedTuple`` field definitions.
+
+Closes #3716

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -421,14 +421,11 @@ class BasicChecker(_BasicChecker):
         self.linter.stats.node_count["klass"] += 1
         self._check_namedtuple_dangerous_defaults(node)
 
-    def _check_namedtuple_dangerous_defaults(
-        self, node: nodes.ClassDef
-    ) -> None:
+    def _check_namedtuple_dangerous_defaults(self, node: nodes.ClassDef) -> None:
         """Check for dangerous default values in typing.NamedTuple fields."""
         try:
             if not any(
-                ancestor.qname() == "typing.NamedTuple"
-                for ancestor in node.ancestors()
+                ancestor.qname() == "typing.NamedTuple" for ancestor in node.ancestors()
             ):
                 return
         except astroid.InferenceError:
@@ -461,9 +458,7 @@ class BasicChecker(_BasicChecker):
                         msg = f"{default.as_string()} ({value.qname()})"
                 else:
                     msg = f"{default.as_string()} ({DEFAULT_ARGUMENT_SYMBOLS[value.qname()]})"
-                self.add_message(
-                    "dangerous-default-value", node=child, args=(msg,)
-                )
+                self.add_message("dangerous-default-value", node=child, args=(msg,))
 
     @utils.only_required_for_messages(
         "pointless-statement",

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -413,11 +413,57 @@ class BasicChecker(_BasicChecker):
         """Check module name, docstring and required arguments."""
         self.linter.stats.node_count["module"] += 1
 
-    def visit_classdef(self, _: nodes.ClassDef) -> None:
+    @utils.only_required_for_messages("dangerous-default-value")
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
         """Check module name, docstring and redefinition
         increment branch counter.
         """
         self.linter.stats.node_count["klass"] += 1
+        self._check_namedtuple_dangerous_defaults(node)
+
+    def _check_namedtuple_dangerous_defaults(
+        self, node: nodes.ClassDef
+    ) -> None:
+        """Check for dangerous default values in typing.NamedTuple fields."""
+        try:
+            if not any(
+                ancestor.qname() == "typing.NamedTuple"
+                for ancestor in node.ancestors()
+            ):
+                return
+        except astroid.InferenceError:
+            return
+
+        def is_iterable(internal_node: nodes.NodeNG) -> bool:
+            return isinstance(internal_node, (nodes.List, nodes.Set, nodes.Dict))
+
+        for child in node.body:
+            if not isinstance(child, nodes.AnnAssign) or child.value is None:
+                continue
+            default = child.value
+            try:
+                value = next(default.infer())
+            except astroid.InferenceError:
+                continue
+
+            if (
+                isinstance(value, astroid.Instance)
+                and value.qname() in DEFAULT_ARGUMENT_SYMBOLS
+            ):
+                if value is default:
+                    msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
+                elif isinstance(value, astroid.Instance) or is_iterable(value):
+                    if is_iterable(default):
+                        msg = value.pytype()
+                    elif isinstance(default, nodes.Call):
+                        msg = f"{value.name}() ({value.qname()})"
+                    else:
+                        msg = f"{default.as_string()} ({value.qname()})"
+                else:
+                    msg = f"{default.as_string()} ({DEFAULT_ARGUMENT_SYMBOLS[value.qname()]})"
+                self.add_message(
+                    "dangerous-default-value", node=child, args=(msg,)
+                )
 
     @utils.only_required_for_messages(
         "pointless-statement",

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -615,7 +615,7 @@ class BasicChecker(_BasicChecker):
         if value is default:
             msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
         elif isinstance(default, nodes.Call):
-            msg = f"{value.name}() ({value.qname()})"
+            msg = f"{value.name}()"
         else:
             # The argument is a name referring to a value from somewhere else
             # which turns out to be a list, dict or set.

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -413,13 +413,13 @@ class BasicChecker(_BasicChecker):
         """Check module name, docstring and required arguments."""
         self.linter.stats.node_count["module"] += 1
 
-    @utils.only_required_for_messages("dangerous-default-value")
     def visit_classdef(self, node: nodes.ClassDef) -> None:
         """Check module name, docstring and redefinition
         increment branch counter.
         """
         self.linter.stats.node_count["klass"] += 1
-        self._check_namedtuple_dangerous_defaults(node)
+        if self.linter.is_message_enabled("dangerous-default-value"):
+            self._check_namedtuple_dangerous_defaults(node)
 
     def _check_namedtuple_dangerous_defaults(self, node: nodes.ClassDef) -> None:
         """Check for dangerous default values in typing.NamedTuple fields."""
@@ -438,9 +438,8 @@ class BasicChecker(_BasicChecker):
             if not isinstance(child, nodes.AnnAssign) or child.value is None:
                 continue
             default = child.value
-            try:
-                value = next(default.infer())
-            except astroid.InferenceError:
+            value = utils.safe_infer(default)
+            if value is None:
                 continue
 
             if (

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -605,11 +605,7 @@ class BasicChecker(_BasicChecker):
         self, default: nodes.NodeNG, msg_node: nodes.NodeNG
     ) -> None:
         """Emit dangerous-default-value if the inferred default is mutable."""
-        try:
-            value = next(default.infer())
-        except astroid.InferenceError:
-            return
-
+        value = utils.safe_infer(default)
         if (
             not isinstance(value, astroid.Instance)
             or value.qname() not in DEFAULT_ARGUMENT_SYMBOLS

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -619,7 +619,7 @@ class BasicChecker(_BasicChecker):
         else:
             # The argument is a name referring to a value from somewhere else
             # which turns out to be a list, dict or set.
-            msg = f"{default.as_string()} ({value.qname()})"
+            msg = default.as_string()
         self.add_message("dangerous-default-value", node=msg_node, args=(msg,))
 
     @utils.only_required_for_messages("unreachable", "lost-exception")

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -612,14 +612,11 @@ class BasicChecker(_BasicChecker):
         if qname not in DEFAULT_ARGUMENT_SYMBOLS:
             # The inferred type itself isn't a known mutable, but it might
             # be a subclass of one (e.g. ``class MyDict(dict): ...``).
-            proxied = getattr(value, "_proxied", None)
-            if proxied is None:
-                return
             try:
                 qname = next(
                     (
                         cls.qname()
-                        for cls in proxied.ancestors()
+                        for cls in value._proxied.ancestors()
                         if cls.qname() in DEFAULT_ARGUMENT_SYMBOLS
                     ),
                     "",

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -611,10 +611,25 @@ class BasicChecker(_BasicChecker):
             or value.qname() not in DEFAULT_ARGUMENT_SYMBOLS
         ):
             return
+        qname = value.qname()
+        if value is default:
+            # Literal: [], {}, {1, 2}
+            msg = DEFAULT_ARGUMENT_SYMBOLS[qname]
+        elif isinstance(default, nodes.Call):
+            # Call: set(), list(), collections.deque(). For builtins the
+            # qname is redundant with the call itself, so drop it.
+            if qname.startswith("builtins."):
+                msg = f"{value.name}()"
+            else:
+                msg = f"{value.name}() ({qname})"
+        else:
+            # Variable name referring to a mutable from somewhere else; the
+            # name alone is uninformative, so include the qname.
+            msg = f"{default.as_string()} ({qname})"
         self.add_message(
             "dangerous-default-value",
             node=msg_node,
-            args=(DEFAULT_ARGUMENT_SYMBOLS[value.qname()],),
+            args=(msg,),
             confidence=INFERENCE,
         )
 

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -418,46 +418,18 @@ class BasicChecker(_BasicChecker):
         increment branch counter.
         """
         self.linter.stats.node_count["klass"] += 1
-        if self.linter.is_message_enabled("dangerous-default-value"):
-            self._check_namedtuple_dangerous_defaults(node)
-
-    def _check_namedtuple_dangerous_defaults(self, node: nodes.ClassDef) -> None:
-        """Check for dangerous default values in typing.NamedTuple fields."""
+        if not self.linter.is_message_enabled("dangerous-default-value"):
+            return
         try:
             if not any(
                 ancestor.qname() == "typing.NamedTuple" for ancestor in node.ancestors()
             ):
                 return
-        except astroid.InferenceError:  # pragma: no cover
+        except astroid.InferenceError:
             return
-
-        def is_iterable(internal_node: nodes.NodeNG) -> bool:
-            return isinstance(internal_node, (nodes.List, nodes.Set, nodes.Dict))
-
         for child in node.body:
-            if not isinstance(child, nodes.AnnAssign) or child.value is None:
-                continue
-            default = child.value
-            value = utils.safe_infer(default)
-            if value is None:
-                continue
-
-            if (
-                isinstance(value, astroid.Instance)
-                and value.qname() in DEFAULT_ARGUMENT_SYMBOLS
-            ):
-                if value is default:
-                    msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
-                elif isinstance(value, astroid.Instance) or is_iterable(value):
-                    if is_iterable(default):  # pragma: no cover
-                        msg = value.pytype()
-                    elif isinstance(default, nodes.Call):
-                        msg = f"{value.name}() ({value.qname()})"
-                    else:
-                        msg = f"{default.as_string()} ({value.qname()})"
-                else:  # pragma: no cover
-                    msg = f"{default.as_string()} ({DEFAULT_ARGUMENT_SYMBOLS[value.qname()]})"
-                self.add_message("dangerous-default-value", node=child, args=(msg,))
+            if isinstance(child, nodes.AnnAssign) and child.value is not None:
+                self._check_dangerous_default(child.value, child)
 
     @utils.only_required_for_messages(
         "pointless-statement",
@@ -625,49 +597,41 @@ class BasicChecker(_BasicChecker):
             self.linter.stats.node_count["method"] += 1
         else:
             self.linter.stats.node_count["function"] += 1
-        self._check_dangerous_default(node)
+        for default in (node.args.defaults or []) + (node.args.kw_defaults or []):
+            if default:
+                self._check_dangerous_default(default, node)
 
     visit_asyncfunctiondef = visit_functiondef
 
-    def _check_dangerous_default(self, node: nodes.FunctionDef) -> None:
-        """Check for dangerous default values as arguments."""
+    def _check_dangerous_default(
+        self, default: nodes.NodeNG, msg_node: nodes.NodeNG
+    ) -> None:
+        """Emit dangerous-default-value if the inferred default is mutable."""
+        try:
+            value = next(default.infer())
+        except astroid.InferenceError:
+            return
 
-        def is_iterable(internal_node: nodes.NodeNG) -> bool:
-            return isinstance(internal_node, (nodes.List, nodes.Set, nodes.Dict))
+        if (
+            not isinstance(value, astroid.Instance)
+            or value.qname() not in DEFAULT_ARGUMENT_SYMBOLS
+        ):
+            return
 
-        defaults = (node.args.defaults or []) + (node.args.kw_defaults or [])
-        for default in defaults:
-            if not default:
-                continue
-            try:
-                value = next(default.infer())
-            except astroid.InferenceError:
-                continue
-
-            if (
-                isinstance(value, astroid.Instance)
-                and value.qname() in DEFAULT_ARGUMENT_SYMBOLS
-            ):
-                if value is default:
-                    msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
-                elif isinstance(value, astroid.Instance) or is_iterable(value):
-                    # We are here in the following situation(s):
-                    #   * a dict/set/list/tuple call which wasn't inferred
-                    #     to a syntax node ({}, () etc.). This can happen
-                    #     when the arguments are invalid or unknown to
-                    #     the inference.
-                    #   * a variable from somewhere else, which turns out to be a list
-                    #     or a dict.
-                    if is_iterable(default):
-                        msg = value.pytype()
-                    elif isinstance(default, nodes.Call):
-                        msg = f"{value.name}() ({value.qname()})"
-                    else:
-                        msg = f"{default.as_string()} ({value.qname()})"
-                else:
-                    # this argument is a name
-                    msg = f"{default.as_string()} ({DEFAULT_ARGUMENT_SYMBOLS[value.qname()]})"
-                self.add_message("dangerous-default-value", node=node, args=(msg,))
+        if value is default:
+            msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
+        elif isinstance(default, (nodes.List, nodes.Set, nodes.Dict)):
+            # A dict/set/list/tuple call which wasn't inferred to a syntax
+            # node ({}, () etc.). This can happen when the arguments are
+            # invalid or unknown to the inference.
+            msg = value.pytype()
+        elif isinstance(default, nodes.Call):
+            msg = f"{value.name}() ({value.qname()})"
+        else:
+            # The argument is a name referring to a value from somewhere else
+            # which turns out to be a list, dict or set.
+            msg = f"{default.as_string()} ({value.qname()})"
+        self.add_message("dangerous-default-value", node=msg_node, args=(msg,))
 
     @utils.only_required_for_messages("unreachable", "lost-exception")
     def visit_return(self, node: nodes.Return) -> None:

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -428,7 +428,7 @@ class BasicChecker(_BasicChecker):
                 ancestor.qname() == "typing.NamedTuple" for ancestor in node.ancestors()
             ):
                 return
-        except astroid.InferenceError:
+        except astroid.InferenceError:  # pragma: no cover
             return
 
         def is_iterable(internal_node: nodes.NodeNG) -> bool:
@@ -449,13 +449,13 @@ class BasicChecker(_BasicChecker):
                 if value is default:
                     msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
                 elif isinstance(value, astroid.Instance) or is_iterable(value):
-                    if is_iterable(default):
+                    if is_iterable(default):  # pragma: no cover
                         msg = value.pytype()
                     elif isinstance(default, nodes.Call):
                         msg = f"{value.name}() ({value.qname()})"
                     else:
                         msg = f"{default.as_string()} ({value.qname()})"
-                else:
+                else:  # pragma: no cover
                     msg = f"{default.as_string()} ({DEFAULT_ARGUMENT_SYMBOLS[value.qname()]})"
                 self.add_message("dangerous-default-value", node=child, args=(msg,))
 

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -611,16 +611,12 @@ class BasicChecker(_BasicChecker):
             or value.qname() not in DEFAULT_ARGUMENT_SYMBOLS
         ):
             return
-
-        if value is default:
-            msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
-        elif isinstance(default, nodes.Call):
-            msg = f"{value.name}()"
-        else:
-            # The argument is a name referring to a value from somewhere else
-            # which turns out to be a list, dict or set.
-            msg = default.as_string()
-        self.add_message("dangerous-default-value", node=msg_node, args=(msg,))
+        self.add_message(
+            "dangerous-default-value",
+            node=msg_node,
+            args=(DEFAULT_ARGUMENT_SYMBOLS[value.qname()],),
+            confidence=INFERENCE,
+        )
 
     @utils.only_required_for_messages("unreachable", "lost-exception")
     def visit_return(self, node: nodes.Return) -> None:

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -606,12 +606,28 @@ class BasicChecker(_BasicChecker):
     ) -> None:
         """Emit dangerous-default-value if the inferred default is mutable."""
         value = utils.safe_infer(default)
-        if (
-            not isinstance(value, astroid.Instance)
-            or value.qname() not in DEFAULT_ARGUMENT_SYMBOLS
-        ):
+        if not isinstance(value, astroid.Instance):
             return
         qname = value.qname()
+        if qname not in DEFAULT_ARGUMENT_SYMBOLS:
+            # The inferred type itself isn't a known mutable, but it might
+            # be a subclass of one (e.g. ``class MyDict(dict): ...``).
+            proxied = getattr(value, "_proxied", None)
+            if proxied is None:
+                return
+            try:
+                qname = next(
+                    (
+                        cls.qname()
+                        for cls in proxied.ancestors()
+                        if cls.qname() in DEFAULT_ARGUMENT_SYMBOLS
+                    ),
+                    "",
+                )
+            except astroid.InferenceError:  # pragma: no cover
+                return
+            if not qname:
+                return
         if value is default:
             # Literal: [], {}, {1, 2}
             msg = DEFAULT_ARGUMENT_SYMBOLS[qname]

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -418,14 +418,12 @@ class BasicChecker(_BasicChecker):
         increment branch counter.
         """
         self.linter.stats.node_count["klass"] += 1
-        if not self.linter.is_message_enabled("dangerous-default-value"):
-            return
         try:
             if not any(
                 ancestor.qname() == "typing.NamedTuple" for ancestor in node.ancestors()
             ):
                 return
-        except astroid.InferenceError:
+        except astroid.InferenceError:  # pragma: no cover
             return
         for child in node.body:
             if isinstance(child, nodes.AnnAssign) and child.value is not None:
@@ -620,11 +618,6 @@ class BasicChecker(_BasicChecker):
 
         if value is default:
             msg = DEFAULT_ARGUMENT_SYMBOLS[value.qname()]
-        elif isinstance(default, (nodes.List, nodes.Set, nodes.Dict)):
-            # A dict/set/list/tuple call which wasn't inferred to a syntax
-            # node ({}, () etc.). This can happen when the arguments are
-            # invalid or unknown to the inference.
-            msg = value.pytype()
         elif isinstance(default, nodes.Call):
             msg = f"{value.name}() ({value.qname()})"
         else:

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -616,12 +616,7 @@ class BasicChecker(_BasicChecker):
             # Literal: [], {}, {1, 2}
             msg = DEFAULT_ARGUMENT_SYMBOLS[qname]
         elif isinstance(default, nodes.Call):
-            # Call: set(), list(), collections.deque(). For builtins the
-            # qname is redundant with the call itself, so drop it.
-            if qname.startswith("builtins."):
-                msg = f"{value.name}()"
-            else:
-                msg = f"{value.name}() ({qname})"
+            msg = f"{value.name}()"
         else:
             # Variable name referring to a mutable from somewhere else; the
             # name alone is uninformative, so include the qname.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -9,9 +9,10 @@ import copy
 import itertools
 import tokenize
 from collections.abc import Iterator
+from dataclasses import dataclass, field
 from functools import cached_property, reduce
 from re import Pattern
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import astroid
 from astroid import bases, nodes, objects
@@ -210,14 +211,15 @@ def _is_part_of_assignment_target(node: nodes.NodeNG) -> bool:
     return False
 
 
-class ConsiderUsingWithStack(NamedTuple):
+@dataclass
+class ConsiderUsingWithStack:
     """Stack for objects that may potentially trigger a R1732 message
     if they are not used in a ``with`` block later on.
     """
 
-    module_scope: dict[str, nodes.NodeNG] = {}
-    class_scope: dict[str, nodes.NodeNG] = {}
-    function_scope: dict[str, nodes.NodeNG] = {}
+    module_scope: dict[str, nodes.NodeNG] = field(default_factory=dict)
+    class_scope: dict[str, nodes.NodeNG] = field(default_factory=dict)
+    function_scope: dict[str, nodes.NodeNG] = field(default_factory=dict)
 
     def __iter__(self) -> Iterator[dict[str, nodes.NodeNG]]:
         yield from (self.function_scope, self.class_scope, self.module_scope)

--- a/pylint/message/_deleted_message_ids.py
+++ b/pylint/message/_deleted_message_ids.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import cache
 from typing import NamedTuple
 
@@ -11,7 +12,7 @@ from typing import NamedTuple
 class DeletedMessage(NamedTuple):
     msgid: str
     symbol: str
-    old_names: list[tuple[str, str]] = []
+    old_names: Sequence[tuple[str, str]] = ()
 
 
 DELETED_MSGID_PREFIXES: list[int] = []

--- a/pylint/message/message_id_store.py
+++ b/pylint/message/message_id_store.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import NoReturn
 
 from pylint.exceptions import (
@@ -56,7 +57,7 @@ class MessageIdStore:
             raise UnknownMessageError(msg) from e
 
     def register_message_definition(
-        self, msgid: str, symbol: str, old_names: list[tuple[str, str]]
+        self, msgid: str, symbol: str, old_names: Sequence[tuple[str, str]]
     ) -> None:
         self.check_msgid_and_symbol(msgid, symbol)
         self.add_msgid_and_symbol(msgid, symbol)

--- a/tests/functional/a/async_functions.txt
+++ b/tests/functional/a/async_functions.txt
@@ -6,7 +6,7 @@ too-many-arguments:27:0:27:26:complex_function:Too many arguments (9/5):UNDEFINE
 too-many-branches:27:0:27:26:complex_function:Too many branches (13/12):UNDEFINED
 too-many-positional-arguments:27:0:27:26:complex_function:Too many positional arguments (9/5):HIGH
 too-many-return-statements:27:0:27:26:complex_function:Too many return statements (10/6):UNDEFINED
-dangerous-default-value:60:0:60:14:func:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:60:0:60:14:func:Dangerous default value [] as argument:INFERENCE
 duplicate-argument-name:60:18:60:19:func:Duplicate argument name 'a' in function definition:HIGH
 disallowed-name:65:0:65:13:foo:"Disallowed name ""foo""":HIGH
 empty-docstring:65:0:65:13:foo:Empty function docstring:HIGH

--- a/tests/functional/d/dangerous_default_value.txt
+++ b/tests/functional/d/dangerous_default_value.txt
@@ -1,23 +1,23 @@
 dangerous-default-value:6:0:6:13:function1:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:10:0:10:13:function2:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:10:0:10:13:function2:Dangerous default value HEHE (builtins.dict) as argument:INFERENCE
 dangerous-default-value:18:0:18:13:function4:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:28:0:28:13:function6:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:32:0:32:13:function7:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:36:0:36:13:function8:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:28:0:28:13:function6:Dangerous default value GLOBAL_SET (builtins.set) as argument:INFERENCE
+dangerous-default-value:32:0:32:13:function7:Dangerous default value dict() as argument:INFERENCE
+dangerous-default-value:36:0:36:13:function8:Dangerous default value list() as argument:INFERENCE
 dangerous-default-value:40:0:40:13:function9:Dangerous default value [] as argument:INFERENCE
 dangerous-default-value:44:0:44:14:function10:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:48:0:48:14:function11:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:52:0:52:14:function12:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:61:0:61:14:function13:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:65:0:65:14:function14:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:73:0:73:14:function15:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:48:0:48:14:function11:Dangerous default value list() as argument:INFERENCE
+dangerous-default-value:52:0:52:14:function12:Dangerous default value dict() as argument:INFERENCE
+dangerous-default-value:61:0:61:14:function13:Dangerous default value OINK (builtins.dict) as argument:INFERENCE
+dangerous-default-value:65:0:65:14:function14:Dangerous default value dict() as argument:INFERENCE
+dangerous-default-value:73:0:73:14:function15:Dangerous default value INVALID_DICT (builtins.dict) as argument:INFERENCE
 dangerous-default-value:77:0:77:14:function16:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:81:0:81:14:function17:Dangerous default value collections.deque() as argument:INFERENCE
-dangerous-default-value:85:0:85:14:function18:Dangerous default value collections.ChainMap() as argument:INFERENCE
-dangerous-default-value:89:0:89:14:function19:Dangerous default value collections.Counter() as argument:INFERENCE
-dangerous-default-value:93:0:93:14:function20:Dangerous default value collections.OrderedDict() as argument:INFERENCE
-dangerous-default-value:97:0:97:14:function21:Dangerous default value collections.defaultdict() as argument:INFERENCE
-dangerous-default-value:101:0:101:14:function22:Dangerous default value collections.UserDict() as argument:INFERENCE
-dangerous-default-value:105:0:105:14:function23:Dangerous default value collections.UserList() as argument:INFERENCE
+dangerous-default-value:81:0:81:14:function17:Dangerous default value deque() (collections.deque) as argument:INFERENCE
+dangerous-default-value:85:0:85:14:function18:Dangerous default value ChainMap() (collections.ChainMap) as argument:INFERENCE
+dangerous-default-value:89:0:89:14:function19:Dangerous default value Counter() (collections.Counter) as argument:INFERENCE
+dangerous-default-value:93:0:93:14:function20:Dangerous default value OrderedDict() (collections.OrderedDict) as argument:INFERENCE
+dangerous-default-value:97:0:97:14:function21:Dangerous default value defaultdict() (collections.defaultdict) as argument:INFERENCE
+dangerous-default-value:101:0:101:14:function22:Dangerous default value UserDict() (collections.UserDict) as argument:INFERENCE
+dangerous-default-value:105:0:105:14:function23:Dangerous default value UserList() (collections.UserList) as argument:INFERENCE
 dangerous-default-value:109:0:109:14:function24:Dangerous default value [] as argument:INFERENCE
 dangerous-default-value:116:4:116:16:Clazz.__init__:Dangerous default value {} as argument:INFERENCE

--- a/tests/functional/d/dangerous_default_value.txt
+++ b/tests/functional/d/dangerous_default_value.txt
@@ -12,12 +12,12 @@ dangerous-default-value:61:0:61:14:function13:Dangerous default value OINK (buil
 dangerous-default-value:65:0:65:14:function14:Dangerous default value dict() as argument:INFERENCE
 dangerous-default-value:73:0:73:14:function15:Dangerous default value INVALID_DICT (builtins.dict) as argument:INFERENCE
 dangerous-default-value:77:0:77:14:function16:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:81:0:81:14:function17:Dangerous default value deque() (collections.deque) as argument:INFERENCE
-dangerous-default-value:85:0:85:14:function18:Dangerous default value ChainMap() (collections.ChainMap) as argument:INFERENCE
-dangerous-default-value:89:0:89:14:function19:Dangerous default value Counter() (collections.Counter) as argument:INFERENCE
-dangerous-default-value:93:0:93:14:function20:Dangerous default value OrderedDict() (collections.OrderedDict) as argument:INFERENCE
-dangerous-default-value:97:0:97:14:function21:Dangerous default value defaultdict() (collections.defaultdict) as argument:INFERENCE
-dangerous-default-value:101:0:101:14:function22:Dangerous default value UserDict() (collections.UserDict) as argument:INFERENCE
-dangerous-default-value:105:0:105:14:function23:Dangerous default value UserList() (collections.UserList) as argument:INFERENCE
+dangerous-default-value:81:0:81:14:function17:Dangerous default value deque() as argument:INFERENCE
+dangerous-default-value:85:0:85:14:function18:Dangerous default value ChainMap() as argument:INFERENCE
+dangerous-default-value:89:0:89:14:function19:Dangerous default value Counter() as argument:INFERENCE
+dangerous-default-value:93:0:93:14:function20:Dangerous default value OrderedDict() as argument:INFERENCE
+dangerous-default-value:97:0:97:14:function21:Dangerous default value defaultdict() as argument:INFERENCE
+dangerous-default-value:101:0:101:14:function22:Dangerous default value UserDict() as argument:INFERENCE
+dangerous-default-value:105:0:105:14:function23:Dangerous default value UserList() as argument:INFERENCE
 dangerous-default-value:109:0:109:14:function24:Dangerous default value [] as argument:INFERENCE
 dangerous-default-value:116:4:116:16:Clazz.__init__:Dangerous default value {} as argument:INFERENCE

--- a/tests/functional/d/dangerous_default_value.txt
+++ b/tests/functional/d/dangerous_default_value.txt
@@ -1,23 +1,23 @@
-dangerous-default-value:6:0:6:13:function1:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:10:0:10:13:function2:Dangerous default value HEHE (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:18:0:18:13:function4:Dangerous default value set() (builtins.set) as argument:UNDEFINED
-dangerous-default-value:28:0:28:13:function6:Dangerous default value GLOBAL_SET (builtins.set) as argument:UNDEFINED
-dangerous-default-value:32:0:32:13:function7:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:36:0:36:13:function8:Dangerous default value list() (builtins.list) as argument:UNDEFINED
-dangerous-default-value:40:0:40:13:function9:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:44:0:44:14:function10:Dangerous default value {} as argument:UNDEFINED
-dangerous-default-value:48:0:48:14:function11:Dangerous default value list() (builtins.list) as argument:UNDEFINED
-dangerous-default-value:52:0:52:14:function12:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:61:0:61:14:function13:Dangerous default value OINK (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:65:0:65:14:function14:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:73:0:73:14:function15:Dangerous default value INVALID_DICT (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:77:0:77:14:function16:Dangerous default value set() as argument:UNDEFINED
-dangerous-default-value:81:0:81:14:function17:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
-dangerous-default-value:85:0:85:14:function18:Dangerous default value ChainMap() (collections.ChainMap) as argument:UNDEFINED
-dangerous-default-value:89:0:89:14:function19:Dangerous default value Counter() (collections.Counter) as argument:UNDEFINED
-dangerous-default-value:93:0:93:14:function20:Dangerous default value OrderedDict() (collections.OrderedDict) as argument:UNDEFINED
-dangerous-default-value:97:0:97:14:function21:Dangerous default value defaultdict() (collections.defaultdict) as argument:UNDEFINED
-dangerous-default-value:101:0:101:14:function22:Dangerous default value UserDict() (collections.UserDict) as argument:UNDEFINED
-dangerous-default-value:105:0:105:14:function23:Dangerous default value UserList() (collections.UserList) as argument:UNDEFINED
-dangerous-default-value:109:0:109:14:function24:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:116:4:116:16:Clazz.__init__:Dangerous default value {} as argument:UNDEFINED
+dangerous-default-value:6:0:6:13:function1:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:10:0:10:13:function2:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:18:0:18:13:function4:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:28:0:28:13:function6:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:32:0:32:13:function7:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:36:0:36:13:function8:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:40:0:40:13:function9:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:44:0:44:14:function10:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:48:0:48:14:function11:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:52:0:52:14:function12:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:61:0:61:14:function13:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:65:0:65:14:function14:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:73:0:73:14:function15:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:77:0:77:14:function16:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:81:0:81:14:function17:Dangerous default value collections.deque() as argument:INFERENCE
+dangerous-default-value:85:0:85:14:function18:Dangerous default value collections.ChainMap() as argument:INFERENCE
+dangerous-default-value:89:0:89:14:function19:Dangerous default value collections.Counter() as argument:INFERENCE
+dangerous-default-value:93:0:93:14:function20:Dangerous default value collections.OrderedDict() as argument:INFERENCE
+dangerous-default-value:97:0:97:14:function21:Dangerous default value collections.defaultdict() as argument:INFERENCE
+dangerous-default-value:101:0:101:14:function22:Dangerous default value collections.UserDict() as argument:INFERENCE
+dangerous-default-value:105:0:105:14:function23:Dangerous default value collections.UserList() as argument:INFERENCE
+dangerous-default-value:109:0:109:14:function24:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:116:4:116:16:Clazz.__init__:Dangerous default value {} as argument:INFERENCE

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -1,0 +1,50 @@
+# pylint: disable=missing-docstring, use-list-literal, use-dict-literal
+import collections
+from typing import List, NamedTuple
+
+
+class BadListDefault(NamedTuple):
+    avgs: List[float] = []  # [dangerous-default-value]
+    stds: List[float] = []  # [dangerous-default-value]
+
+
+class BadDictDefault(NamedTuple):
+    data: dict = {}  # [dangerous-default-value]
+
+
+class BadSetDefault(NamedTuple):
+    items: set = set()  # [dangerous-default-value]
+
+
+class BadSetLiteralDefault(NamedTuple):
+    items: set = {1, 2}  # [dangerous-default-value]
+
+
+class BadListCallDefault(NamedTuple):
+    items: list = list()  # [dangerous-default-value]
+
+
+class BadDictCallDefault(NamedTuple):
+    data: dict = dict()  # [dangerous-default-value]
+
+
+class BadDequeDefault(NamedTuple):
+    items: collections.deque = collections.deque()  # [dangerous-default-value]
+
+
+class SafeNamedTuple(NamedTuple):
+    name: str = "default"
+    count: int = 0
+    flag: bool = True
+    tags: tuple = ()
+    frozen: frozenset = frozenset()
+
+
+class MixedNamedTuple(NamedTuple):
+    name: str = "ok"
+    items: list = []  # [dangerous-default-value]
+
+
+class NoDefaultNamedTuple(NamedTuple):
+    name: str
+    value: int

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -64,3 +64,11 @@ class NoDefaultNamedTuple(NamedTuple):
 
 class GlobalDangerousDefault(NamedTuple):
     items: set = DANGEROUS_GLOBAL  # [dangerous-default-value]
+    
+    
+class BadCustomStoreDefault(NamedTuple):
+    store: CustomMutableStore = CustomMutableStore()  # [dangerous-default-value]
+    
+    
+class SafeCustomStoreDefault(NamedTuple):
+    store: CustomImmutableStore = CustomImmutableStore()    

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -1,11 +1,8 @@
 # pylint: disable=missing-module-docstring, missing-class-docstring, use-list-literal, use-dict-literal
 import collections
-import random
 from typing import NamedTuple
 
 DANGEROUS_GLOBAL = set()
-
-AMBIGUOUS_DEFAULT = [] if random.random() > 0.5 else {}
 
 
 class BadListDefault(NamedTuple):
@@ -57,7 +54,3 @@ class NoDefaultNamedTuple(NamedTuple):
 
 class GlobalDangerousDefault(NamedTuple):
     items: set = DANGEROUS_GLOBAL  # [dangerous-default-value]
-
-
-class UninferrableDefault(NamedTuple):
-    items: list | dict = AMBIGUOUS_DEFAULT

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-module-docstring, missing-class-docstring, use-list-literal, use-dict-literal
+# pylint: disable=missing-module-docstring, missing-class-docstring, missing-function-docstring, multiple-statements, use-list-literal, use-dict-literal
 import collections
 from typing import NamedTuple
 

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -1,6 +1,11 @@
 # pylint: disable=missing-module-docstring, missing-class-docstring, use-list-literal, use-dict-literal
 import collections
+import random
 from typing import NamedTuple
+
+DANGEROUS_GLOBAL = set()
+
+AMBIGUOUS_DEFAULT = [] if random.random() > 0.5 else {}
 
 
 class BadListDefault(NamedTuple):
@@ -48,3 +53,11 @@ class MixedNamedTuple(NamedTuple):
 class NoDefaultNamedTuple(NamedTuple):
     name: str
     value: int
+
+
+class GlobalDangerousDefault(NamedTuple):
+    items: set = DANGEROUS_GLOBAL  # [dangerous-default-value]
+
+
+class UninferrableDefault(NamedTuple):
+    items: list | dict = AMBIGUOUS_DEFAULT

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -10,8 +10,8 @@ class CustomImmutableStore(frozenset): pass
 
 def create_my_custom_immutable_data_store() -> CustomImmutableStore:
     return CustomImmutableStore()
-    
-    
+
+
 def create_my_custom_mutable_data_store() -> CustomMutableStore:
     return CustomMutableStore()
 
@@ -64,11 +64,11 @@ class NoDefaultNamedTuple(NamedTuple):
 
 class GlobalDangerousDefault(NamedTuple):
     items: set = DANGEROUS_GLOBAL  # [dangerous-default-value]
-    
-    
+
+
 class BadCustomStoreDefault(NamedTuple):
     store: CustomMutableStore = CustomMutableStore()  # [dangerous-default-value]
-    
-    
+
+
 class SafeCustomStoreDefault(NamedTuple):
-    store: CustomImmutableStore = CustomImmutableStore()    
+    store: CustomImmutableStore = CustomImmutableStore()

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -5,6 +5,16 @@ from typing import NamedTuple
 DANGEROUS_GLOBAL = set()
 
 
+class CustomMutableStore(dict): pass
+class CustomImmutableStore(frozenset): pass
+
+def create_my_custom_immutable_data_store() -> CustomImmutableStore:
+    return CustomImmutableStore()
+    
+    
+def create_my_custom_mutable_data_store() -> CustomMutableStore:
+    return CustomMutableStore()
+
 class BadListDefault(NamedTuple):
     avgs: list[float] = []  # [dangerous-default-value]
     stds: list[float] = []  # [dangerous-default-value]

--- a/tests/functional/d/dangerous_default_value_namedtuple.py
+++ b/tests/functional/d/dangerous_default_value_namedtuple.py
@@ -1,11 +1,11 @@
-# pylint: disable=missing-docstring, use-list-literal, use-dict-literal
+# pylint: disable=missing-module-docstring, missing-class-docstring, use-list-literal, use-dict-literal
 import collections
-from typing import List, NamedTuple
+from typing import NamedTuple
 
 
 class BadListDefault(NamedTuple):
-    avgs: List[float] = []  # [dangerous-default-value]
-    stds: List[float] = []  # [dangerous-default-value]
+    avgs: list[float] = []  # [dangerous-default-value]
+    stds: list[float] = []  # [dangerous-default-value]
 
 
 class BadDictDefault(NamedTuple):

--- a/tests/functional/d/dangerous_default_value_namedtuple.txt
+++ b/tests/functional/d/dangerous_default_value_namedtuple.txt
@@ -1,0 +1,9 @@
+dangerous-default-value:7:4:7:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:8:4:8:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:12:4:12:19:BadDictDefault:Dangerous default value {} as argument:UNDEFINED
+dangerous-default-value:16:4:16:22:BadSetDefault:Dangerous default value set() (builtins.set) as argument:UNDEFINED
+dangerous-default-value:20:4:20:23:BadSetLiteralDefault:Dangerous default value set() as argument:UNDEFINED
+dangerous-default-value:24:4:24:24:BadListCallDefault:Dangerous default value list() (builtins.list) as argument:UNDEFINED
+dangerous-default-value:28:4:28:23:BadDictCallDefault:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
+dangerous-default-value:32:4:32:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
+dangerous-default-value:45:4:45:20:MixedNamedTuple:Dangerous default value [] as argument:UNDEFINED

--- a/tests/functional/d/dangerous_default_value_namedtuple.txt
+++ b/tests/functional/d/dangerous_default_value_namedtuple.txt
@@ -1,9 +1,10 @@
-dangerous-default-value:7:4:7:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:8:4:8:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:12:4:12:19:BadDictDefault:Dangerous default value {} as argument:UNDEFINED
-dangerous-default-value:16:4:16:22:BadSetDefault:Dangerous default value set() (builtins.set) as argument:UNDEFINED
-dangerous-default-value:20:4:20:23:BadSetLiteralDefault:Dangerous default value set() as argument:UNDEFINED
-dangerous-default-value:24:4:24:24:BadListCallDefault:Dangerous default value list() (builtins.list) as argument:UNDEFINED
-dangerous-default-value:28:4:28:23:BadDictCallDefault:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:32:4:32:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
-dangerous-default-value:45:4:45:20:MixedNamedTuple:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:12:4:12:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:13:4:13:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:17:4:17:19:BadDictDefault:Dangerous default value {} as argument:UNDEFINED
+dangerous-default-value:21:4:21:22:BadSetDefault:Dangerous default value set() (builtins.set) as argument:UNDEFINED
+dangerous-default-value:25:4:25:23:BadSetLiteralDefault:Dangerous default value set() as argument:UNDEFINED
+dangerous-default-value:29:4:29:24:BadListCallDefault:Dangerous default value list() (builtins.list) as argument:UNDEFINED
+dangerous-default-value:33:4:33:23:BadDictCallDefault:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
+dangerous-default-value:37:4:37:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
+dangerous-default-value:50:4:50:20:MixedNamedTuple:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:59:4:59:33:GlobalDangerousDefault:Dangerous default value DANGEROUS_GLOBAL (builtins.set) as argument:UNDEFINED

--- a/tests/functional/d/dangerous_default_value_namedtuple.txt
+++ b/tests/functional/d/dangerous_default_value_namedtuple.txt
@@ -1,10 +1,10 @@
-dangerous-default-value:12:4:12:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:13:4:13:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:17:4:17:19:BadDictDefault:Dangerous default value {} as argument:UNDEFINED
-dangerous-default-value:21:4:21:22:BadSetDefault:Dangerous default value set() (builtins.set) as argument:UNDEFINED
-dangerous-default-value:25:4:25:23:BadSetLiteralDefault:Dangerous default value set() as argument:UNDEFINED
-dangerous-default-value:29:4:29:24:BadListCallDefault:Dangerous default value list() (builtins.list) as argument:UNDEFINED
-dangerous-default-value:33:4:33:23:BadDictCallDefault:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:37:4:37:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
-dangerous-default-value:50:4:50:20:MixedNamedTuple:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:59:4:59:33:GlobalDangerousDefault:Dangerous default value DANGEROUS_GLOBAL (builtins.set) as argument:UNDEFINED
+dangerous-default-value:9:4:9:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:10:4:10:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:14:4:14:19:BadDictDefault:Dangerous default value {} as argument:UNDEFINED
+dangerous-default-value:18:4:18:22:BadSetDefault:Dangerous default value set() (builtins.set) as argument:UNDEFINED
+dangerous-default-value:22:4:22:23:BadSetLiteralDefault:Dangerous default value set() as argument:UNDEFINED
+dangerous-default-value:26:4:26:24:BadListCallDefault:Dangerous default value list() (builtins.list) as argument:UNDEFINED
+dangerous-default-value:30:4:30:23:BadDictCallDefault:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
+dangerous-default-value:34:4:34:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
+dangerous-default-value:47:4:47:20:MixedNamedTuple:Dangerous default value [] as argument:UNDEFINED
+dangerous-default-value:56:4:56:33:GlobalDangerousDefault:Dangerous default value DANGEROUS_GLOBAL (builtins.set) as argument:UNDEFINED

--- a/tests/functional/d/dangerous_default_value_namedtuple.txt
+++ b/tests/functional/d/dangerous_default_value_namedtuple.txt
@@ -1,10 +1,11 @@
-dangerous-default-value:9:4:9:26:BadListDefault:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:10:4:10:26:BadListDefault:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:14:4:14:19:BadDictDefault:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:18:4:18:22:BadSetDefault:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:22:4:22:23:BadSetLiteralDefault:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:26:4:26:24:BadListCallDefault:Dangerous default value list() as argument:INFERENCE
-dangerous-default-value:30:4:30:23:BadDictCallDefault:Dangerous default value dict() as argument:INFERENCE
-dangerous-default-value:34:4:34:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:INFERENCE
-dangerous-default-value:47:4:47:20:MixedNamedTuple:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:56:4:56:33:GlobalDangerousDefault:Dangerous default value DANGEROUS_GLOBAL (builtins.set) as argument:INFERENCE
+dangerous-default-value:19:4:19:26:BadListDefault:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:20:4:20:26:BadListDefault:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:24:4:24:19:BadDictDefault:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:28:4:28:22:BadSetDefault:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:32:4:32:23:BadSetLiteralDefault:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:36:4:36:24:BadListCallDefault:Dangerous default value list() as argument:INFERENCE
+dangerous-default-value:40:4:40:23:BadDictCallDefault:Dangerous default value dict() as argument:INFERENCE
+dangerous-default-value:44:4:44:50:BadDequeDefault:Dangerous default value deque() as argument:INFERENCE
+dangerous-default-value:57:4:57:20:MixedNamedTuple:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:66:4:66:33:GlobalDangerousDefault:Dangerous default value DANGEROUS_GLOBAL (builtins.set) as argument:INFERENCE
+dangerous-default-value:70:4:70:52:BadCustomStoreDefault:Dangerous default value CustomMutableStore() as argument:INFERENCE

--- a/tests/functional/d/dangerous_default_value_namedtuple.txt
+++ b/tests/functional/d/dangerous_default_value_namedtuple.txt
@@ -3,8 +3,8 @@ dangerous-default-value:10:4:10:26:BadListDefault:Dangerous default value [] as 
 dangerous-default-value:14:4:14:19:BadDictDefault:Dangerous default value {} as argument:INFERENCE
 dangerous-default-value:18:4:18:22:BadSetDefault:Dangerous default value set() as argument:INFERENCE
 dangerous-default-value:22:4:22:23:BadSetLiteralDefault:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:26:4:26:24:BadListCallDefault:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:30:4:30:23:BadDictCallDefault:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:34:4:34:50:BadDequeDefault:Dangerous default value collections.deque() as argument:INFERENCE
+dangerous-default-value:26:4:26:24:BadListCallDefault:Dangerous default value list() as argument:INFERENCE
+dangerous-default-value:30:4:30:23:BadDictCallDefault:Dangerous default value dict() as argument:INFERENCE
+dangerous-default-value:34:4:34:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:INFERENCE
 dangerous-default-value:47:4:47:20:MixedNamedTuple:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:56:4:56:33:GlobalDangerousDefault:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:56:4:56:33:GlobalDangerousDefault:Dangerous default value DANGEROUS_GLOBAL (builtins.set) as argument:INFERENCE

--- a/tests/functional/d/dangerous_default_value_namedtuple.txt
+++ b/tests/functional/d/dangerous_default_value_namedtuple.txt
@@ -1,10 +1,10 @@
-dangerous-default-value:9:4:9:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:10:4:10:26:BadListDefault:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:14:4:14:19:BadDictDefault:Dangerous default value {} as argument:UNDEFINED
-dangerous-default-value:18:4:18:22:BadSetDefault:Dangerous default value set() (builtins.set) as argument:UNDEFINED
-dangerous-default-value:22:4:22:23:BadSetLiteralDefault:Dangerous default value set() as argument:UNDEFINED
-dangerous-default-value:26:4:26:24:BadListCallDefault:Dangerous default value list() (builtins.list) as argument:UNDEFINED
-dangerous-default-value:30:4:30:23:BadDictCallDefault:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:34:4:34:50:BadDequeDefault:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
-dangerous-default-value:47:4:47:20:MixedNamedTuple:Dangerous default value [] as argument:UNDEFINED
-dangerous-default-value:56:4:56:33:GlobalDangerousDefault:Dangerous default value DANGEROUS_GLOBAL (builtins.set) as argument:UNDEFINED
+dangerous-default-value:9:4:9:26:BadListDefault:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:10:4:10:26:BadListDefault:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:14:4:14:19:BadDictDefault:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:18:4:18:22:BadSetDefault:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:22:4:22:23:BadSetLiteralDefault:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:26:4:26:24:BadListCallDefault:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:30:4:30:23:BadDictCallDefault:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:34:4:34:50:BadDequeDefault:Dangerous default value collections.deque() as argument:INFERENCE
+dangerous-default-value:47:4:47:20:MixedNamedTuple:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:56:4:56:33:GlobalDangerousDefault:Dangerous default value set() as argument:INFERENCE

--- a/tests/functional/g/generic_alias/generic_alias_side_effects.txt
+++ b/tests/functional/g/generic_alias/generic_alias_side_effects.txt
@@ -1,8 +1,8 @@
 dangerous-default-value:19:0:19:13:function4:Dangerous default value set() as argument:INFERENCE
-dangerous-default-value:27:0:27:13:function7:Dangerous default value {} as argument:INFERENCE
-dangerous-default-value:31:0:31:13:function8:Dangerous default value [] as argument:INFERENCE
-dangerous-default-value:35:0:35:14:function17:Dangerous default value collections.deque() as argument:INFERENCE
-dangerous-default-value:39:0:39:14:function18:Dangerous default value collections.ChainMap() as argument:INFERENCE
-dangerous-default-value:43:0:43:14:function19:Dangerous default value collections.Counter() as argument:INFERENCE
-dangerous-default-value:47:0:47:14:function20:Dangerous default value collections.OrderedDict() as argument:INFERENCE
-dangerous-default-value:51:0:51:14:function21:Dangerous default value collections.defaultdict() as argument:INFERENCE
+dangerous-default-value:27:0:27:13:function7:Dangerous default value dict() as argument:INFERENCE
+dangerous-default-value:31:0:31:13:function8:Dangerous default value list() as argument:INFERENCE
+dangerous-default-value:35:0:35:14:function17:Dangerous default value deque() (collections.deque) as argument:INFERENCE
+dangerous-default-value:39:0:39:14:function18:Dangerous default value ChainMap() (collections.ChainMap) as argument:INFERENCE
+dangerous-default-value:43:0:43:14:function19:Dangerous default value Counter() (collections.Counter) as argument:INFERENCE
+dangerous-default-value:47:0:47:14:function20:Dangerous default value OrderedDict() (collections.OrderedDict) as argument:INFERENCE
+dangerous-default-value:51:0:51:14:function21:Dangerous default value defaultdict() (collections.defaultdict) as argument:INFERENCE

--- a/tests/functional/g/generic_alias/generic_alias_side_effects.txt
+++ b/tests/functional/g/generic_alias/generic_alias_side_effects.txt
@@ -1,8 +1,8 @@
-dangerous-default-value:19:0:19:13:function4:Dangerous default value set() (builtins.set) as argument:UNDEFINED
-dangerous-default-value:27:0:27:13:function7:Dangerous default value dict() (builtins.dict) as argument:UNDEFINED
-dangerous-default-value:31:0:31:13:function8:Dangerous default value list() (builtins.list) as argument:UNDEFINED
-dangerous-default-value:35:0:35:14:function17:Dangerous default value deque() (collections.deque) as argument:UNDEFINED
-dangerous-default-value:39:0:39:14:function18:Dangerous default value ChainMap() (collections.ChainMap) as argument:UNDEFINED
-dangerous-default-value:43:0:43:14:function19:Dangerous default value Counter() (collections.Counter) as argument:UNDEFINED
-dangerous-default-value:47:0:47:14:function20:Dangerous default value OrderedDict() (collections.OrderedDict) as argument:UNDEFINED
-dangerous-default-value:51:0:51:14:function21:Dangerous default value defaultdict() (collections.defaultdict) as argument:UNDEFINED
+dangerous-default-value:19:0:19:13:function4:Dangerous default value set() as argument:INFERENCE
+dangerous-default-value:27:0:27:13:function7:Dangerous default value {} as argument:INFERENCE
+dangerous-default-value:31:0:31:13:function8:Dangerous default value [] as argument:INFERENCE
+dangerous-default-value:35:0:35:14:function17:Dangerous default value collections.deque() as argument:INFERENCE
+dangerous-default-value:39:0:39:14:function18:Dangerous default value collections.ChainMap() as argument:INFERENCE
+dangerous-default-value:43:0:43:14:function19:Dangerous default value collections.Counter() as argument:INFERENCE
+dangerous-default-value:47:0:47:14:function20:Dangerous default value collections.OrderedDict() as argument:INFERENCE
+dangerous-default-value:51:0:51:14:function21:Dangerous default value collections.defaultdict() as argument:INFERENCE

--- a/tests/functional/g/generic_alias/generic_alias_side_effects.txt
+++ b/tests/functional/g/generic_alias/generic_alias_side_effects.txt
@@ -1,8 +1,8 @@
 dangerous-default-value:19:0:19:13:function4:Dangerous default value set() as argument:INFERENCE
 dangerous-default-value:27:0:27:13:function7:Dangerous default value dict() as argument:INFERENCE
 dangerous-default-value:31:0:31:13:function8:Dangerous default value list() as argument:INFERENCE
-dangerous-default-value:35:0:35:14:function17:Dangerous default value deque() (collections.deque) as argument:INFERENCE
-dangerous-default-value:39:0:39:14:function18:Dangerous default value ChainMap() (collections.ChainMap) as argument:INFERENCE
-dangerous-default-value:43:0:43:14:function19:Dangerous default value Counter() (collections.Counter) as argument:INFERENCE
-dangerous-default-value:47:0:47:14:function20:Dangerous default value OrderedDict() (collections.OrderedDict) as argument:INFERENCE
-dangerous-default-value:51:0:51:14:function21:Dangerous default value defaultdict() (collections.defaultdict) as argument:INFERENCE
+dangerous-default-value:35:0:35:14:function17:Dangerous default value deque() as argument:INFERENCE
+dangerous-default-value:39:0:39:14:function18:Dangerous default value ChainMap() as argument:INFERENCE
+dangerous-default-value:43:0:43:14:function19:Dangerous default value Counter() as argument:INFERENCE
+dangerous-default-value:47:0:47:14:function20:Dangerous default value OrderedDict() as argument:INFERENCE
+dangerous-default-value:51:0:51:14:function21:Dangerous default value defaultdict() as argument:INFERENCE


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
Right now, pylint's `dangerous-default-value` (W0102) only catches mutable defaults on regular function and method arguments. But the exact same bug can happen with `typing.NamedTuple` field defaults and pylint stays silent about it.

```python
from typing import List, NamedTuple

class LibStats(NamedTuple):
    avgs: List[float] = []   # mutable default shared across all instances
    stds: List[float] = []   # same problem

lib_a = LibStats()
lib_b = LibStats()
lib_a.avgs.append(1.0)
assert lib_a.avgs != lib_b.avgs  # FAILS — list is shared
```

### Root cause

The existing `_check_dangerous_default` method is only triggered via `visit_functiondef`, which inspects `node.args.defaults`. When a class inherits from `typing.NamedTuple`, the field defaults are `AnnAssign` nodes inside a `ClassDef` body — the checker never sees them.

### What this PR does

Adds a new `_check_namedtuple_dangerous_defaults` method to `BasicChecker` that:

1. Detects classes inheriting from `typing.NamedTuple` (using the same `ancestor.qname()` pattern already used in `variables.py` and `design_analysis.py`)
2. Iterates over `AnnAssign` nodes in the class body
3. Infers the default value and checks it against the existing `DEFAULT_ARGUMENT_SYMBOLS` map
4. Emits `dangerous-default-value` on the specific field line

The check is called from `visit_classdef`, which was updated with the `@utils.only_required_for_messages("dangerous-default-value")` decorator.

### Code change

In `pylint/checkers/base/basic_checker.py`:

```diff
-    def visit_classdef(self, _: nodes.ClassDef) -> None:
+    @utils.only_required_for_messages("dangerous-default-value")
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
         """Check module name, docstring and redefinition
         increment branch counter.
         """
         self.linter.stats.node_count["klass"] += 1
+        self._check_namedtuple_dangerous_defaults(node)
```

The new `_check_namedtuple_dangerous_defaults` method reuses the same mutable-default detection logic from `_check_dangerous_default`, applied to `AnnAssign.value` nodes instead of function argument defaults.

### Tests

Added a new functional test `dangerous_default_value_namedtuple.py` covering:
- `[]`, `{}`, `set()`, `{1, 2}` (set literal), `list()`, `dict()`, `collections.deque()` defaults → all emit W0102
- Safe defaults (`str`, `int`, `bool`, `tuple`, `frozenset`) → no warning
- Mixed classes (some safe, some mutable fields)
- Classes with no defaults at all

Closes #3716

### Checklist
- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``