### PR TITLE
Fix ``function-redefined`` false positive for names matching ``dummy-variables-rgx``

### DIFF
--- a/doc/whatsnew/fragments/10665.false_positive
+++ b/doc/whatsnew/fragments/10665.false_positive
@@ -1,0 +1,7 @@
+Fix a false positive for ``function-redefined`` (E0102) when reusing names that
+match ``dummy-variables-rgx`` (such as ``_``), which is common for
+``pytest-bdd`` step definitions. This restores the behavior from before pylint
+4.0.0; as a consequence the false negative fixed in #9894 is reintroduced for
+functions whose name matches ``dummy-variables-rgx``.
+
+Closes #10665

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -640,6 +640,9 @@ class BasicErrorChecker(_BasicChecker):
                     ):
                         return
 
+            dummy_variables_rgx = self.linter.config.dummy_variables_rgx
+            if dummy_variables_rgx and dummy_variables_rgx.match(node.name):
+                return
             self.add_message(
                 "function-redefined",
                 node=node,

--- a/tests/functional/f/function_redefined.py
+++ b/tests/functional/f/function_redefined.py
@@ -94,7 +94,7 @@ def math(): # [function-redefined]
     pass
 
 import math as _
-def fun():
+def _():
     pass
 
 # pylint: disable=too-few-public-methods

--- a/tests/functional/f/function_redefined_private_function.py
+++ b/tests/functional/f/function_redefined_private_function.py
@@ -1,6 +1,14 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring
+# Names matching ``dummy-variables-rgx`` are exempt from function-redefined,
+# e.g. ``_`` used repeatedly as a pytest-bdd step name (issue #10665).
+def _():
+    pass
+
+def _():
+    pass
+
 def _my_func():
     pass
 
-def _my_func():  # [function-redefined]
+def _my_func():
     pass

--- a/tests/functional/f/function_redefined_private_function.txt
+++ b/tests/functional/f/function_redefined_private_function.txt
@@ -1,1 +1,0 @@
-function-redefined:5:0:5:12:_my_func:function already defined line 2:UNDEFINED


### PR DESCRIPTION



## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Restore the pre-4.0 behavior of skipping ``function-redefined`` when the function name matches ``dummy-variables-rgx`` (e.g. ``_``), which is the common pattern used for ``pytest-bdd`` step definitions. As a side effect, the false negative addressed in #9894 is reintroduced for functions whose name matches that regex; users wanting to flag e.g. ``_my_func`` can tighten ``dummy-variables-rgx`` accordingly.

Closes #10665