### PR TITLE
Fix false positive method-hidden for bare cached_property import

### DIFF
--- a/doc/whatsnew/fragments/11037.false_positive
+++ b/doc/whatsnew/fragments/11037.false_positive
@@ -1,0 +1,3 @@
+Fix false positive ``method-hidden`` when ``cached_property`` is imported directly with ``from functools import cached_property``.
+
+Refs #11037

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1263,7 +1263,7 @@ a metaclass class method.",
                                 "attribute-defined-outside-init", args=attr, node=node
                             )
 
-    # pylint: disable = too-many-branches
+    # pylint: disable = too-many-branches, too-many-return-statements
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Check method arguments, overriding."""
         # ignore actual functions

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
 _AccessNodes: TypeAlias = nodes.Attribute | nodes.AssignAttr
 
 INVALID_BASE_CLASSES = {"bool", "range", "slice", "memoryview"}
-ALLOWED_PROPERTIES = {"bultins.property", "functools.cached_property"}
 BUILTIN_DECORATORS = {"builtins.property", "builtins.classmethod"}
 ASTROID_TYPE_COMPARATORS = {
     nodes.Const: lambda a, b: a.value == b.value,
@@ -1303,11 +1302,8 @@ a metaclass class method.",
                     case nodes.Attribute(attrname="getter" | "setter" | "deleter"):
                         # attribute affectation will call this method, not hiding it
                         return
-                    case nodes.Name():
-                        if decorator.name in ALLOWED_PROPERTIES:
-                            # attribute affectation will either call a setter or raise
-                            # an attribute error, anyway not hiding the function
-                            return
+                    case nodes.Name(name="property"):
+                        return
                     case nodes.Attribute():
                         if self._check_functools_or_not(decorator):
                             return
@@ -1315,6 +1311,11 @@ a metaclass class method.",
                 # Infer the decorator and see if it returns something useful
                 inferred = safe_infer(decorator)
                 if not inferred:
+                    return
+                if (
+                    isinstance(inferred, nodes.ClassDef)
+                    and inferred.qname() == "functools.cached_property"
+                ):
                     return
                 if isinstance(inferred, nodes.FunctionDef):
                     # Okay, it's a decorator, let's see what it can infer.

--- a/tests/functional/m/method_hidden.py
+++ b/tests/functional/m/method_hidden.py
@@ -2,6 +2,7 @@
 # pylint: disable=unused-private-member
 """check method hiding ancestor attribute
 """
+from functools import cached_property
 import functools as ft
 import something_else as functools  # pylint: disable=import-error
 
@@ -123,6 +124,12 @@ class CachedChild(Parent):
 
     @functools.cached_property
     def _protected_two(self):
+        pass
+
+
+class CachedChildFromImport(Parent):
+    @cached_property
+    def _protected(self):
         pass
 
 

--- a/tests/functional/m/method_hidden.txt
+++ b/tests/functional/m/method_hidden.txt
@@ -1,3 +1,3 @@
-method-hidden:19:4:19:12:Cdef.abcd:An attribute defined in functional.m.method_hidden line 13 hides this method:UNDEFINED
-method-hidden:87:4:87:11:One.one:An attribute defined in functional.m.method_hidden line 85 hides this method:UNDEFINED
-method-hidden:115:4:115:18:Child._protected:An attribute defined in functional.m.method_hidden line 110 hides this method:UNDEFINED
+method-hidden:20:4:20:12:Cdef.abcd:An attribute defined in functional.m.method_hidden line 14 hides this method:UNDEFINED
+method-hidden:88:4:88:11:One.one:An attribute defined in functional.m.method_hidden line 86 hides this method:UNDEFINED
+method-hidden:116:4:116:18:Child._protected:An attribute defined in functional.m.method_hidden line 111 hides this method:UNDEFINED


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

This PR fixes a false positive method-hidden (E0202) when `cached_property` is imported directly with `from functools import cached_property` and used as a bare `@cached_property` decorator. The original fix in #8758 only handled the `@functools.cached_property` attribute form - the bare name form slipped through because the Name-node check compared short names against qualified names (and had a typo `"bultins.property"`), and `cached_property` lacks `__set__` so the descriptor fallback didn't recognize it either. Now the checker matches `@property` by name as a fast path and resolves bare `@cached_property` via `safe_infer` + qname check. 

Example:
```python
from functools import cached_property

class Base:
    def __init__(self, val):
        self.val = val

class Child(Base):
    @cached_property
    def val(self):
        return 42  # was: E0202 (false positive)
```

Refs #8753