### PR TITLE
Fix false positive for inconsistent-return-statements on unbound NoReturn methods

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -367,6 +367,7 @@ uid
 uml
 un
 unary
+unboundmethod
 unflattens
 unhandled
 unicode

--- a/doc/whatsnew/fragments/9692.false_positive
+++ b/doc/whatsnew/fragments/9692.false_positive
@@ -1,0 +1,7 @@
+Fix a false positive for ``inconsistent-return-statements`` when an instance
+method annotated with ``NoReturn`` (or ``Never``) is called via the class
+rather than an instance (e.g. ``MyClass.raise_method(obj)``). The unbound
+method form is now recognised as never returning, matching the existing
+behaviour for the bound-method form.
+
+Closes #9692

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2017,7 +2017,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 if utils.is_terminating_func(node):
                     return True
                 return any(
-                    isinstance(maybe_func, (nodes.FunctionDef, bases.BoundMethod))
+                    isinstance(
+                        maybe_func,
+                        (nodes.FunctionDef, bases.BoundMethod, bases.UnboundMethod),
+                    )
                     and self._is_function_def_never_returning(maybe_func)
                     for maybe_func in utils.infer_all(node.func)
                 )
@@ -2058,12 +2061,14 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         return False
 
     def _is_function_def_never_returning(
-        self, node: nodes.FunctionDef | astroid.BoundMethod
+        self,
+        node: nodes.FunctionDef | astroid.BoundMethod | astroid.UnboundMethod,
     ) -> bool:
         """Return True if the function never returns, False otherwise.
 
         Args:
-            node (nodes.FunctionDef or astroid.BoundMethod): function definition node to be analyzed.
+            node (nodes.FunctionDef, astroid.BoundMethod, or astroid.UnboundMethod):
+                function definition node to be analyzed.
 
         Returns:
             bool: True if the function never returns, False otherwise.

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.py
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.py
@@ -1,5 +1,5 @@
 """Testing inconsistent returns involving typing.NoReturn annotations."""
-# pylint: disable=missing-docstring, invalid-name
+# pylint: disable=missing-docstring, invalid-name, too-few-public-methods
 
 import sys
 import typing
@@ -103,6 +103,21 @@ class ClassUnderTest:
             return n
         except ValueError:
             self._falsely_no_return_method()
+
+
+# https://github.com/pylint-dev/pylint/issues/9692
+class ClassWithNoReturnMethod:
+    def raise_instance_method(self) -> NoReturn:
+        raise RuntimeError
+
+def bug_pylint_9692(obj):
+    """Every return is consistent because raise_instance_method is annotated
+    NoReturn, even when called as an unbound method via the class.
+    """
+    if __name__:
+        return None
+    ClassWithNoReturnMethod.raise_instance_method(obj)
+
 
 # https://github.com/pylint-dev/pylint/issues/7565
 def never_is_handled_like_noreturn(arg: typing.Union[int, str]) -> int:

--- a/tests/functional/i/inconsistent/inconsistent_returns_noreturn.txt
+++ b/tests/functional/i/inconsistent/inconsistent_returns_noreturn.txt
@@ -1,3 +1,3 @@
 inconsistent-return-statements:40:0:40:25:bug_pylint_4122_wrong:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
 inconsistent-return-statements:85:4:85:29:ClassUnderTest.bug_pylint_8747_wrong:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
-inconsistent-return-statements:133:0:133:18:ensure_message:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED
+inconsistent-return-statements:148:0:148:18:ensure_message:Either all return statements in a function should return an expression, or none of them should.:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #9692.

Calling an instance method via the class (e.g. `MyClass.raise_method(obj)`)
is inferred by astroid as an `UnboundMethod` rather than a `BoundMethod`.
`RefactoringChecker._is_node_return_ended` only looked for `FunctionDef`
and `BoundMethod` when determining whether a `Call` never returns, so the
unbound form of a `NoReturn`-annotated method was missed and
`inconsistent-return-statements` was emitted incorrectly. Test case 4d
from the linked issue is the canonical example:

```python
from typing import NoReturn

class MyClass:
    def raise_instance_method(self) -> NoReturn:
        raise RuntimeError

def test_case_4d(obj):  # was flagged R1710, shouldn't be
    if __name__:
        return None
    MyClass.raise_instance_method(obj)
```

The fix adds `bases.UnboundMethod` to the isinstance check in
`_is_node_return_ended` and widens the type signature of
`_is_function_def_never_returning` accordingly. `UnboundMethod` already
proxies `qname()` and `returns` to the underlying `FunctionDef`, so the
existing inspection logic works unchanged once the type is accepted.

A regression test was added to `inconsistent_returns_noreturn.py`; with
the fix reverted the test correctly fails with an unexpected
`inconsistent-return-statements` on the new function.