### PR TITLE
Preserve falsey explicit locations in ``add_message``

### DIFF
--- a/doc/whatsnew/fragments/11020.bugfix
+++ b/doc/whatsnew/fragments/11020.bugfix
@@ -1,0 +1,3 @@
+Fix ``add_message`` silently overwriting an explicit ``col_offset=0`` (or any other zero-valued ``line``/``end_lineno``/``end_col_offset``) with the AST node's value. The internal ``_add_one_message`` helper used a falsey check (``if not col_offset:``) to detect an omitted argument, which incorrectly treated a legitimate ``0`` the same as ``None``. It now uses an identity check against ``None``.
+
+Refs #11020

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1235,22 +1235,22 @@ class PyLinter(
         # Look up "location" data of node if not yet supplied
         if node:
             if node.position:
-                if not line:
+                if line is None:
                     line = node.position.lineno
-                if not col_offset:
+                if col_offset is None:
                     col_offset = node.position.col_offset
-                if not end_lineno:
+                if end_lineno is None:
                     end_lineno = node.position.end_lineno
-                if not end_col_offset:
+                if end_col_offset is None:
                     end_col_offset = node.position.end_col_offset
             else:
-                if not line:
+                if line is None:
                     line = node.fromlineno
-                if not col_offset:
+                if col_offset is None:
                     col_offset = node.col_offset
-                if not end_lineno:
+                if end_lineno is None:
                     end_lineno = node.end_lineno
-                if not end_col_offset:
+                if end_col_offset is None:
                     end_col_offset = node.end_col_offset
 
         # should this message be displayed

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -515,6 +515,20 @@ def test_addmessage(linter: PyLinter) -> None:
     )
 
 
+def test_addmessage_preserves_explicit_zero_col_offset(linter: PyLinter) -> None:
+    """An explicit ``col_offset=0`` from the caller must not be overwritten
+    by the node's value (``not 0`` is True so the old falsey check was buggy).
+    """
+    linter.set_reporter(testutils.GenericTestReporter())
+    linter.open()
+    linter.set_current_module("m")
+    module_node = astroid.parse("\n\nfunc(arg)", module_name="m")
+    arg_node = module_node.body[0].value.args[0]  # ``arg`` — col_offset == 5
+    assert arg_node.col_offset != 0  # sanity-check fixture
+    linter.add_message("C0321", node=arg_node, col_offset=0)
+    assert linter.reporter.messages[0].location.column == 0
+
+
 def test_addmessage_invalid(linter: PyLinter) -> None:
     linter.set_reporter(testutils.GenericTestReporter())
     linter.open()


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |


## Description

``_add_one_message`` used ``if not col_offset:`` (and likewise for ``line``/``end_lineno``/``end_col_offset``) to detect "caller didn't supply this field". Since ``not 0`` is ``True``, an explicit zero from the caller — which is a valid column index — was silently overwritten by the node's value.

Switch to ``X is None`` so we only fill from the node when the field was actually omitted.

Refs #10894
