### PR TITLE
fix: use metaclass __call__ signature on class instantiation

### DIFF
--- a/doc/whatsnew/fragments/11032.false_positive
+++ b/doc/whatsnew/fragments/11032.false_positive
@@ -1,0 +1,3 @@
+Check for metaclass __call__ signature when evaluating arguments of a class call.
+
+Closes #11032

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -604,6 +604,23 @@ def _enum_has_attribute(
     return node.attrname in enum_attributes
 
 
+def _get_local_callable(
+    node: nodes.NodeNG, attr: str
+) -> tuple[CallableObjects | None, bool, bool]:
+    try:
+        c = node.local_attr(attr)[-1]
+    except astroid.NotFoundError:
+        c = None
+    is_from_object = bool(c and c.parent.scope().name == "object")
+    is_from_builtins = bool(c and c.root().name in sys.builtin_module_names)
+    return c, is_from_object, is_from_builtins
+
+
+def _check_is_function_def(obj: Any) -> None:
+    if not isinstance(obj, nodes.FunctionDef):
+        raise ValueError
+
+
 def _determine_callable(
     callable_obj: nodes.NodeNG,
 ) -> tuple[CallableObjects, int, str]:
@@ -628,20 +645,25 @@ def _determine_callable(
         case nodes.Lambda():
             return callable_obj, parameters, "lambda"
         case nodes.ClassDef():
-            # Class instantiation, lookup __new__ instead.
-            # If we only find object.__new__, we can safely check __init__
-            # instead. If __new__ belongs to builtins, then we look
+            # Class instantiation, Check first for a metaclass __call__ definition.
+            # Then lookup __new__. If we only find object.__new__,
+            # we can safely check __init__ instead.
+            # If __new__ belongs to builtins, then we look
             # again for __init__ in the locals, since we won't have
             # argument information for the builtin __new__ function.
-            try:
-                # Use the last definition of __new__.
-                new = callable_obj.local_attr("__new__")[-1]
-            except astroid.NotFoundError:
-                new = None
 
-            from_object = new and new.parent.scope().name == "object"
-            from_builtins = new and new.root().name in sys.builtin_module_names
+            # Try to use the metaclass' __call__ if any.
+            meta = callable_obj.metaclass()
+            if meta and isinstance(meta, nodes.NodeNG):
+                meta_call, _, from_builtins = _get_local_callable(meta, "__call__")
+                if meta_call and not from_builtins:
+                    _check_is_function_def(meta_call)
+                    return meta_call, parameters, "class"
 
+            # Use the last definition of __new__.
+            new, from_object, from_builtins = _get_local_callable(
+                callable_obj, "__new__"
+            )
             if not new or from_object or from_builtins:
                 try:
                     # Use the last definition of __init__.
@@ -651,9 +673,7 @@ def _determine_callable(
             else:
                 callable_obj = new
 
-            if not isinstance(callable_obj, nodes.FunctionDef):
-                raise ValueError
-            # both have an extra implicit 'cls'/'self' argument.
+            _check_is_function_def(callable_obj)
             return callable_obj, parameters, "constructor"
 
     raise ValueError

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -333,3 +333,24 @@ class Foo:
     a = func(42)
 
 isinstance(1) # [no-value-for-parameter]
+
+
+# Check if respecting Python's actual runtime MRO when using metaclasses
+class Meta(type):
+    """Metaclass with a __call__ method that takes more arguments than the class it creates."""
+    def __call__(cls, a: int, b: int, c: int) -> "MyClass":
+        """Calls the class __call__ with the first argument."""
+        return super().__call__(a)
+
+
+class MyClass(metaclass=Meta): # pylint: disable=too-few-public-methods
+    """Class with a __init__ method that takes fewer arguments than the metaclass __call__."""
+    def __init__(self, a: str) -> None:
+        """Initializes the class."""
+        self.a = a
+        self.b = None
+
+
+MyClass(1, 2, 3, 4) # [too-many-function-args]
+MyClass(1, 2) # [no-value-for-parameter]
+MyClass(1, 2, 3)

--- a/tests/functional/a/arguments.txt
+++ b/tests/functional/a/arguments.txt
@@ -40,3 +40,5 @@ unexpected-keyword-arg:218:0:218:43::Unexpected keyword argument 'fourth' in fun
 redundant-keyword-arg:308:0:308:79::Argument 'banana' passed by position and keyword in function call:UNDEFINED
 no-value-for-parameter:318:0:318:16::No value for argument 'param1' in function call:UNDEFINED
 no-value-for-parameter:335:0:335:13::No value for argument '__class_or_tuple' in function call:HIGH
+too-many-function-args:354:0:354:19::Too many positional arguments for class call:UNDEFINED
+no-value-for-parameter:355:0:355:13::No value for argument 'c' in class call:UNDEFINED

--- a/tests/functional/t/too/too_many_function_args.py
+++ b/tests/functional/t/too/too_many_function_args.py
@@ -22,3 +22,22 @@ def main(param):
 # Negative case, see `_check_isinstance_args` in `./pylint/checkers/typecheck.py`
 isinstance(1, int, int) # [too-many-function-args]
 isinstance(1, 1, int) # [too-many-function-args, isinstance-second-argument-not-valid-type]
+
+# Check if respecting Python's actual runtime MRO when using metaclasses
+class Meta(type):
+    """Metaclass with a __call__ method that takes more arguments than the class it creates."""
+    def __call__(cls, a: int, b: int, c: int) -> "MyClass":
+        """Calls the class __call__ with the first argument."""
+        return super().__call__(a)
+
+
+class MyClass(metaclass=Meta): # pylint: disable=too-few-public-methods
+    """Class with a __init__ method that takes fewer arguments than the metaclass __call__."""
+    def __init__(self, a: str) -> None:
+        """Initializes the class."""
+        self.a = a
+        self.b = None
+
+
+MyClass(1, 2, 3, 4) # [too-many-function-args]
+MyClass(1, 2, 3)

--- a/tests/functional/t/too/too_many_function_args.txt
+++ b/tests/functional/t/too/too_many_function_args.txt
@@ -1,3 +1,4 @@
 too-many-function-args:23:0:23:23::Too many positional arguments for function call:HIGH
 isinstance-second-argument-not-valid-type:24:0:24:21::Second argument of isinstance is not a type:INFERENCE
 too-many-function-args:24:0:24:21::Too many positional arguments for function call:HIGH
+too-many-function-args:42:0:42:19::Too many positional arguments for class call:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Fixes a E1121 (too-many-function-args), a E1120 (no-value-for-parameter) and probaly other false positives related to the function signature, that triggers when a class uses a metaclass that overrides `__call__` with a different signature.

This was caused by `_determine_callable` in `pylint/checkers/typecheck.py` that was not checking for the potential metaclass and their potential `__call__` override and rather solely checked `__init__` and `__new__`. Adding a check for it's existence and returning it solved the false positives.

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #11032 

### Checklist

- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [x] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``