### PR TITLE
Fix false positive E0203 for bare type annotations

### DIFF
--- a/doc/whatsnew/fragments/11015.false_positive
+++ b/doc/whatsnew/fragments/11015.false_positive
@@ -1,0 +1,4 @@
+Fix ``access-member-before-definition`` false positive for bare type annotations
+(``self.x: Type``) that don't assign a value.
+
+Refs #11015

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -2044,6 +2044,15 @@ a metaclass class method.",
             else:
                 # filter out augment assignment nodes
                 defstmts = [stmt for stmt in defstmts if stmt not in nodes_lst]
+                # filter out bare annotations (self.x: Type) with no value
+                defstmts = [
+                    stmt
+                    for stmt in defstmts
+                    if not (
+                        isinstance(stmt.parent, nodes.AnnAssign)
+                        and stmt.parent.value is None
+                    )
+                ]
                 if not defstmts:
                     # only augment assignment for this node, no-member should be
                     # triggered by the typecheck checker

--- a/tests/functional/a/access/access_member_before_definition.py
+++ b/tests/functional/a/access/access_member_before_definition.py
@@ -45,3 +45,15 @@ class MyClass1:
     def __init__(self):
         self.first += 5  # [access-member-before-definition]
         self.first = 0
+
+
+class BareAnnotationNotADefinition:
+    def process(self):
+        _ = self.widget
+        self.widget: int
+
+
+class AnnotatedAssignmentIsADefinition:
+    def process(self):
+        _ = self.widget  # [access-member-before-definition]
+        self.widget: int = 5

--- a/tests/functional/a/access/access_member_before_definition.py
+++ b/tests/functional/a/access/access_member_before_definition.py
@@ -49,7 +49,7 @@ class MyClass1:
 
 class BareAnnotationNotADefinition:
     def process(self):
-        _ = self.widget
+        _ = self.widget  # known false negative
         self.widget: int
 
 

--- a/tests/functional/a/access/access_member_before_definition.txt
+++ b/tests/functional/a/access/access_member_before_definition.txt
@@ -1,3 +1,4 @@
 access-member-before-definition:9:15:9:25:Aaaa.__init__:Access to member '_var2' before its definition line 10:UNDEFINED
 access-member-before-definition:28:19:28:29:Bbbb.catchme:Access to member '_repo' before its definition line 30:UNDEFINED
 access-member-before-definition:46:8:46:18:MyClass1.__init__:Access to member 'first' before its definition line 47:UNDEFINED
+access-member-before-definition:58:12:58:23:AnnotatedAssignmentIsADefinition.process:Access to member 'widget' before its definition line 59:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR fixes a false positive `access-member-before-definition` (E0203) where a bare type annotation like `self.widget: int` was treated as an attribute definition. Bare annotations are type hints that don't assign a value - they do nothing at runtime - so earlier reads of the same attribute in the method shouldn't be flagged. 

Example:
```python
class MyClass:
    def process(self):
        print(self.widget)   # was: E0203 (false positive)
        self.widget: int     # not a definition, just a hint
```
