### PR TITLE
Pin PyPy 3.11 to avoid astroid bootstrap failure (#10999)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "pypy-3.10"
           - os: ubuntu-latest
-            python-version: "pypy-3.11"
+            python-version: "pypy-3.11-v7.3.20"
     runs-on: ${{ matrix.os }}
     outputs:
       python-key: ${{ steps.generate-python-key.outputs.key }}


### PR DESCRIPTION
(cherry picked from commit 25d42ce9e444595fbc48f5bf6b9615357e6ca3ff)
