### PR TITLE
Allow digits in ParamSpec and TypeVarTuple names for invalid-name check

### DIFF
--- a/doc/whatsnew/fragments/11090.bugfix
+++ b/doc/whatsnew/fragments/11090.bugfix
@@ -1,0 +1,8 @@
+Allow digits in ParamSpec and TypeVarTuple names for `invalid-name` check.
+
+The default `paramspec-rgx` and `typevartuple-rgx` patterns rejected names
+containing digits (e.g. ``Ec2P``, ``S3Ts``), emitting a false ``invalid-name``
+(C0103). Allow digits in the lowercase segments, consistent with the
+``typevar`` and ``typealias`` patterns.
+
+Closes #11090

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -42,8 +42,8 @@ DEFAULT_PATTERNS = {
     "typevar": re.compile(
         r"^_{0,2}(?!T[A-Z])(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:T)?(?<!Type))(?:_co(?:ntra)?)?$"
     ),
-    "paramspec": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z]+)+(?:P)?(?<!Type))$"),
-    "typevartuple": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z]+)+(?:Ts)?(?<!Type))$"),
+    "paramspec": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:P)?(?<!Type))$"),
+    "typevartuple": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:Ts)?(?<!Type))$"),
     "typealias": re.compile(
         r"^_{0,2}(?!T[A-Z]|Type)[A-Z]+[a-z0-9]+(?:[A-Z][a-z0-9]+)*$"
     ),

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -43,7 +43,9 @@ DEFAULT_PATTERNS = {
         r"^_{0,2}(?!T[A-Z])(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:T)?(?<!Type))(?:_co(?:ntra)?)?$"
     ),
     "paramspec": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:P)?(?<!Type))$"),
-    "typevartuple": re.compile(r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:Ts)?(?<!Type))$"),
+    "typevartuple": re.compile(
+        r"^_{0,2}(?:[A-Z]+|(?:[A-Z]+[a-z0-9]+)+(?:Ts)?(?<!Type))$"
+    ),
     "typealias": re.compile(
         r"^_{0,2}(?!T[A-Z]|Type)[A-Z]+[a-z0-9]+(?:[A-Z][a-z0-9]+)*$"
     ),

--- a/tests/functional/t/type/typevar_naming_style_default.311.txt
+++ b/tests/functional/t/type/typevar_naming_style_default.311.txt
@@ -20,5 +20,5 @@ invalid-name:68:0:68:7::"Type variable name ""badName"" doesn't conform to prede
 typevar-double-variance:69:0:69:4::TypeVar cannot be both covariant and contravariant:INFERENCE
 typevar-name-incorrect-variance:69:0:69:4::Type variable name does not reflect variance:INFERENCE
 invalid-name:76:0:76:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:82:0:82:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:96:0:96:7::"Type variable tuple name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:83:0:83:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:98:0:98:7::"Type variable tuple name ""badName"" doesn't conform to predefined naming style":HIGH

--- a/tests/functional/t/type/typevar_naming_style_default.py
+++ b/tests/functional/t/type/typevar_naming_style_default.py
@@ -74,12 +74,14 @@ P = ParamSpec("P")
 _P = ParamSpec("_P")
 GoodNameP = ParamSpec("GoodNameP")
 badName = ParamSpec("badName")  # [invalid-name]
+Ec2P = ParamSpec("Ec2P")
 
 # -- typing_extensions.ParamSpec --
 P = te.ParamSpec("P")
 _P = te.ParamSpec("_P")
 GoodNameP = te.ParamSpec("GoodNameP")
 badName = te.ParamSpec("badName")  # [invalid-name]
+Ec2P = te.ParamSpec("Ec2P")
 
 
 # # -- typing.TypeVarTuple (TODO 3.11+) --
@@ -94,3 +96,4 @@ Ts = te.TypeVarTuple("Ts")
 _Ts = te.TypeVarTuple("_Ts")
 GoodNameTs = te.TypeVarTuple("GoodNameTs")
 badName = te.TypeVarTuple("badName")  # >=3.11:[invalid-name]
+S3Ts = te.TypeVarTuple("S3Ts")

--- a/tests/functional/t/type/typevar_naming_style_default.txt
+++ b/tests/functional/t/type/typevar_naming_style_default.txt
@@ -20,4 +20,4 @@ invalid-name:68:0:68:7::"Type variable name ""badName"" doesn't conform to prede
 typevar-double-variance:69:0:69:4::TypeVar cannot be both covariant and contravariant:INFERENCE
 typevar-name-incorrect-variance:69:0:69:4::Type variable name does not reflect variance:INFERENCE
 invalid-name:76:0:76:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
-invalid-name:82:0:82:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH
+invalid-name:83:0:83:7::"Parameter specification variable name ""badName"" doesn't conform to predefined naming style":HIGH


### PR DESCRIPTION
Closes #11090

Follow-up to #11078 — the typevar regex was updated to allow digits but paramspec and typevartuple were missed. Two-character change in each: [a-z]+ → [a-z0-9]+.

Test cases added mirroring the #11078 pattern (Ec2P, S3Ts). Expected output files unchanged — valid names produce no errors.