### PR TITLE
Fix crash on non-constant ``TypeVar`` variance argument

### DIFF
--- a/doc/whatsnew/fragments/11022.bugfix
+++ b/doc/whatsnew/fragments/11022.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the name checker when a non-constant value is passed as the ``covariant`` or ``contravariant`` argument of a ``TypeVar``.
+
+Closes #11022

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -736,10 +736,10 @@ class NameChecker(_BasicChecker):
 
         name_arg = None
         for kw in keywords:
+            if not isinstance(kw.value, nodes.Const):
+                continue
             if variance == TypeVarVariance.double_variant:
                 pass
-            elif not isinstance(kw.value, nodes.Const):
-                continue
             elif kw.arg == "covariant" and kw.value.value:
                 variance = (
                     TypeVarVariance.covariant
@@ -752,8 +752,7 @@ class NameChecker(_BasicChecker):
                     if variance != TypeVarVariance.covariant
                     else TypeVarVariance.double_variant
                 )
-
-            if kw.arg == "name" and isinstance(kw.value, nodes.Const):
+            if kw.arg == "name":
                 name_arg = kw.value.value
 
         if name_arg is None and args and isinstance(args[0], nodes.Const):

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -736,10 +736,10 @@ class NameChecker(_BasicChecker):
 
         name_arg = None
         for kw in keywords:
-            if not isinstance(kw.value, nodes.Const):
-                continue
             if variance == TypeVarVariance.double_variant:
                 pass
+            elif not isinstance(kw.value, nodes.Const):
+                continue
             elif kw.arg == "covariant" and kw.value.value:
                 variance = (
                     TypeVarVariance.covariant
@@ -753,7 +753,7 @@ class NameChecker(_BasicChecker):
                     else TypeVarVariance.double_variant
                 )
 
-            if kw.arg == "name":
+            if kw.arg == "name" and isinstance(kw.value, nodes.Const):
                 name_arg = kw.value.value
 
         if name_arg is None and args and isinstance(args[0], nodes.Const):

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -738,13 +738,21 @@ class NameChecker(_BasicChecker):
         for kw in keywords:
             if variance == TypeVarVariance.double_variant:
                 pass
-            elif kw.arg == "covariant" and kw.value.value:
+            elif (
+                kw.arg == "covariant"
+                and isinstance(kw.value, nodes.Const)
+                and kw.value.value
+            ):
                 variance = (
                     TypeVarVariance.covariant
                     if variance != TypeVarVariance.contravariant
                     else TypeVarVariance.double_variant
                 )
-            elif kw.arg == "contravariant" and kw.value.value:
+            elif (
+                kw.arg == "contravariant"
+                and isinstance(kw.value, nodes.Const)
+                and kw.value.value
+            ):
                 variance = (
                     TypeVarVariance.contravariant
                     if variance != TypeVarVariance.covariant

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -736,30 +736,24 @@ class NameChecker(_BasicChecker):
 
         name_arg = None
         for kw in keywords:
+            if not isinstance(kw.value, nodes.Const):
+                continue
             if variance == TypeVarVariance.double_variant:
                 pass
-            elif (
-                kw.arg == "covariant"
-                and isinstance(kw.value, nodes.Const)
-                and kw.value.value
-            ):
+            elif kw.arg == "covariant" and kw.value.value:
                 variance = (
                     TypeVarVariance.covariant
                     if variance != TypeVarVariance.contravariant
                     else TypeVarVariance.double_variant
                 )
-            elif (
-                kw.arg == "contravariant"
-                and isinstance(kw.value, nodes.Const)
-                and kw.value.value
-            ):
+            elif kw.arg == "contravariant" and kw.value.value:
                 variance = (
                     TypeVarVariance.contravariant
                     if variance != TypeVarVariance.covariant
                     else TypeVarVariance.double_variant
                 )
 
-            if kw.arg == "name" and isinstance(kw.value, nodes.Const):
+            if kw.arg == "name":
                 name_arg = kw.value.value
 
         if name_arg is None and args and isinstance(args[0], nodes.Const):

--- a/tests/functional/r/regression_02/regression_11022.py
+++ b/tests/functional/r/regression_02/regression_11022.py
@@ -1,0 +1,13 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11022.
+
+Passing a non-constant value as the ``covariant`` or ``contravariant``
+argument of ``TypeVar`` crashed the name checker, which assumed the
+keyword value was always a constant.
+"""
+
+from typing import TypeVar
+
+VARIANCE = True
+
+T = TypeVar("T", covariant=VARIANCE)
+T = TypeVar("T", contravariant=VARIANCE)


### PR DESCRIPTION

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

``_check_typevar`` read ``kw.value.value`` directly for the ``covariant`` and ``contravariant`` keywords, assuming the argument was always a constant. When it is any other expression, such as a name, the node has no ``value`` attribute and the name checker crashed with an ``AttributeError``. Guard the access with an ``isinstance`` check against ``nodes.Const``, mirroring the existing handling of the ``name`` keyword.

Closes #11022
