### PR TITLE
Fix crash when a name resolves to a dataclass-synthesized __init__

### DIFF
--- a/doc/whatsnew/fragments/11023.bugfix
+++ b/doc/whatsnew/fragments/11023.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the variable checker when a name resolves to a dataclass-synthesized ``__init__``, which has no line number.
+
+Closes #11023

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -159,6 +159,10 @@ def _detect_global_scope(
                 class B(C): ...
         class C: ...
     """
+    if defframe.lineno is None:
+        # ``defframe`` is a synthetic node, such as a dataclass-generated
+        # ``__init__``, so it has no source position to order against.
+        return False
     def_scope = scope = None
     if frame and frame.parent:
         scope = frame.parent.scope()

--- a/tests/functional/r/regression_02/regression_11023.py
+++ b/tests/functional/r/regression_02/regression_11023.py
@@ -1,0 +1,13 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11023.
+
+A dataclass-synthesized ``__init__`` has no line number, which crashed
+``_detect_global_scope`` while resolving a bare reference to it.
+"""
+from dataclasses import dataclass
+
+
+@dataclass
+class DataClass:
+    """A dataclass referencing its own synthesized ``__init__``."""
+
+    __init__  # [pointless-statement]

--- a/tests/functional/r/regression_02/regression_11023.txt
+++ b/tests/functional/r/regression_02/regression_11023.txt
@@ -1,0 +1,1 @@
+pointless-statement:13:4:13:12:DataClass:Statement seems to have no effect:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

``_detect_global_scope`` ordered two frames by line number, but a node synthesized by an astroid brain (such as the ``__init__`` generated for a ``@dataclass``) has ``lineno`` set to ``None``. Resolving a bare reference to such a member crashed with ``TypeError: '<' not supported between instances of 'int' and 'NoneType'``.

The only two non-``False`` returns of that function are ``< defframe.lineno`` comparisons, and a synthesized definition has no source ordering, so the function now returns ``False`` when ``defframe`` has no line number.

Closes #11023