### PR TITLE
Fix crash when ``NotImplemented`` is used as an ``if`` test

### DIFF
--- a/doc/whatsnew/fragments/11025.bugfix
+++ b/doc/whatsnew/fragments/11025.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the variables checker when ``NotImplemented`` is used as the test of an ``if`` statement, which raised a ``TypeError`` in a boolean context on Python 3.14.
+
+Closes #11025

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -730,8 +730,15 @@ scope_type : {self.scope_type}
                 only_search_else = False
                 continue
             val = inferred.value
-            only_search_if = only_search_if or (val != NotImplemented and val)
-            only_search_else = only_search_else and val != NotImplemented and not val
+            if val is NotImplemented:
+                # ``bool(NotImplemented)`` raises ``TypeError`` on Python 3.14+
+                # (and warned since 3.9). ``NotImplemented`` is the only value
+                # ``Const`` carries whose truthiness is undefined, so treat it
+                # like a non-``Const`` inference: we can't tell which branch runs.
+                only_search_else = False
+                continue
+            only_search_if = only_search_if or bool(val)
+            only_search_else = only_search_else and not val
 
         # Only search else branch when test condition is inferred to be false
         if all_inferred and only_search_else:

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -731,7 +731,7 @@ scope_type : {self.scope_type}
                 continue
             val = inferred.value
             only_search_if = only_search_if or (val != NotImplemented and val)
-            only_search_else = only_search_else and not val
+            only_search_else = only_search_else and val != NotImplemented and not val
 
         # Only search else branch when test condition is inferred to be false
         if all_inferred and only_search_else:

--- a/tests/functional/r/regression_02/regression_11025.py
+++ b/tests/functional/r/regression_02/regression_11025.py
@@ -1,0 +1,11 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11025.
+
+Using ``NotImplemented`` as an ``if`` test crashed the variables checker
+because ``not NotImplemented`` raises a ``TypeError`` in a boolean context
+on Python 3.14.
+"""
+
+if NotImplemented:
+    VALUE = 1
+
+print(VALUE)  # [possibly-used-before-assignment]

--- a/tests/functional/r/regression_02/regression_11025.txt
+++ b/tests/functional/r/regression_02/regression_11025.txt
@@ -1,0 +1,1 @@
+possibly-used-before-assignment:11:6:11:11::Possibly using variable 'VALUE' before assignment:CONTROL_FLOW


### PR DESCRIPTION


<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

``_inferred_to_define_name_raise_or_return_for_if_node`` evaluated ``not val`` on every inferred constant test value. On Python 3.14, ``not NotImplemented`` raises a ``TypeError`` because ``NotImplemented`` must not be used in a boolean context. The adjacent ``only_search_if`` line already guarded against ``NotImplemented``, so apply the same guard to ``only_search_else``.

Closes #11025
