### PR TITLE
Fix a crash in `consider-using-enumerate` for non-name loop targets

### DIFF
--- a/doc/whatsnew/fragments/10099.bugfix
+++ b/doc/whatsnew/fragments/10099.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in ``consider-using-enumerate`` when the ``for`` loop target is an attribute (e.g. ``for self.idx in range(len(x))``) rather than a simple variable name.
+
+Closes #10099

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -230,6 +230,13 @@ class RecommendationChecker(checkers.BaseChecker):
             case nodes.Name(name="self") if scope.name == "__iter__":
                 return
 
+        # ``consider-using-enumerate`` only applies to a simple loop variable.
+        # A tuple or attribute target (e.g. ``for self.idx in range(len(x))``)
+        # cannot be rewritten with ``enumerate``, and accessing
+        # ``node.target.name`` on such a target raises AttributeError (#10099).
+        if not isinstance(node.target, nodes.AssignName):
+            return
+
         # Verify that the body of the for loop uses a subscript
         # with the object that was iterated. This uses some heuristics
         # in order to make sure that the same object is used in the

--- a/tests/functional/c/consider/consider_using_enumerate.py
+++ b/tests/functional/c/consider/consider_using_enumerate.py
@@ -83,3 +83,13 @@ def my_function(instance: MyClass):
     for i in range(len(instance.my_list)):  # [consider-using-enumerate]
         var = instance.my_list[i]
         print(var)
+
+
+# Crash regression: a non-name loop target (here an attribute on a parameter)
+# must not crash the checker. https://github.com/pylint-dev/pylint/issues/10099
+# The ``other[index]`` subscript in the body is required to reach the code path
+# that crashed (the checker only inspects bodies that subscript a name); do not
+# remove it or this stops covering the bug.
+def loop_into_attribute(obj, items, other, index):
+    for obj.idx in range(len(items)):  # no crash, no message
+        print(other[index])


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`consider-using-enumerate` crashes with `AttributeError: 'AssignAttr' object has no attribute 'name'` when the `for` loop target is not a plain variable.

`_check_consider_using_enumerate` accesses `node.target.name` unconditionally while matching the loop variable against subscripts in the body. When the target is an attribute, tuple, or subscript (e.g. `for self.idx in range(len(x)):`), `node.target` is an `AssignAttr`/`Tuple`/`Subscript` with no `.name`, so the access raises.

Fixed by returning early when the target is not an `AssignName`. This is also the correct semantics: a non-name target can't be rewritten with `enumerate`, so no message should be emitted (it mirrors the existing early-return for the `__iter__`/`self` case just above).

Added a functional regression case and a news fragment.

Closes #10099
