### PR TITLE
[primer] Add comparator test cases for classification and rename

### DIFF
--- a/tests/testutils/_primer/cases/new_messages_classified/expected.txt
+++ b/tests/testutils/_primer/cases/new_messages_classified/expected.txt
@@ -1,0 +1,23 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astropy](https://github.com/astropy/astropy):**
+
+1 "astroid error(s)" were found. Please open the GitHub Actions log to see what failed or crashed.
+
+The following messages are now emitted:
+
+<details>
+
+1) locally-disabled:
+*Locally disabling looping-through-iterator (W4801)*
+https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
+2) useless-suppression:
+*Useless suppression of 'looping-through-iterator'*
+https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L14
+3) unused-variable:
+*Unused variable 'foo'*
+https://github.com/astropy/astropy/blob/1fb40bc1f22f176254ef583065aa155f53f3b414/astropy/coordinates/angles/angle_parsetab.py#L42
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/new_messages_classified/expected_comparator.json
+++ b/tests/testutils/_primer/cases/new_messages_classified/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astropy", "missing": 0, "new": 4 }]

--- a/tests/testutils/_primer/cases/new_messages_classified/main.json
+++ b/tests/testutils/_primer/cases/new_messages_classified/main.json
@@ -1,0 +1,6 @@
+{
+  "astropy": {
+    "commit": "1fb40bc1f22f176254ef583065aa155f53f3b414",
+    "messages": []
+  }
+}

--- a/tests/testutils/_primer/cases/new_messages_classified/pr.json
+++ b/tests/testutils/_primer/cases/new_messages_classified/pr.json
@@ -1,0 +1,67 @@
+{
+  "astropy": {
+    "commit": "1fb40bc1f22f176254ef583065aa155f53f3b414",
+    "messages": [
+      {
+        "type": "error",
+        "module": "astropy.coordinates.angles.angle_parsetab",
+        "obj": "",
+        "line": 1,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py",
+        "symbol": "astroid-error",
+        "message": "Fatal error while checking 'astropy/module.py'. Please open an issue.",
+        "messageId": "F0002",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py"
+      },
+      {
+        "type": "info",
+        "module": "astropy.coordinates.angles.angle_parsetab",
+        "obj": "",
+        "line": 14,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py",
+        "symbol": "locally-disabled",
+        "message": "Locally disabling looping-through-iterator (W4801)",
+        "messageId": "I0011",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py"
+      },
+      {
+        "type": "warning",
+        "module": "astropy.coordinates.angles.angle_parsetab",
+        "obj": "",
+        "line": 14,
+        "column": 0,
+        "endLine": null,
+        "endColumn": null,
+        "path": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py",
+        "symbol": "useless-suppression",
+        "message": "Useless suppression of 'looping-through-iterator'",
+        "messageId": "I0021",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py"
+      },
+      {
+        "type": "warning",
+        "module": "astropy.coordinates.angles.angle_parsetab",
+        "obj": "my_function",
+        "line": 42,
+        "column": 4,
+        "endLine": 42,
+        "endColumn": 16,
+        "path": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py",
+        "symbol": "unused-variable",
+        "message": "Unused variable 'foo'",
+        "messageId": "W0612",
+        "confidence": "UNDEFINED",
+        "absolutePath": "tests/.pylint_primer_tests/astropy/astropy/astropy/coordinates/angles/angle_parsetab.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/symbol_renamed/expected.txt
+++ b/tests/testutils/_primer/cases/symbol_renamed/expected.txt
@@ -1,0 +1,24 @@
+🤖 **Effect of this PR on checked open source code:** 🤖
+
+
+**Effect on [astroid](https://github.com/pylint-dev/astroid):**
+
+The following messages are now emitted:
+
+<details>
+
+1) possibly-used-before-assignment:
+*Possibly using variable 'orig_key' before assignment*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
+</details>
+
+The following messages are no longer emitted:
+
+<details>
+
+1) used-before-assignment:
+*Using variable 'orig_key' before assignment*
+https://github.com/pylint-dev/astroid/blob/123456789abcdef/astroid/wcs.py#L3072
+</details>
+
+*This comment was generated for commit v2.14.2*

--- a/tests/testutils/_primer/cases/symbol_renamed/expected_comparator.json
+++ b/tests/testutils/_primer/cases/symbol_renamed/expected_comparator.json
@@ -1,0 +1,1 @@
+[{ "package": "astroid", "missing": 1, "new": 1 }]

--- a/tests/testutils/_primer/cases/symbol_renamed/main.json
+++ b/tests/testutils/_primer/cases/symbol_renamed/main.json
@@ -1,0 +1,22 @@
+{
+  "astroid": {
+    "commit": "1234567890abcdef",
+    "messages": [
+      {
+        "type": "error",
+        "module": "astroid.wcs",
+        "obj": "WCS.fix",
+        "line": 3072,
+        "column": 12,
+        "endLine": 3072,
+        "endColumn": 20,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py",
+        "symbol": "used-before-assignment",
+        "message": "Using variable 'orig_key' before assignment",
+        "messageId": "E0601",
+        "confidence": "HIGH",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py"
+      }
+    ]
+  }
+}

--- a/tests/testutils/_primer/cases/symbol_renamed/pr.json
+++ b/tests/testutils/_primer/cases/symbol_renamed/pr.json
@@ -1,0 +1,22 @@
+{
+  "astroid": {
+    "commit": "123456789abcdef",
+    "messages": [
+      {
+        "type": "warning",
+        "module": "astroid.wcs",
+        "obj": "WCS.fix",
+        "line": 3072,
+        "column": 12,
+        "endLine": 3072,
+        "endColumn": 20,
+        "path": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py",
+        "symbol": "possibly-used-before-assignment",
+        "message": "Possibly using variable 'orig_key' before assignment",
+        "messageId": "E0606",
+        "confidence": "INFERENCE",
+        "absolutePath": "tests/.pylint_primer_tests/pylint-dev/astroid/astroid/wcs.py"
+      }
+    ]
+  }
+}


### PR DESCRIPTION


## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Add the ``new_messages_classified`` and ``symbol_renamed`` primer comparison fixtures. Their ``expected.txt`` and
``expected_comparator.json`` capture the comparator's current output.

Landing them on their own lets a follow-up change to the comparator show its effect on the rendered comment as a reviewable diff rather than as brand-new expected files.