### PR TITLE
Fix `superfluous-parens` false negative for a single literal after `in`

### DIFF
--- a/doc/whatsnew/fragments/9878.false_negative
+++ b/doc/whatsnew/fragments/9878.false_negative
@@ -1,0 +1,7 @@
+``superfluous-parens`` (``C0325``) no longer false-negatives on a single
+parenthesised literal after the ``in`` keyword, e.g. ``x in ("foo")``. The
+parentheses around a single string or number literal are now reported as
+superfluous, while a tuple (``x in ("foo",)``) or a larger expression
+(``x in ("foo" + bar)``) is still left untouched.
+
+Closes #9878

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -355,9 +355,18 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                     if found_and_or:
                         return
                     if keyword_token == "in":
-                        # This special case was added in https://github.com/pylint-dev/pylint/pull/4948
-                        # but it could be removed in the future. Avoid churn for now.
-                        return
+                        # Parentheses around a tuple after ``in`` are required, so
+                        # they were given a blanket pass in pull request #4948.
+                        # Parentheses around a single literal (e.g. ``x in ("a")``)
+                        # are still superfluous, so report only those and leave
+                        # anything more complex untouched to avoid the false
+                        # positives #4948 guarded against.
+                        single_literal = i == start + 3 and tokens[start + 2].type in {
+                            tokenize.STRING,
+                            tokenize.NUMBER,
+                        }
+                        if not single_literal:
+                            return
                     self.add_message(
                         "superfluous-parens", line=line_num, args=keyword_token
                     )

--- a/tests/functional/s/superfluous_parens.py
+++ b/tests/functional/s/superfluous_parens.py
@@ -81,3 +81,14 @@ hi = ("CONST",)
 
 #TODO: maybe get this line to report [superfluous-parens] without causing other false positives.
 assert "" + ("Version " + "String") in Z
+
+# Parentheses around a single literal after ``in`` are superfluous (#9878),
+# but parentheses around a tuple or a larger expression are not.
+if Z in ("CONST"):  # [superfluous-parens]
+    pass
+if Z in ("CONST",):
+    pass
+if Z in ("a", "b"):
+    pass
+if Z in ("Version " + "String"):
+    pass

--- a/tests/functional/s/superfluous_parens.txt
+++ b/tests/functional/s/superfluous_parens.txt
@@ -10,3 +10,4 @@ superfluous-parens:75:0:None:None::Unnecessary parens after '=' keyword:UNDEFINE
 superfluous-parens:76:0:None:None::Unnecessary parens after 'assert' keyword:UNDEFINED
 superfluous-parens:77:0:None:None::Unnecessary parens after 'assert' keyword:UNDEFINED
 superfluous-parens:79:0:None:None::Unnecessary parens after '=' keyword:UNDEFINED
+superfluous-parens:87:0:None:None::Unnecessary parens after 'in' keyword:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`superfluous-parens` (`C0325`) did not trigger on a single parenthesized literal after the `in` keyword, e.g. `if x in ("foo"):` — the redundant parentheses went unreported.

`in` was given a blanket pass in #4948 because the parentheses around a *tuple* (`x in (1, 2)`) are required. The parentheses around a single string/number literal are still superfluous, so this narrows the exemption: a single literal token after `in` is now reported, while tuples, double-paren generator expressions (the case #4948 guarded against), and larger expressions are left untouched.

Added functional tests (one positive case, three must-not-warn guards) and a news fragment.

Closes #9878

The sibling false negative with `and`/`or` operators (Refs #10084) is intentionally left out of scope here.
