### PR TITLE
Fix `invalid-name` false positive for `typing_extensions.TypeAlias`

### DIFF
--- a/doc/whatsnew/fragments/11013.false_positive
+++ b/doc/whatsnew/fragments/11013.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for ``invalid-name`` when ``TypeAlias`` is imported from
+``typing_extensions`` instead of ``typing``.
+
+Closes #11013

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -700,21 +700,31 @@ class NameChecker(_BasicChecker):
     @staticmethod
     def _assigns_typealias(node: nodes.NodeNG | None) -> bool:
         """Check if a node is assigning a TypeAlias."""
-        inferred = utils.safe_infer(node)
-        if isinstance(inferred, (nodes.ClassDef, bases.UnionType)):
-            qname = inferred.qname()
-            if qname == "typing.TypeAlias":
-                return True
-            if qname in {".Union", "builtins.Union", "builtins.UnionType"}:
-                # Union is a special case because it can be used as a type alias
-                # or as a type annotation. We only want to check the former.
-                assert node is not None
-                return not isinstance(node.parent, nodes.AnnAssign)
-        elif isinstance(inferred, nodes.FunctionDef):
-            # TODO: when py3.12 is minimum, remove this condition
-            # TypeAlias became a class in python 3.12
-            if inferred.qname() == "typing.TypeAlias":
-                return True
+        if node is None:
+            return False
+        try:
+            inferred_values = list(node.infer())
+        except astroid.InferenceError:
+            return False
+        # ``typing_extensions.TypeAlias`` yields both a ClassDef (typing brain
+        # remap) and a FunctionDef (legacy typing_extensions impl), so the
+        # previous ``safe_infer`` would return None. Walk every inference result.
+        for inferred in inferred_values:
+            if isinstance(inferred, (nodes.ClassDef, bases.UnionType)):
+                qname = inferred.qname()
+                if qname == "typing.TypeAlias":
+                    return True
+                if qname in {".Union", "builtins.Union", "builtins.UnionType"}:
+                    # Union is a special case because it can be used as a type
+                    # alias or as a type annotation. We only want to check the
+                    # former.
+                    if not isinstance(node.parent, nodes.AnnAssign):
+                        return True
+            elif isinstance(inferred, nodes.FunctionDef):
+                # TODO: when py3.12 is minimum, remove this condition
+                # TypeAlias became a class in python 3.12
+                if inferred.qname() == "typing.TypeAlias":
+                    return True
         return False
 
     def _check_typevar(self, name: str, node: nodes.AssignName) -> None:

--- a/tests/functional/r/regression_11/regression_11013.py
+++ b/tests/functional/r/regression_11/regression_11013.py
@@ -1,0 +1,18 @@
+"""Regression test for #11013: TypeAlias imported from typing_extensions.
+
+``typing_extensions.TypeAlias`` infers to both a ``ClassDef`` (via the typing
+brain remap) and a ``FunctionDef`` (the legacy typing_extensions implementation).
+``safe_infer`` returned ``None`` for the ambiguous result, so the assignment was
+not recognised as a type alias and pylint fell through to the ``invalid-name``
+``const`` check.
+"""
+# pylint: disable=missing-class-docstring,unused-import,too-few-public-methods
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    AuthenticationType: TypeAlias = "Authentication"
+
+
+class Authentication: ...


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓ | :bug: Bug fix |

## Description

Closes #11013

`typing_extensions.TypeAlias` infers to two values: a `ClassDef` (from the typing brain remap) and the legacy `FunctionDef` (the `typing_extensions` implementation). `NameChecker._assigns_typealias` used `utils.safe_infer`, which returns `None` for ambiguous inferences, so the call returned `False`, the assignment was not recognised as a type alias, and pylint fell through to the `invalid-name` `const` (`UPPER_CASE`) check.

Reproduction (verified on `pylint 4.0.5`):

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from typing_extensions import TypeAlias

    AuthenticationType: TypeAlias = "Authentication"
```
emits:
```
C0103: Constant name "AuthenticationType" doesn't conform to UPPER_CASE naming style (invalid-name)
```

The `TYPE_CHECKING` block is incidental; the same false positive fires when `TypeAlias` is imported from `typing_extensions` at module level. With `from typing import TypeAlias` the snippet is clean.

The fix walks every inference result instead of relying on `safe_infer`, so the `ClassDef`/`FunctionDef` whose `qname()` is `typing.TypeAlias` is found regardless of how many siblings astroid yields. The `Union` special case is preserved.