### PR TITLE
Avoid crashing on empty len calls

### DIFF
--- a/doc/whatsnew/fragments/11028.bugfix
+++ b/doc/whatsnew/fragments/11028.bugfix
@@ -1,0 +1,1 @@
+Avoided a crash from the implicit booleaness checker for ``len()`` calls without arguments.

--- a/doc/whatsnew/fragments/11028.bugfix
+++ b/doc/whatsnew/fragments/11028.bugfix
@@ -1,1 +1,3 @@
 Avoided a crash from the implicit booleaness checker for ``len()`` calls without arguments.
+
+Closes #11028

--- a/pylint/checkers/refactoring/implicit_booleaness_checker.py
+++ b/pylint/checkers/refactoring/implicit_booleaness_checker.py
@@ -122,6 +122,8 @@ class ImplicitBooleanessChecker(checkers.BaseChecker):
         # this len() call is part of a test condition
         if not utils.is_test_condition(node, parent):
             return
+        if not node.args:
+            return
         len_arg = node.args[0]
         if isinstance(len_arg, (nodes.ListComp, nodes.SetComp, nodes.DictComp)):
             # The node is a comprehension as in len([x for x in ...])

--- a/tests/functional/u/use/use_implicit_booleaness_not_len.py
+++ b/tests/functional/u/use/use_implicit_booleaness_not_len.py
@@ -193,3 +193,10 @@ if len('TEST'):
 def github_issue_10100():
     if len((x for x in [1, 2, 3])):  # Should be fine
         print("yay!")
+
+
+def github_issue_11028():
+    # Do not crash when another checker handles the missing argument.
+    # pylint: disable=no-value-for-parameter
+    if len():
+        pass


### PR DESCRIPTION
## Type of Changes

|     | Type |
| --- | --- |
| x | :bug: Bug fix |

## Description

The implicit booleaness checker now skips `len()` calls without arguments, leaving the missing-argument handling to the normal argument checker instead of crashing while indexing `node.args`.

Closes #11028

## Tests

- `.venv\Scripts\python -m pytest "tests/test_functional.py::test_functional[use_implicit_booleaness_not_len]" -q`
- `.venv\Scripts\python -m pytest "tests/test_functional.py::test_functional[use_implicit_booleaness_not_len]" "tests/test_functional.py::test_functional[use_implicit_booleaness_not_comparison]" "tests/test_functional.py::test_functional[use_implicit_booleaness_not_comparison_to_zero]" "tests/test_functional.py::test_functional[use_implicit_booleaness_not_comparison_to_string]" -q`
- `.venv\Scripts\python -m ruff check pylint\checkers\refactoring\implicit_booleaness_checker.py`
- `.venv\Scripts\python -m black --check pylint\checkers\refactoring\implicit_booleaness_checker.py`
- `git diff --check`