### PR TITLE
Fix `invalid-name` false positive in `if __name__ == "__main__":` block

### DIFF
--- a/doc/data/messages/i/invalid-name/details.rst
+++ b/doc/data/messages/i/invalid-name/details.rst
@@ -36,6 +36,18 @@ name is found in, and not the type of object assigned.
 | ``typealias``      | Type alias declared with ``TypeAlias`` or assignments of ``Union``.                                         |
 +--------------------+-------------------------------------------------------------------------------------------------------------+
 
+Names assigned in an ``if __name__ == "__main__":`` block are an exception: such
+a block reads like a script body, so a name there is accepted if it follows
+either the ``const`` or the ``variable`` naming style::
+
+    if __name__ == "__main__":
+        apple_count = count_apples()  # accepted, variable style
+        APPLE_COUNT = count_apples()  # accepted, constant style
+        appleCount = count_apples()  # reported, it follows neither style
+
+The ``else`` branch of such a block runs when the module is imported, so names
+assigned there keep following the ``const`` naming style.
+
 Default behavior
 ~~~~~~~~~~~~~~~~
 By default, Pylint will enforce PEP8_-suggested names.

--- a/doc/whatsnew/fragments/10766.false_positive
+++ b/doc/whatsnew/fragments/10766.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``invalid-name`` (C0103) on names assigned in an
+``if __name__ == "__main__":`` block. Such a block reads like a script body, so
+a name there is now accepted if it matches either the constant or the variable
+naming style.
+
+Closes #10766

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -112,6 +112,42 @@ def _redefines_import(node: nodes.AssignName) -> bool:
     return False
 
 
+def _is_dunder_main_test(test: nodes.NodeNG) -> bool:
+    """Detect a ``__name__ == "__main__"`` comparison (in either order)."""
+    if not isinstance(test, nodes.Compare) or [op for op, _ in test.ops] != ["=="]:
+        return False
+    operands = [test.left, test.ops[0][1]]
+    has_name = any(
+        isinstance(operand, nodes.Name) and operand.name == "__name__"
+        for operand in operands
+    )
+    has_main = any(
+        isinstance(operand, nodes.Const) and operand.value == "__main__"
+        for operand in operands
+    )
+    return has_name and has_main
+
+
+def _in_dunder_main_block(node: nodes.AssignName) -> bool:
+    """Detect that the given node is assigned in an
+    ``if __name__ == "__main__":`` block.
+
+    Returns True if the node is in the body of such a block, False otherwise.
+    """
+    child = node
+    parent = node.parent
+    while parent is not None and not isinstance(parent, nodes.Module):
+        if (
+            isinstance(parent, nodes.If)
+            and _is_dunder_main_test(parent.test)
+            and child in parent.body
+        ):
+            return True
+        child = parent
+        parent = parent.parent
+    return False
+
+
 def _determine_function_name_type(
     node: nodes.FunctionDef, config: argparse.Namespace
 ) -> str:
@@ -511,7 +547,10 @@ class NameChecker(_BasicChecker):
                     if not self._meets_exception_for_non_consts(
                         inferred_assign_type, node.name
                     ):
-                        self._check_name("const", node.name, node)
+                        if _in_dunder_main_block(node):
+                            self._check_name_in_main_block(node)
+                        else:
+                            self._check_name("const", node.name, node)
                 else:
                     node_type = "variable"
                     iattrs = tuple(node.frame().igetattr(node.name))
@@ -531,6 +570,11 @@ class NameChecker(_BasicChecker):
                     if not self._meets_exception_for_non_consts(
                         inferred_assign_type, node.name
                     ):
+                        if node_type == "const" and _in_dunder_main_block(node):
+                            self._check_name_in_main_block(
+                                node, disallowed_check_only=redefines_import
+                            )
+                            return
                         self._check_name(
                             node_type,
                             node.name,
@@ -565,6 +609,24 @@ class NameChecker(_BasicChecker):
                 self._check_name("class_const", node.name, node)
             else:
                 self._check_name("class_attribute", node.name, node)
+
+    def _check_name_in_main_block(
+        self, node: nodes.AssignName, disallowed_check_only: bool = False
+    ) -> None:
+        """Check a module-level name assigned in an ``if __name__ == "__main__":``
+        block.
+
+        Such a block reads like a script body, so a name there may legitimately
+        follow either the constant or the variable naming style.
+        """
+        node_type = (
+            "const"
+            if self._name_regexps["const"].match(node.name) is not None
+            else "variable"
+        )
+        self._check_name(
+            node_type, node.name, node, disallowed_check_only=disallowed_check_only
+        )
 
     def _meets_exception_for_non_consts(
         self, inferred_assign_type: InferenceResult | None, name: str

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -114,6 +114,42 @@ def _redefines_import(node: nodes.AssignName) -> bool:
     return False
 
 
+def _is_dunder_main_test(test: nodes.NodeNG) -> bool:
+    """Detect a ``__name__ == "__main__"`` comparison (in either order)."""
+    if not isinstance(test, nodes.Compare) or [op for op, _ in test.ops] != ["=="]:
+        return False
+    operands = [test.left, test.ops[0][1]]
+    has_name = any(
+        isinstance(operand, nodes.Name) and operand.name == "__name__"
+        for operand in operands
+    )
+    has_main = any(
+        isinstance(operand, nodes.Const) and operand.value == "__main__"
+        for operand in operands
+    )
+    return has_name and has_main
+
+
+def _in_dunder_main_block(node: nodes.AssignName) -> bool:
+    """Detect that the given node is assigned in an
+    ``if __name__ == "__main__":`` block.
+
+    Returns True if the node is in the body of such a block, False otherwise.
+    """
+    child = node
+    parent = node.parent
+    while parent is not None and not isinstance(parent, nodes.Module):
+        if (
+            isinstance(parent, nodes.If)
+            and _is_dunder_main_test(parent.test)
+            and child in parent.body
+        ):
+            return True
+        child = parent
+        parent = parent.parent
+    return False
+
+
 def _determine_function_name_type(
     node: nodes.FunctionDef, config: argparse.Namespace
 ) -> str:
@@ -513,7 +549,10 @@ class NameChecker(_BasicChecker):
                     if not self._meets_exception_for_non_consts(
                         inferred_assign_type, node.name
                     ):
-                        self._check_name("const", node.name, node)
+                        if _in_dunder_main_block(node):
+                            self._check_name_in_main_block(node)
+                        else:
+                            self._check_name("const", node.name, node)
                 else:
                     node_type = "variable"
                     iattrs = tuple(node.frame().igetattr(node.name))
@@ -533,6 +572,11 @@ class NameChecker(_BasicChecker):
                     if not self._meets_exception_for_non_consts(
                         inferred_assign_type, node.name
                     ):
+                        if node_type == "const" and _in_dunder_main_block(node):
+                            self._check_name_in_main_block(
+                                node, disallowed_check_only=redefines_import
+                            )
+                            return
                         self._check_name(
                             node_type,
                             node.name,
@@ -567,6 +611,24 @@ class NameChecker(_BasicChecker):
                 self._check_name("class_const", node.name, node)
             else:
                 self._check_name("class_attribute", node.name, node)
+
+    def _check_name_in_main_block(
+        self, node: nodes.AssignName, disallowed_check_only: bool = False
+    ) -> None:
+        """Check a module-level name assigned in an ``if __name__ == "__main__":``
+        block.
+
+        Such a block reads like a script body, so a name there may legitimately
+        follow either the constant or the variable naming style.
+        """
+        node_type = (
+            "const"
+            if self._name_regexps["const"].match(node.name) is not None
+            else "variable"
+        )
+        self._check_name(
+            node_type, node.name, node, disallowed_check_only=disallowed_check_only
+        )
 
     def _meets_exception_for_non_consts(
         self, inferred_assign_type: InferenceResult | None, name: str

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -549,10 +549,12 @@ class NameChecker(_BasicChecker):
                     if not self._meets_exception_for_non_consts(
                         inferred_assign_type, node.name
                     ):
-                        if _in_dunder_main_block(node):
-                            self._check_name_in_main_block(node)
-                        else:
-                            self._check_name("const", node.name, node)
+                        node_type = (
+                            self._name_type_in_main_block(node)
+                            if _in_dunder_main_block(node)
+                            else "const"
+                        )
+                        self._check_name(node_type, node.name, node)
                 else:
                     node_type = "variable"
                     iattrs = tuple(node.frame().igetattr(node.name))
@@ -573,10 +575,7 @@ class NameChecker(_BasicChecker):
                         inferred_assign_type, node.name
                     ):
                         if node_type == "const" and _in_dunder_main_block(node):
-                            self._check_name_in_main_block(
-                                node, disallowed_check_only=redefines_import
-                            )
-                            return
+                            node_type = self._name_type_in_main_block(node)
                         self._check_name(
                             node_type,
                             node.name,
@@ -612,23 +611,18 @@ class NameChecker(_BasicChecker):
             else:
                 self._check_name("class_attribute", node.name, node)
 
-    def _check_name_in_main_block(
-        self, node: nodes.AssignName, disallowed_check_only: bool = False
-    ) -> None:
-        """Check a module-level name assigned in an ``if __name__ == "__main__":``
-        block.
+    def _name_type_in_main_block(self, node: nodes.AssignName) -> str:
+        """Name type to check a name assigned in an ``if __name__ == "__main__":``
+        block against.
 
         Such a block reads like a script body, so a name there may legitimately
-        follow either the constant or the variable naming style.
+        follow either the constant or the variable naming style. Returning the
+        style the name already conforms to lets both pass, and reports the name
+        against the variable style when it conforms to neither.
         """
-        node_type = (
-            "const"
-            if self._name_regexps["const"].match(node.name) is not None
-            else "variable"
-        )
-        self._check_name(
-            node_type, node.name, node, disallowed_check_only=disallowed_check_only
-        )
+        if self._name_regexps["const"].match(node.name) is not None:
+            return "const"
+        return "variable"
 
     def _meets_exception_for_non_consts(
         self, inferred_assign_type: InferenceResult | None, name: str

--- a/tests/functional/n/name/name_in_main_block.py
+++ b/tests/functional/n/name/name_in_main_block.py
@@ -1,0 +1,18 @@
+"""Names assigned in an ``if __name__ == "__main__":`` block read like a script
+body, so they may follow either the constant or the variable naming style."""
+# pylint: disable=missing-function-docstring
+
+
+def main() -> int:
+    return 0
+
+
+MODULE_CONST = 1
+module_var = 2  # [invalid-name]
+
+
+if __name__ == "__main__":
+    exit_code = main()  # variable style is accepted
+    EXIT_CODE = main()  # constant style is accepted
+    BadMix = main()  # [invalid-name]
+    raise SystemExit(exit_code or EXIT_CODE or BadMix)

--- a/tests/functional/n/name/name_in_main_block.py
+++ b/tests/functional/n/name/name_in_main_block.py
@@ -1,6 +1,7 @@
 """Names assigned in an ``if __name__ == "__main__":`` block read like a script
 body, so they may follow either the constant or the variable naming style."""
 # pylint: disable=missing-function-docstring
+import sys
 
 
 def main() -> int:
@@ -15,4 +16,12 @@ if __name__ == "__main__":
     exit_code = main()  # variable style is accepted
     EXIT_CODE = main()  # constant style is accepted
     BadMix = main()  # [invalid-name]
-    raise SystemExit(exit_code or EXIT_CODE or BadMix)
+    unused_returnCode = main()  # [invalid-name]
+    if sys.argv[1:]:
+        exclusively_assigned = main()  # exclusive assignments read as a constant
+    else:
+        exclusively_assigned = 0
+    sys.exit(exit_code or EXIT_CODE or BadMix or exclusively_assigned)
+else:
+    # The ``else`` branch runs on import, so it keeps the constant naming style.
+    imported_flag = main()  # [invalid-name]

--- a/tests/functional/n/name/name_in_main_block.txt
+++ b/tests/functional/n/name/name_in_main_block.txt
@@ -1,0 +1,2 @@
+invalid-name:11:0:11:10::"Constant name ""module_var"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:17:4:17:10::"Variable name ""BadMix"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/n/name/name_in_main_block.txt
+++ b/tests/functional/n/name/name_in_main_block.txt
@@ -1,2 +1,4 @@
-invalid-name:11:0:11:10::"Constant name ""module_var"" doesn't conform to UPPER_CASE naming style":HIGH
-invalid-name:17:4:17:10::"Variable name ""BadMix"" doesn't conform to snake_case naming style":HIGH
+invalid-name:12:0:12:10::"Constant name ""module_var"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:18:4:18:10::"Variable name ""BadMix"" doesn't conform to snake_case naming style":HIGH
+invalid-name:19:4:19:21::"Variable name ""unused_returnCode"" doesn't conform to snake_case naming style":HIGH
+invalid-name:27:4:27:17::"Constant name ""imported_flag"" doesn't conform to UPPER_CASE naming style":HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Names assigned in an `if __name__ == "__main__":` block were checked against the
**constant** naming style, so an ordinary variable produced a false
`invalid-name` (C0103):

```python
def main() -> int:
    ...

if __name__ == "__main__":
    exit_code = main()  # C0103: Constant name "exit_code" doesn't conform to UPPER_CASE
    raise SystemExit(exit_code)
```

The `__main__` guard reads like a script body, where a name can reasonably be a
one-off variable *or* a module constant. This PR special-cases that block so a
name is accepted if it matches **either** the constant or the variable naming
style (and is still reported otherwise). This follows the direction discussed in
#10700 ("let module-level names pass against either constant or variable regexes,
but not anything else").

Behaviour:

```python
if __name__ == "__main__":
    exit_code = main()  # ok (variable style)
    EXIT_CODE = main()  # ok (constant style)
    BadMix = main()     # still C0103 (matches neither)
```

Module-level names *outside* the block are unaffected. Detection only matches the
body of the guard (not its `else`) and accepts both `__name__ == "__main__"` and
the reversed comparison.

Closes #10766
