### PR TITLE
Fix crash when enum member inference fails

### DIFF
--- a/doc/whatsnew/fragments/11069.bugfix
+++ b/doc/whatsnew/fragments/11069.bugfix
@@ -1,0 +1,3 @@
+Avoid crashing when enum member inference fails while checking enum subclasses.
+
+Closes #11069

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -936,12 +936,9 @@ a metaclass class method.",
             self.add_message("duplicate-bases", args=node.name, node=node)
 
     def _check_enum_base(self, node: nodes.ClassDef, ancestor: nodes.ClassDef) -> None:
-        try:
-            members = ancestor.getattr("__members__")
-        except (astroid.AttributeInferenceError, astroid.NotFoundError):
-            members = []
-
-        match members:
+        if not isinstance(ancestor, nodes.ClassDef):
+            return
+        match ancestor.locals.get("__members__", []):
             case [nodes.Dict(items=items), *_] if items:
                 for _, name_node in items:
                     # Exempt type annotations without value assignments

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -936,7 +936,12 @@ a metaclass class method.",
             self.add_message("duplicate-bases", args=node.name, node=node)
 
     def _check_enum_base(self, node: nodes.ClassDef, ancestor: nodes.ClassDef) -> None:
-        match ancestor.getattr("__members__"):
+        try:
+            members = ancestor.getattr("__members__")
+        except (astroid.AttributeInferenceError, astroid.NotFoundError):
+            members = []
+
+        match members:
             case [nodes.Dict(items=items), *_] if items:
                 for _, name_node in items:
                     # Exempt type annotations without value assignments

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -936,8 +936,6 @@ a metaclass class method.",
             self.add_message("duplicate-bases", args=node.name, node=node)
 
     def _check_enum_base(self, node: nodes.ClassDef, ancestor: nodes.ClassDef) -> None:
-        if not isinstance(ancestor, nodes.ClassDef):
-            return
         match ancestor.locals.get("__members__", []):
             case [nodes.Dict(items=items), *_] if items:
                 for _, name_node in items:

--- a/tests/regrtest_data/enum_members_inference_crash.py
+++ b/tests/regrtest_data/enum_members_inference_crash.py
@@ -1,0 +1,13 @@
+from enum import Enum, IntFlag
+from typing import Generic
+
+
+class len:
+    pass
+
+
+class C(IntFlag):
+    pass
+
+
+Enum.EnumType = None


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Closes #11069

`_check_enum_base` now handles `__members__` lookup failures instead of letting astroid inference errors become fatal crashes.

Added the issue reproducer as a regression test.

Tests:

- `PYTHONPATH=$PWD .venv/bin/python -m pytest tests/test_regr.py -q`
- `PYTHONPATH=$PWD .venv/bin/python -m pytest tests/test_functional.py -k invalid_enum_extension -q`
- `PYTHONPATH=$PWD .venv/bin/python -m towncrier check --compare-with upstream/main`