### PR TITLE
Fix a crash in bad-open-mode when the mode is NotImplemented

### DIFF
--- a/doc/whatsnew/fragments/11099.bugfix
+++ b/doc/whatsnew/fragments/11099.bugfix
@@ -1,0 +1,4 @@
+Fix a crash in the ``bad-open-mode`` check when the ``mode`` argument of
+``open`` is the ``NotImplemented`` constant (Python >= 3.14).
+
+Closes #11099

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -874,13 +874,14 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                 self.add_message(
                     "bad-open-mode",
                     node=node,
-                    args=mode_arg.value or str(mode_arg.value),
+                    # avoid a boolean context on the constant ``bool(NotImplemented)``
+                    # raises a TypeError on Python >= 3.14
+                    args=str(mode_arg.value),
                     confidence=confidence,
                 )
 
         if not mode_arg or (
-            isinstance(mode_arg, nodes.Const)
-            and not (mode_arg.value and "b" in str(mode_arg.value))
+            isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
         ):
             confidence = HIGH
             try:

--- a/tests/functional/b/bad_open_mode.py
+++ b/tests/functional/b/bad_open_mode.py
@@ -22,3 +22,5 @@ open(NAME, "Ua", encoding="utf-8")  # [bad-open-mode]
 open(NAME, "Ur++", encoding="utf-8")  # [bad-open-mode]
 open(NAME, "Ut", encoding="utf-8")
 open(NAME, "Ubr")
+# Crashed with a TypeError on Python >= 3.14 (issue #11099)
+open(NAME, NotImplemented)  # [bad-open-mode, unspecified-encoding]

--- a/tests/functional/b/bad_open_mode.txt
+++ b/tests/functional/b/bad_open_mode.txt
@@ -4,3 +4,5 @@ bad-open-mode:14:0:14:33::"""+"" is not a valid mode for open.":HIGH
 bad-open-mode:15:0:15:34::"""xw"" is not a valid mode for open.":HIGH
 bad-open-mode:21:0:21:34::"""Ua"" is not a valid mode for open.":HIGH
 bad-open-mode:22:0:22:36::"""Ur++"" is not a valid mode for open.":HIGH
+bad-open-mode:26:0:26:26::"""NotImplemented"" is not a valid mode for open.":HIGH
+unspecified-encoding:26:0:26:26::Using open without explicitly specifying an encoding:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

On Python >= 3.14, evaluating `NotImplemented` in a boolean context raises a `TypeError` (it was a `DeprecationWarning` before). `_check_open_call` did this twice for a constant `mode` argument:

- `args=mode_arg.value or str(mode_arg.value)` when emitting `bad-open-mode`, which is where the reported crash happens;
- `not (mode_arg.value and "b" in str(mode_arg.value))` in the binary-mode test that gates the `unspecified-encoding` check, which would crash next on the same file once the first site is fixed.

Since the `bad-open-mode` message is `%s`-formatted, `mode_arg.value or str(mode_arg.value)` always rendered as `str(mode_arg.value)` anyway, so the first site now passes `str(mode_arg.value)` directly. The binary-mode test becomes `"b" not in str(mode_arg.value)`, which keeps the existing behavior for all constant values without putting the constant in a boolean context.

With the fix, `open(f, NotImplemented)` emits `bad-open-mode` and `unspecified-encoding` (the same messages Python <= 3.13 produced) instead of crashing. The new functional test line exercises both sites: with only the first one fixed it still crashes on 3.14.

Closes #11099
