### PR TITLE
Fix crash checking a metaclass attribute chain not rooted at a name

### DIFF
--- a/doc/whatsnew/fragments/11030.bugfix
+++ b/doc/whatsnew/fragments/11030.bugfix
@@ -1,0 +1,5 @@
+Fix a crash in the variables checker when a class declares a metaclass whose
+attribute-access chain does not bottom out at a name (e.g.
+``class C(metaclass=None._)``).
+
+Closes #11030

--- a/doc/whatsnew/fragments/11031.bugfix
+++ b/doc/whatsnew/fragments/11031.bugfix
@@ -1,5 +1,6 @@
 Fix a crash in the variables checker when a class declares a metaclass whose
 attribute-access chain does not bottom out at a name (e.g.
 ``class C(metaclass=None._)``).
+Originally reported as ``pylint-dev/astroid#3066``.
 
-Closes #11030
+Refs #11031

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3428,9 +3428,10 @@ class VariablesChecker(BaseChecker):
                 # bind name
                 pass
             case nodes.Attribute(expr=attr):
-                while not isinstance(attr, nodes.Name):
+                while isinstance(attr, nodes.Attribute):
                     attr = attr.expr
-                name = attr.name
+                if isinstance(attr, nodes.Name):
+                    name = attr.name
             case nodes.Call(func=nodes.Name(name=name)):
                 # bind name
                 pass
@@ -3456,7 +3457,8 @@ class VariablesChecker(BaseChecker):
                     found = True
                     break
         if (
-            not found
+            name
+            and not found
             and not metaclass
             and not (
                 name in nodes.Module.scope_attrs

--- a/tests/functional/u/undefined/undefined_variable_metaclass_non_name.py
+++ b/tests/functional/u/undefined/undefined_variable_metaclass_non_name.py
@@ -1,0 +1,14 @@
+"""Regression test for a crash in the variables checker when a class uses a
+metaclass whose attribute-access chain does not bottom out at a ``Name``.
+
+For ``metaclass=None._`` the metaclass node is an ``Attribute`` whose ``expr``
+is a ``Const``; walking the ``.expr`` chain looking for a ``Name`` used to
+crash with an ``AttributeError``.
+
+https://github.com/pylint-dev/pylint/issues/11030
+"""
+# pylint: disable=too-few-public-methods,missing-class-docstring
+
+
+class C(metaclass=None._):
+    pass


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

``_check_classdef_metaclasses`` walked the ``.expr`` chain of an ``Attribute`` metaclass with ``while not isinstance(attr, nodes.Name)``, assuming the chain always terminates in a ``Name``. For a metaclass such as ``None._`` the chain bottoms out at a ``Const``, so the loop accessed ``.expr`` on a non-Attribute node and crashed with an ``AttributeError``.

Walk only while the node is an ``Attribute`` and bind the name solely when the base is a ``Name``. Also guard the ``undefined-variable`` report with a non-empty name so an unresolved chain no longer reports an empty variable name.

Closes https://github.com/pylint-dev/astroid/issues/3066