### PR TITLE
Allow digits in TypeVar names for invalid-name check

### DIFF
--- a/doc/whatsnew/fragments/8499.false_positive
+++ b/doc/whatsnew/fragments/8499.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``invalid-name`` (C0103) where the default
+``typevar-rgx`` rejected ``TypeVar`` names containing digits, such as
+``Ec2T``.
+
+Closes #8499

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -40,7 +40,7 @@ _BadNamesTuple = tuple[nodes.NodeNG, str, str, interfaces.Confidence]
 # Default patterns for name types that do not have styles
 DEFAULT_PATTERNS = {
     "typevar": re.compile(
-        r"^_{0,2}(?!T[A-Z])(?:[A-Z]+|(?:[A-Z]+[a-z]+)+(?:T)?(?<!Type))(?:_co(?:ntra)?)?$"
+        r"^_{0,2}(?!T[A-Z])(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:T)?(?<!Type))(?:_co(?:ntra)?)?$"
     ),
     "paramspec": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z]+)+(?:P)?(?<!Type))$"),
     "typevartuple": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z]+)+(?:Ts)?(?<!Type))$"),

--- a/tests/functional/t/type/typevar_naming_style_default.311.txt
+++ b/tests/functional/t/type/typevar_naming_style_default.311.txt
@@ -5,20 +5,20 @@ typevar-double-variance:23:0:23:4::TypeVar cannot be both covariant and contrava
 typevar-name-incorrect-variance:23:0:23:4::Type variable name does not reflect variance:INFERENCE
 typevar-double-variance:24:0:24:8::TypeVar cannot be both covariant and contravariant:INFERENCE
 typevar-name-incorrect-variance:24:0:24:8::Type variable name does not reflect variance:INFERENCE
-invalid-name:37:0:37:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
-invalid-name:38:0:38:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
-invalid-name:39:0:39:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
-invalid-name:42:0:42:7::"Type variable name ""TAnyStr"" doesn't conform to predefined naming style":HIGH
-invalid-name:45:0:45:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:46:0:46:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
-invalid-name:47:0:47:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
-invalid-name:51:4:51:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
-invalid-name:52:4:52:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
-typevar-name-incorrect-variance:52:4:52:26::"Type variable name does not reflect variance. ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:54:13:54:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
-invalid-name:63:0:63:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
-typevar-double-variance:64:0:64:4::TypeVar cannot be both covariant and contravariant:INFERENCE
-typevar-name-incorrect-variance:64:0:64:4::Type variable name does not reflect variance:INFERENCE
-invalid-name:71:0:71:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:77:0:77:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:91:0:91:7::"Type variable tuple name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:42:0:42:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
+invalid-name:43:0:43:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
+invalid-name:44:0:44:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
+invalid-name:47:0:47:7::"Type variable name ""TAnyStr"" doesn't conform to predefined naming style":HIGH
+invalid-name:50:0:50:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:51:0:51:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
+invalid-name:52:0:52:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:56:4:56:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
+invalid-name:57:4:57:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
+typevar-name-incorrect-variance:57:4:57:26::"Type variable name does not reflect variance. ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:59:13:59:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:68:0:68:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+typevar-double-variance:69:0:69:4::TypeVar cannot be both covariant and contravariant:INFERENCE
+typevar-name-incorrect-variance:69:0:69:4::Type variable name does not reflect variance:INFERENCE
+invalid-name:76:0:76:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:82:0:82:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:96:0:96:7::"Type variable tuple name ""badName"" doesn't conform to predefined naming style":HIGH

--- a/tests/functional/t/type/typevar_naming_style_default.py
+++ b/tests/functional/t/type/typevar_naming_style_default.py
@@ -34,6 +34,11 @@ HVACModeT = TypeVar("HVACModeT")
 TodoT = TypeVar("TodoT")
 TypeT = TypeVar("TypeT")
 _IPAddress = TypeVar("_IPAddress")
+
+# Names containing digits
+Ec2T = TypeVar("Ec2T")
+S3BucketT = TypeVar("S3BucketT")
+Utf8T = TypeVar("Utf8T")
 CALLABLE_T = TypeVar("CALLABLE_T")  # [invalid-name]
 DeviceType = TypeVar("DeviceType")  # [invalid-name]
 IPAddressU = TypeVar("IPAddressU")  # [invalid-name]

--- a/tests/functional/t/type/typevar_naming_style_default.txt
+++ b/tests/functional/t/type/typevar_naming_style_default.txt
@@ -5,19 +5,19 @@ typevar-double-variance:23:0:23:4::TypeVar cannot be both covariant and contrava
 typevar-name-incorrect-variance:23:0:23:4::Type variable name does not reflect variance:INFERENCE
 typevar-double-variance:24:0:24:8::TypeVar cannot be both covariant and contravariant:INFERENCE
 typevar-name-incorrect-variance:24:0:24:8::Type variable name does not reflect variance:INFERENCE
-invalid-name:37:0:37:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
-invalid-name:38:0:38:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
-invalid-name:39:0:39:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
-invalid-name:42:0:42:7::"Type variable name ""TAnyStr"" doesn't conform to predefined naming style":HIGH
-invalid-name:45:0:45:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:46:0:46:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
-invalid-name:47:0:47:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
-invalid-name:51:4:51:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
-invalid-name:52:4:52:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
-typevar-name-incorrect-variance:52:4:52:26::"Type variable name does not reflect variance. ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
-invalid-name:54:13:54:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
-invalid-name:63:0:63:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
-typevar-double-variance:64:0:64:4::TypeVar cannot be both covariant and contravariant:INFERENCE
-typevar-name-incorrect-variance:64:0:64:4::Type variable name does not reflect variance:INFERENCE
-invalid-name:71:0:71:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:77:0:77:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:42:0:42:10::"Type variable name ""CALLABLE_T"" doesn't conform to predefined naming style":HIGH
+invalid-name:43:0:43:10::"Type variable name ""DeviceType"" doesn't conform to predefined naming style":HIGH
+invalid-name:44:0:44:10::"Type variable name ""IPAddressU"" doesn't conform to predefined naming style":HIGH
+invalid-name:47:0:47:7::"Type variable name ""TAnyStr"" doesn't conform to predefined naming style":HIGH
+invalid-name:50:0:50:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:51:0:51:10::"Type variable name ""badName_co"" doesn't conform to predefined naming style":HIGH
+invalid-name:52:0:52:14::"Type variable name ""badName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:56:4:56:13::"Type variable name ""a_BadName"" doesn't conform to predefined naming style":HIGH
+invalid-name:57:4:57:26::"Type variable name ""a_BadNameWithoutContra"" doesn't conform to predefined naming style":HIGH
+typevar-name-incorrect-variance:57:4:57:26::"Type variable name does not reflect variance. ""a_BadNameWithoutContra"" is contravariant, use ""a_BadNameWithoutContra_contra"" instead":INFERENCE
+invalid-name:59:13:59:29::"Type variable name ""a_BadName_contra"" doesn't conform to predefined naming style":HIGH
+invalid-name:68:0:68:7::"Type variable name ""badName"" doesn't conform to predefined naming style":HIGH
+typevar-double-variance:69:0:69:4::TypeVar cannot be both covariant and contravariant:INFERENCE
+typevar-name-incorrect-variance:69:0:69:4::Type variable name does not reflect variance:INFERENCE
+invalid-name:76:0:76:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:82:0:82:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH


### PR DESCRIPTION
## Type of Changes

| Type | |
| --- | --- |
| ✓ | 🐛 Bug fix |

## Description

The default `typevar-rgx` did not allow digits in `TypeVar` names, so a name such as `Ec2T` was incorrectly flagged with `invalid-name` (C0103):

```python
from typing import TypeVar

T = TypeVar("T")
EcTwoT = TypeVar("EcTwoT")
Ec2T = TypeVar("Ec2T")  # C0103: doesn't conform to predefined naming style
```

This patch allows digits in the lowercase segments of the `typevar` pattern (`[a-z]+` → `[a-z0-9]+`), consistent with how the sibling `typealias` pattern already handles digits. Names that were previously valid/invalid are unaffected; only digit-containing PascalCase names such as `Ec2T`, `S3BucketT` and `Utf8T` are now accepted.

Functional test cases were added to `typevar_naming_style_default.py` and a changelog fragment is included.

Closes #8499