### PR TITLE
Refactor check docs exception test parametrization

### DIFF
--- a/tests/extensions/test_check_docs_utils.py
+++ b/tests/extensions/test_check_docs_utils.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import astroid
 import pytest
-from astroid import nodes
 
 from pylint.extensions import _check_docs_utils as utils
 
@@ -23,45 +22,45 @@ def test_space_indentation(string: str, count: int) -> None:
 
 
 @pytest.mark.parametrize(
-    "raise_node,expected",
+    "code,expected",
     [
         (
-            astroid.extract_node("""
+            """
     def my_func():
         raise NotImplementedError #@
-    """),
+    """,
             {"NotImplementedError"},
         ),
         (
-            astroid.extract_node("""
+            """
     def my_func():
         raise NotImplementedError("Not implemented!") #@
-    """),
+    """,
             {"NotImplementedError"},
         ),
         (
-            astroid.extract_node("""
+            """
     def my_func():
         try:
             fake_func()
         except RuntimeError:
             raise #@
-    """),
+    """,
             {"RuntimeError"},
         ),
         (
-            astroid.extract_node("""
+            """
     def my_func():
         try:
             fake_func()
         except RuntimeError:
             if another_func():
                 raise #@
-    """),
+    """,
             {"RuntimeError"},
         ),
         (
-            astroid.extract_node("""
+            """
     def my_func():
         try:
             fake_func()
@@ -71,11 +70,11 @@ def test_space_indentation(string: str, count: int) -> None:
                 raise #@
             except NameError:
                 pass
-    """),
+    """,
             {"RuntimeError"},
         ),
         (
-            astroid.extract_node("""
+            """
     def my_func():
         try:
             fake_func()
@@ -84,43 +83,44 @@ def test_space_indentation(string: str, count: int) -> None:
                 another_func()
             except NameError:
                 raise #@
-    """),
+    """,
             {"NameError"},
         ),
         (
-            astroid.extract_node("""
+            """
     def my_func():
         try:
             fake_func()
         except:
             raise #@
-    """),
+    """,
             set(),
         ),
         (
-            astroid.extract_node("""
+            """
     def my_func():
         try:
             fake_func()
         except (RuntimeError, ValueError):
             raise #@
-    """),
+    """,
             {"RuntimeError", "ValueError"},
         ),
         (
-            astroid.extract_node("""
+            """
     import not_a_module
     def my_func():
         try:
             fake_func()
         except not_a_module.Error:
             raise #@
-    """),
+    """,
             set(),
         ),
     ],
 )
-def test_exception(raise_node: nodes.NodeNG, expected: set[str]) -> None:
+def test_exception(code: str, expected: set[str]) -> None:
+    raise_node = astroid.extract_node(code)
     found_nodes = utils.possible_exc_types(raise_node)
     for node in found_nodes:
         assert isinstance(node, astroid.nodes.ClassDef)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
|  | :bug: Bug fix          |
|  | :sparkles: New feature |
| ✓   | :hammer: Refactoring   |
|  | :scroll: Docs          |

## Description

Refactors `test_exception` in `tests/extensions/test_check_docs_utils.py` to defer `astroid.extract_node()` calls from parametrize-time to test-time.

### Changes

- Move `astroid.extract_node()` from `@pytest.mark.parametrize` into the test body. Previously, every parametrized case called `extract_node()` at module collection time. Now the raw code strings are passed as parameters and `extract_node()` is called inside the test function, improving readability and avoiding unnecessary work during collection.
- Remove unused `from astroid import nodes` import.
- Rename parameter `raise_node` → `code` to better reflect that the parameter is now a string, not an AST node.

Refs #10985

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Refs #9143 

### Checklist
- [x] Relate your change to an issue in the tracker if such an issue exists
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.