### PR TITLE
Fix `unnecessary-comprehension` false positive when iterating a dict

### DIFF
--- a/doc/whatsnew/fragments/8256.false_positive
+++ b/doc/whatsnew/fragments/8256.false_positive
@@ -1,0 +1,7 @@
+Fix a false positive for ``unnecessary-comprehension`` (R1721) when a dict
+comprehension iterates directly over a dict, e.g.
+``{key: value for key, value in some_dict}``. Iterating over a dict yields its
+keys rather than key/value pairs, so ``dict(some_dict)`` would merely copy it
+and is not an equivalent replacement.
+
+Closes #8256

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1865,6 +1865,13 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                     args = (f"list({node.iter.as_string()})",)
                 case [nodes.SetComp(), nodes.Set()]:
                     args = (f"set({node.iter.as_string()})",)
+                case [nodes.DictComp(), nodes.Dict()]:
+                    # Iterating over a dict yields its keys, so
+                    # ``{key: value for key, value in some_dict}`` builds a new,
+                    # different mapping instead of reproducing ``some_dict``.
+                    # ``dict(some_dict)`` would merely copy it, so the
+                    # comprehension is not unnecessary here.
+                    return
             if args:
                 self.add_message(
                     "unnecessary-comprehension", node=node.parent, args=args

--- a/tests/functional/u/unnecessary/unnecessary_comprehension.py
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension.py
@@ -49,3 +49,9 @@ my_set = set()
 ITEMS = {k: v for k, v in my_dict.items()} # [unnecessary-comprehension]
 {k: my_dict[k] for k in my_dict} # [consider-using-dict-items]
 {elem for elem in my_set}  # [unnecessary-comprehension]
+
+# Iterating over a dict yields its keys, not key/value pairs, so the dict
+# comprehension below builds a different mapping; dict(tuple_keys) would only
+# copy it and is not equivalent. Regression test for #8256.
+tuple_keys = {(1, 2): 3}
+{key: value for key, value in tuple_keys}  # not equivalent to dict(tuple_keys)


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`unnecessary-comprehension` (R1721) rewrites a dict comprehension as a single
`dict(...)` call on the iterable. That rewrite is only valid when iterating the
iterable yields the key/value pairs that `dict()` consumes.

When the comprehension iterates **directly over a dict**, iteration yields the
dict's *keys*, not key/value pairs:

```python
dict1 = {(1, 2): 3}
dict2 = {a: b for a, b in dict1}   # -> {1: 2}
```

Here pylint wrongly emitted `use dict(dict1) instead`, but `dict(dict1)` simply
copies `dict1` (`{(1, 2): 3}`), which is not equivalent to the comprehension's
result (`{1: 2}`). The comprehension is doing real work and is not
"unnecessary", so the message is now skipped for this case.

The behaviour of every other case is unchanged:

- `{k: v for k, v in d.items()}` → still suggests `dict(d)` ✓
- `{a: b for a, b in pairs}` (list of pairs / un-inferable iterable) → still
  suggests `dict(pairs)` ✓
- `[x for x in d]` / `{x for x in d}` → still suggest `list(d)` / `set(d)`,
  which *are* equivalent since iterating a dict yields its keys ✓

### Note on the diff

To keep `_check_unnecessary_comprehension` within pylint's own `max-branches`
limit (the dogfood `pylint` job) now that a dict case is added, the explicit
`ListComp`/`SetComp` cases in the inferred-iterable `match` are removed: they
produced exactly the same message as the generic fall-through
(`list(node.iter.as_string())` / `set(node.iter.as_string())`), so removing
them is behaviour-preserving (covered by the existing functional tests).

A regression test is added to
`tests/functional/u/unnecessary/unnecessary_comprehension.py`.

Closes #8256
