### PR TITLE
Fix a crash in not-async-context-manager when the manager has no name

### DIFF
--- a/doc/whatsnew/fragments/11102.bugfix
+++ b/doc/whatsnew/fragments/11102.bugfix
@@ -1,0 +1,5 @@
+Fix a crash in the ``not-async-context-manager`` check when the async
+context manager infers to a value without a name, such as the ``slice``
+returned by ``async with slice(...)``.
+
+Closes #11102

--- a/doc/whatsnew/fragments/11102.bugfix
+++ b/doc/whatsnew/fragments/11102.bugfix
@@ -1,5 +1,5 @@
-Fix a crash in the ``not-async-context-manager`` check when the async
-context manager infers to a value without a name, such as the ``slice``
-returned by ``async with slice(...)``.
+Fix a crash in the ``not-context-manager`` and ``not-async-context-manager``
+checks when the context manager infers to a value without a name, such as the
+``slice`` returned by ``with slice(...)`` / ``async with slice(...)``.
 
 Closes #11102

--- a/pylint/checkers/async_checker.py
+++ b/pylint/checkers/async_checker.py
@@ -88,15 +88,22 @@ class AsyncChecker(checkers.BaseChecker):
                                 continue
                     else:
                         continue
-            # A ``Slice`` inferred from ``slice(...)`` has no ``name``; use its
-            # builtin type name instead.  Every other inferred result reaching
-            # here is name-bearing (a class/function or an instance such as the
-            # ``int`` from ``42``, which astroid models as a named ``Const``).
-            inferred_name = (
-                inferred.pytype().rsplit(".", 1)[-1]
-                if isinstance(inferred, nodes.Slice)
-                else inferred.name
-            )
+            # Only read ``name`` from nodes known to define it; any other
+            # inferred result (e.g. a ``Slice`` from ``slice(...)``) has no
+            # ``name``, so fall back to the inferred type's name to keep the
+            # message informative without risking an ``AttributeError``.
+            if isinstance(
+                inferred,
+                (
+                    nodes.ClassDef,
+                    nodes.FunctionDef,
+                    nodes.Module,
+                    astroid.bases.BaseInstance,
+                ),
+            ):
+                inferred_name = inferred.name
+            else:
+                inferred_name = inferred.pytype().rsplit(".", 1)[-1]
             self.add_message(
                 "not-async-context-manager", node=node, args=(inferred_name,)
             )

--- a/pylint/checkers/async_checker.py
+++ b/pylint/checkers/async_checker.py
@@ -88,8 +88,13 @@ class AsyncChecker(checkers.BaseChecker):
                                 continue
                     else:
                         continue
+            # ``inferred`` is not guaranteed to have a ``name`` (e.g. a ``Slice``
+            # inferred from ``slice(...)``); fall back to its inferred type name.
+            inferred_name = (
+                getattr(inferred, "name", None) or inferred.pytype().rsplit(".", 1)[-1]
+            )
             self.add_message(
-                "not-async-context-manager", node=node, args=(inferred.name,)
+                "not-async-context-manager", node=node, args=(inferred_name,)
             )
 
 

--- a/pylint/checkers/async_checker.py
+++ b/pylint/checkers/async_checker.py
@@ -97,6 +97,7 @@ class AsyncChecker(checkers.BaseChecker):
                 (
                     nodes.ClassDef,
                     nodes.FunctionDef,
+                    nodes.Lambda,
                     nodes.Module,
                     astroid.bases.BaseInstance,
                 ),

--- a/pylint/checkers/async_checker.py
+++ b/pylint/checkers/async_checker.py
@@ -88,10 +88,14 @@ class AsyncChecker(checkers.BaseChecker):
                                 continue
                     else:
                         continue
-            # ``inferred`` is not guaranteed to have a ``name`` (e.g. a ``Slice``
-            # inferred from ``slice(...)``); fall back to its inferred type name.
+            # A ``Slice`` inferred from ``slice(...)`` has no ``name``; use its
+            # builtin type name instead.  Every other inferred result reaching
+            # here is name-bearing (a class/function or an instance such as the
+            # ``int`` from ``42``, which astroid models as a named ``Const``).
             inferred_name = (
-                getattr(inferred, "name", None) or inferred.pytype().rsplit(".", 1)[-1]
+                inferred.pytype().rsplit(".", 1)[-1]
+                if isinstance(inferred, nodes.Slice)
+                else inferred.name
             )
             self.add_message(
                 "not-async-context-manager", node=node, args=(inferred_name,)

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -2010,15 +2010,23 @@ accessed. Python regular expressions are accepted.",
                                 if inferred.name[-5:].lower() == "mixin":
                                     continue
 
-                        # A ``Slice`` inferred from ``slice(...)`` has no ``name``;
-                        # use its builtin type name instead.  Every other inferred
-                        # result reaching here is name-bearing (a class/function or
-                        # an instance such as the ``int`` from ``42``).
-                        inferred_name = (
-                            inferred.pytype().rsplit(".", 1)[-1]
-                            if isinstance(inferred, nodes.Slice)
-                            else inferred.name
-                        )
+                        # Only read ``name`` from nodes known to define it; any
+                        # other inferred result (e.g. a ``Slice`` from
+                        # ``slice(...)``) has no ``name``, so fall back to the
+                        # inferred type's name to keep the message informative
+                        # without risking an ``AttributeError``.
+                        if isinstance(
+                            inferred,
+                            (
+                                nodes.ClassDef,
+                                nodes.FunctionDef,
+                                nodes.Module,
+                                bases.BaseInstance,
+                            ),
+                        ):
+                            inferred_name = inferred.name
+                        else:
+                            inferred_name = inferred.pytype().rsplit(".", 1)[-1]
                         self.add_message(
                             "not-context-manager", node=node, args=(inferred_name,)
                         )

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -2020,6 +2020,7 @@ accessed. Python regular expressions are accepted.",
                             (
                                 nodes.ClassDef,
                                 nodes.FunctionDef,
+                                nodes.Lambda,
                                 nodes.Module,
                                 bases.BaseInstance,
                             ),

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -2010,8 +2010,17 @@ accessed. Python regular expressions are accepted.",
                                 if inferred.name[-5:].lower() == "mixin":
                                     continue
 
+                        # A ``Slice`` inferred from ``slice(...)`` has no ``name``;
+                        # use its builtin type name instead.  Every other inferred
+                        # result reaching here is name-bearing (a class/function or
+                        # an instance such as the ``int`` from ``42``).
+                        inferred_name = (
+                            inferred.pytype().rsplit(".", 1)[-1]
+                            if isinstance(inferred, nodes.Slice)
+                            else inferred.name
+                        )
                         self.add_message(
-                            "not-context-manager", node=node, args=(inferred.name,)
+                            "not-context-manager", node=node, args=(inferred_name,)
                         )
 
     @only_required_for_messages("invalid-unary-operand-type")

--- a/tests/functional/n/not_async_context_manager.py
+++ b/tests/functional/n/not_async_context_manager.py
@@ -58,6 +58,8 @@ async def bad_coro():
         pass
     async with SecondPartialAsyncContextManager(): # [not-async-context-manager]
         pass
+    async with slice(None): # [not-async-context-manager]
+        pass
 
 
 async def good_coro():

--- a/tests/functional/n/not_async_context_manager.txt
+++ b/tests/functional/n/not_async_context_manager.txt
@@ -3,3 +3,4 @@ not-async-context-manager:53:4:54:12:bad_coro:Async context manager 'generator' 
 not-async-context-manager:55:4:56:12:bad_coro:Async context manager 'ContextManager' doesn't implement __aenter__ and __aexit__.:UNDEFINED
 not-async-context-manager:57:4:58:12:bad_coro:Async context manager 'PartialAsyncContextManager' doesn't implement __aenter__ and __aexit__.:UNDEFINED
 not-async-context-manager:59:4:60:12:bad_coro:Async context manager 'SecondPartialAsyncContextManager' doesn't implement __aenter__ and __aexit__.:UNDEFINED
+not-async-context-manager:61:4:62:12:bad_coro:Async context manager 'slice' doesn't implement __aenter__ and __aexit__.:UNDEFINED

--- a/tests/functional/n/not_context_manager.py
+++ b/tests/functional/n/not_context_manager.py
@@ -133,3 +133,6 @@ def not_context_manager():
 
 with not_context_manager(): # [not-context-manager]
     pass
+
+with slice(None): # [not-context-manager]
+    pass

--- a/tests/functional/n/not_context_manager.txt
+++ b/tests/functional/n/not_context_manager.txt
@@ -3,3 +3,4 @@ not-context-manager:37:0:38:8::Context manager 'dec' doesn't implement __enter__
 not-context-manager:55:0:56:8::Context manager 'int' doesn't implement __enter__ and __exit__.:UNDEFINED
 not-context-manager:90:0:91:8::Context manager 'int' doesn't implement __enter__ and __exit__.:UNDEFINED
 not-context-manager:134:0:135:8::Context manager 'generator' doesn't implement __enter__ and __exit__.:UNDEFINED
+not-context-manager:137:0:138:8::Context manager 'slice' doesn't implement __enter__ and __exit__.:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`async with slice(None):` crashed pylint:

```
File "pylint/checkers/async_checker.py", line 92, in visit_asyncwith
    "not-async-context-manager", node=node, args=(inferred.name,)
AttributeError: 'Slice' object has no attribute 'name'
```

`visit_asyncwith` builds the `not-async-context-manager` message argument from `inferred.name`, but the inferred context manager isn't guaranteed to have a name. `slice(None)` infers to a `Slice` node, which has no `name`, so emitting the (otherwise correct) warning raised `AttributeError` and aborted the run.

It now falls back to the inferred type name when there is no `name`, so `slice(None)` reports `Async context manager 'slice' doesn't implement __aenter__ and __aexit__.` — consistent with how the other value managers are already reported (e.g. `async with 42` → `'int'`). Among the value nodes that can appear here only `Slice` lacks a `name` (`Const`/`List`/`Tuple`/`Dict` all expose their type name), so this covers the reported case.

Added the `slice(None)` case to the existing `not_async_context_manager` functional test (crashes on `main`, passes here).

Closes #11102