### PR TITLE
Tighten the typing in ``pylint.message`` and around message's confidence

### DIFF
--- a/doc/whatsnew/fragments/11018.breaking
+++ b/doc/whatsnew/fragments/11018.breaking
@@ -1,0 +1,12 @@
+The ``confidence`` parameter is no longer nullable on any APIs except for
+``is_message_enabled`` (where ``confidence=None`` means "don't filter by
+confidence"). The default became ``interfaces.UNDEFINED`` (an immutable value);
+the behavior is unchanged unless you were passing an explicit ``None``. This
+avoids a runtime check in multiple function to set the default value conditionally.
+
+The ``constants.MSG_STATE_*`` integer were replaced by a ``MessageDisableReason`` enum.
+The old names remain as deprecated aliases pointing at the enum members.
+``MessageDisableReason`` is an ``IntEnum`` so existing code comparing the return of
+``_get_message_state_scope`` to the literal ``0`` / ``1`` / ``2`` keeps working.
+
+Refs #11018

--- a/doc/whatsnew/fragments/11018.internal
+++ b/doc/whatsnew/fragments/11018.internal
@@ -1,8 +1,0 @@
-The ``confidence`` parameter is no longer nullable on any APIs except for
-``is_message_enabled`` (where ``confidence=None`` means "don't filter by
-confidence"). The default became ``interfaces.UNDEFINED`` (an immutable value);
-the behavior is unchanged unless you were passing an explicit ``None``.
-
-This avoid a runtime check in multiple function to set the default value conditionally.
-
-Refs #11018

--- a/doc/whatsnew/fragments/11018.internal
+++ b/doc/whatsnew/fragments/11018.internal
@@ -1,0 +1,8 @@
+The ``confidence`` parameter is no longer nullable on any APIs except for
+``is_message_enabled`` (where ``confidence=None`` means "don't filter by
+confidence"). The default became ``interfaces.UNDEFINED`` (an immutable value);
+the behavior is unchanged unless you were passing an explicit ``None``.
+
+This avoid a runtime check in multiple function to set the default value conditionally.
+
+Refs #11018

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -16,7 +16,7 @@ from astroid import nodes
 from pylint.config.arguments_provider import _ArgumentsProvider
 from pylint.constants import _MSG_ORDER, MAIN_CHECKER_NAME, WarningScope
 from pylint.exceptions import InvalidMessageError
-from pylint.interfaces import Confidence
+from pylint.interfaces import UNDEFINED, Confidence
 from pylint.message.message_definition import MessageDefinition
 from pylint.typing import (
     ExtraMessageOptions,
@@ -145,7 +145,7 @@ class BaseChecker(_ArgumentsProvider):
         line: int | None = None,
         node: nodes.NodeNG | None = None,
         args: Any = None,
-        confidence: Confidence | None = None,
+        confidence: Confidence = UNDEFINED,
         col_offset: int | None = None,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,

--- a/pylint/constants.py
+++ b/pylint/constants.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import enum
 import os
 import platform
 import sys
@@ -22,10 +23,35 @@ IS_PYPY = platform.python_implementation() == "PyPy"
 
 PY_EXTS = (".py", ".pyc", ".pyo", ".pyw", ".so", ".dll")
 
-MSG_STATE_CONFIDENCE = 2
+
+class MessageDisableReason(enum.IntEnum):
+    """Why a message was filtered out or disabled.
+
+    Returned by :meth:`_MessageStateHandler._get_message_state_scope` and
+    consumed by :meth:`FileState.handle_ignored_message`.
+
+    Backed by ``IntEnum`` so the deprecated ``MSG_STATE_*`` integer
+    constants (kept as aliases below) compare equal to the matching
+    enum member — code comparing the return of
+    ``_get_message_state_scope`` to ``0`` / ``1`` / ``2`` keeps working.
+    """
+
+    CONFIG = 0
+    """Disabled globally via configuration (.pylintrc, CLI flags)."""
+
+    MODULE = 1
+    """Disabled by an inline ``# pylint: disable=...`` pragma."""
+
+    CONFIDENCE = 2
+    """Filtered out by the ``--confidence`` setting."""
+
+
+# Old aliases. Prefer ``MessageDisableReason`` for new code.
+MSG_STATE_SCOPE_CONFIG = MessageDisableReason.CONFIG
+MSG_STATE_SCOPE_MODULE = MessageDisableReason.MODULE
+MSG_STATE_CONFIDENCE = MessageDisableReason.CONFIDENCE
+
 _MSG_ORDER = "EWRCIF"
-MSG_STATE_SCOPE_CONFIG = 0
-MSG_STATE_SCOPE_MODULE = 1
 
 # The line/node distinction does not apply to fatal errors and reports.
 _SCOPE_EXEMPT = "FR"

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -6,15 +6,13 @@ from __future__ import annotations
 
 import tokenize
 from collections import defaultdict
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pylint import exceptions, interfaces
 from pylint.constants import (
-    MSG_STATE_CONFIDENCE,
-    MSG_STATE_SCOPE_CONFIG,
-    MSG_STATE_SCOPE_MODULE,
     MSG_TYPES,
     MSG_TYPES_LONG,
+    MessageDisableReason,
 )
 from pylint.interfaces import HIGH
 from pylint.message import MessageDefinition
@@ -263,15 +261,15 @@ class _MessageStateHandler:
         msgid: str,
         line: int | None,
         confidence: interfaces.Confidence,
-    ) -> Literal[0, 1, 2] | None:
+    ) -> MessageDisableReason | None:
         """Return the scope at which the message was disabled / filtered."""
         if confidence.name not in self.linter.config.confidence:
-            return MSG_STATE_CONFIDENCE  # type: ignore[return-value] # mypy does not infer Literal correctly
+            return MessageDisableReason.CONFIDENCE
         try:
             if line in self.linter.file_state._module_msgs_state[msgid]:
-                return MSG_STATE_SCOPE_MODULE  # type: ignore[return-value]
+                return MessageDisableReason.MODULE
         except (KeyError, TypeError):
-            return MSG_STATE_SCOPE_CONFIG  # type: ignore[return-value]
+            return MessageDisableReason.CONFIG
         return None
 
     def _is_one_message_enabled(self, msgid: str, line: int | None) -> bool:

--- a/pylint/lint/message_state_handler.py
+++ b/pylint/lint/message_state_handler.py
@@ -261,12 +261,10 @@ class _MessageStateHandler:
     def _get_message_state_scope(
         self,
         msgid: str,
-        line: int | None = None,
-        confidence: interfaces.Confidence | None = None,
+        line: int | None,
+        confidence: interfaces.Confidence,
     ) -> Literal[0, 1, 2] | None:
-        """Returns the scope at which a message was enabled/disabled."""
-        if confidence is None:
-            confidence = interfaces.UNDEFINED
+        """Return the scope at which the message was disabled / filtered."""
         if confidence.name not in self.linter.config.confidence:
             return MSG_STATE_CONFIDENCE  # type: ignore[return-value] # mypy does not infer Literal correctly
         try:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1222,7 +1222,7 @@ class PyLinter(
         line: int | None,
         node: nodes.NodeNG | None,
         args: Any | None,
-        confidence: interfaces.Confidence | None,
+        confidence: interfaces.Confidence,
         col_offset: int | None,
         end_lineno: int | None,
         end_col_offset: int | None,
@@ -1314,7 +1314,7 @@ class PyLinter(
         line: int | None = None,
         node: nodes.NodeNG | None = None,
         args: Any | None = None,
-        confidence: interfaces.Confidence | None = None,
+        confidence: interfaces.Confidence = interfaces.UNDEFINED,
         col_offset: int | None = None,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
@@ -1327,8 +1327,6 @@ class PyLinter(
         provide line if the line number is different), raw and token checkers
         must provide the line argument.
         """
-        if confidence is None:
-            confidence = interfaces.UNDEFINED
         message_definitions = self.msgs_store.get_message_definitions(msgid)
         for message_definition in message_definitions:
             self._add_one_message(
@@ -1347,7 +1345,7 @@ class PyLinter(
         msgid: str,
         line: int,
         node: nodes.NodeNG | None = None,
-        confidence: interfaces.Confidence | None = interfaces.UNDEFINED,
+        confidence: interfaces.Confidence = interfaces.UNDEFINED,
     ) -> None:
         """Prepares a message to be added to the ignored message storage.
 

--- a/pylint/message/message.py
+++ b/pylint/message/message.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 
 from pylint.constants import MSG_TYPES
-from pylint.interfaces import UNDEFINED, Confidence
+from pylint.interfaces import Confidence
 from pylint.typing import MessageLocationTuple
 
 
@@ -36,14 +36,14 @@ class Message:  # pylint: disable=too-many-instance-attributes
         symbol: str,
         location: MessageLocationTuple,
         msg: str,
-        confidence: Confidence | None,
+        confidence: Confidence,
     ) -> None:
         self.msg_id = msg_id
         self.symbol = symbol
         self.msg = msg
         self.C = msg_id[0]
         self.category = MSG_TYPES[msg_id[0]]
-        self.confidence = confidence or UNDEFINED
+        self.confidence = confidence
         self.abspath = location.abspath
         self.path = location.path
         self.module = location.module

--- a/pylint/testutils/output_line.py
+++ b/pylint/testutils/output_line.py
@@ -20,7 +20,7 @@ class MessageTest(NamedTuple):
     line: int | None = None
     node: nodes.NodeNG | None = None
     args: Any | None = None
-    confidence: Confidence | None = UNDEFINED
+    confidence: Confidence = UNDEFINED
     col_offset: int | None = None
     end_line: int | None = None
     end_col_offset: int | None = None

--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -35,16 +35,12 @@ class UnittestLinter(PyLinter):
         # TODO: Make node non optional
         node: nodes.NodeNG | None = None,
         args: Any = None,
-        confidence: Confidence | None = None,
+        confidence: Confidence = UNDEFINED,
         col_offset: int | None = None,
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
     ) -> None:
         """Add a MessageTest to the _messages attribute of the linter class."""
-        # If confidence is None we set it to UNDEFINED as well in PyLinter
-        if confidence is None:
-            confidence = UNDEFINED
-
         # Look up "location" data of node if not yet supplied
         if node:
             if node.position:

--- a/pylint/utils/file_state.py
+++ b/pylint/utils/file_state.py
@@ -13,7 +13,7 @@ from astroid import nodes
 
 from pylint.constants import (
     INCOMPATIBLE_WITH_USELESS_SUPPRESSION,
-    MSG_STATE_SCOPE_MODULE,
+    MessageDisableReason,
     WarningScope,
 )
 
@@ -207,15 +207,18 @@ class FileState:
             self._raw_module_msgs_state[msg.msgid] = {line: status}
 
     def handle_ignored_message(
-        self, state_scope: Literal[0, 1, 2] | None, msgid: str, line: int | None
+        self,
+        state_scope: MessageDisableReason | None,
+        msgid: str,
+        line: int | None,
     ) -> None:
         """Report an ignored message.
 
-        state_scope is either MSG_STATE_SCOPE_MODULE or MSG_STATE_SCOPE_CONFIG,
-        depending on whether the message was disabled locally in the module,
-        or globally.
+        ``state_scope`` indicates whether the message was disabled
+        inline in the module, globally in the configuration, or filtered
+        out by the ``--confidence`` setting.
         """
-        if state_scope == MSG_STATE_SCOPE_MODULE:
+        if state_scope == MessageDisableReason.MODULE:
             assert isinstance(line, int)  # should always be int inside module scope
 
             try:

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -274,15 +274,23 @@ def test_message_state_scope(initialized_linter: PyLinter) -> None:
 
     linter = initialized_linter
     linter.disable("C0202")
-    assert MSG_STATE_SCOPE_CONFIG == linter._get_message_state_scope("C0202")
+    assert MSG_STATE_SCOPE_CONFIG == linter._get_message_state_scope(
+        "C0202", None, interfaces.UNDEFINED
+    )
     linter.disable("W0101", scope="module", line=3)
-    assert MSG_STATE_SCOPE_CONFIG == linter._get_message_state_scope("C0202")
-    assert MSG_STATE_SCOPE_MODULE == linter._get_message_state_scope("W0101", 3)
+    assert MSG_STATE_SCOPE_CONFIG == linter._get_message_state_scope(
+        "C0202", None, interfaces.UNDEFINED
+    )
+    assert MSG_STATE_SCOPE_MODULE == linter._get_message_state_scope(
+        "W0101", 3, interfaces.UNDEFINED
+    )
     linter.enable("W0102", scope="module", line=3)
-    assert MSG_STATE_SCOPE_MODULE == linter._get_message_state_scope("W0102", 3)
+    assert MSG_STATE_SCOPE_MODULE == linter._get_message_state_scope(
+        "W0102", 3, interfaces.UNDEFINED
+    )
     linter.config = FakeConfig()
     assert MSG_STATE_CONFIDENCE == linter._get_message_state_scope(
-        "this-is-bad", confidence=interfaces.INFERENCE
+        "this-is-bad", None, confidence=interfaces.INFERENCE
     )
 
 

--- a/tests/reporters/unittest_json_reporter.py
+++ b/tests/reporters/unittest_json_reporter.py
@@ -241,7 +241,7 @@ def get_linter_result_for_v2(message: dict[str, Any]) -> list[dict[str, Any]]:
                     end_column=None,
                 ),
                 msg="This is the actual message",
-                confidence=None,
+                confidence=UNDEFINED,
             ),
             id="not-everything-defined",
         ),


### PR DESCRIPTION
## Type of Changes


|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The ``confidence`` parameter is no longer nullable on any APIs except for
``is_message_enabled`` (where ``confidence=None`` means "don't filter by
confidence"). The default became ``interfaces.UNDEFINED`` (an immutable value);
the behavior is unchanged unless you were passing an explicit ``None``.

This avoid a runtime check in multiple function to set the default value conditionally.

Refs #10894

