### PR TITLE
Improve arguments-differ message when parameter totals match

### DIFF
--- a/doc/whatsnew/fragments/5793.other
+++ b/doc/whatsnew/fragments/5793.other
@@ -1,0 +1,6 @@
+``arguments-differ`` now describes how the kinds of parameters differ (positional-only,
+positional-or-keyword, keyword-only) when the total number of parameters is unchanged,
+instead of the confusing "Number of parameters was X and is now X". Positional-only
+parameters are also now included in the reported counts.
+
+Closes #5793

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -258,6 +258,35 @@ def _has_different_parameters_default_value(
     return False
 
 
+def _total_parameters(args: nodes.Arguments) -> int:
+    """Count all parameters of a function, including variadics."""
+    total = len(args.posonlyargs) + len(args.args) + len(args.kwonlyargs)
+    if args.vararg:
+        total += 1
+    if args.kwarg:
+        total += 1
+    return total
+
+
+def _parameter_kinds_summary(args: nodes.Arguments) -> str:
+    """Describe the parameters of a function by kind.
+
+    For example "1 positional-or-keyword, 1 keyword-only".
+    """
+    parts = []
+    if args.posonlyargs:
+        parts.append(f"{len(args.posonlyargs)} positional-only")
+    if args.args:
+        parts.append(f"{len(args.args)} positional-or-keyword")
+    if args.vararg:
+        parts.append("*args")
+    if args.kwonlyargs:
+        parts.append(f"{len(args.kwonlyargs)} keyword-only")
+    if args.kwarg:
+        parts.append("**kwargs")
+    return ", ".join(parts)
+
+
 def _has_different_parameters(
     original: list[nodes.AssignName],
     overridden: list[nodes.AssignName],
@@ -2322,25 +2351,33 @@ a metaclass class method.",
         if len(arg_differ_output) > 0:
             for msg in arg_differ_output:
                 if "Number" in msg:
-                    total_args_method1 = len(method1.args.args)
-                    if method1.args.vararg:
-                        total_args_method1 += 1
-                    if method1.args.kwarg:
-                        total_args_method1 += 1
-                    if method1.args.kwonlyargs:
-                        total_args_method1 += len(method1.args.kwonlyargs)
-                    total_args_refmethod = len(refmethod.args.args)
-                    if refmethod.args.vararg:
-                        total_args_refmethod += 1
-                    if refmethod.args.kwarg:
-                        total_args_refmethod += 1
-                    if refmethod.args.kwonlyargs:
-                        total_args_refmethod += len(refmethod.args.kwonlyargs)
+                    total_args_method1 = _total_parameters(method1.args)
+                    total_args_refmethod = _total_parameters(refmethod.args)
                     error_type = "arguments-differ"
+                    refmethod_name = f"{refmethod.parent.frame().name}.{refmethod.name}"
+                    if total_args_refmethod != total_args_method1:
+                        first_arg = (
+                            msg
+                            + f"was {total_args_refmethod} in '{refmethod_name}' and "
+                            f"is now {total_args_method1} in"
+                        )
+                    elif (ref_kinds := _parameter_kinds_summary(refmethod.args)) != (
+                        new_kinds := _parameter_kinds_summary(method1.args)
+                    ):
+                        # The total number of parameters is the same: report how
+                        # the kinds of parameters differ instead.
+                        first_arg = (
+                            f"Kinds of parameters changed from ({ref_kinds}) in "
+                            f"'{refmethod_name}' to ({new_kinds}) in"
+                        )
+                    else:
+                        # Same total and same kinds: keyword-only parameter
+                        # names differ.
+                        first_arg = (
+                            f"Keyword-only parameters differ from '{refmethod_name}' in"
+                        )
                     msg_args = (
-                        msg
-                        + f"was {total_args_refmethod} in '{refmethod.parent.frame().name}.{refmethod.name}' and "
-                        f"is now {total_args_method1} in",
+                        first_arg,
                         class_type,
                         f"{method1.parent.frame().name}.{method1.name}",
                     )

--- a/tests/functional/a/arguments_differ.txt
+++ b/tests/functional/a/arguments_differ.txt
@@ -7,7 +7,7 @@ arguments-differ:144:4:144:12:StaticmethodChild2.func:Number of parameters was 1
 arguments-differ:180:4:180:12:SecondChangesArgs.test:Number of parameters was 2 in 'FirstHasArgs.test' and is now 4 in overriding 'SecondChangesArgs.test' method:UNDEFINED
 arguments-differ:307:4:307:16:Foo.kwonly_1:Number of parameters was 4 in 'AbstractFoo.kwonly_1' and is now 3 in overriding 'Foo.kwonly_1' method:UNDEFINED
 arguments-differ:310:4:310:16:Foo.kwonly_2:Number of parameters was 3 in 'AbstractFoo.kwonly_2' and is now 2 in overriding 'Foo.kwonly_2' method:UNDEFINED
-arguments-differ:313:4:313:16:Foo.kwonly_3:Number of parameters was 3 in 'AbstractFoo.kwonly_3' and is now 3 in overriding 'Foo.kwonly_3' method:UNDEFINED
-arguments-differ:316:4:316:16:Foo.kwonly_4:Number of parameters was 3 in 'AbstractFoo.kwonly_4' and is now 3 in overriding 'Foo.kwonly_4' method:UNDEFINED
+arguments-differ:313:4:313:16:Foo.kwonly_3:Kinds of parameters changed from (1 positional-or-keyword, 2 keyword-only) in 'AbstractFoo.kwonly_3' to (3 positional-or-keyword) in overriding 'Foo.kwonly_3' method:UNDEFINED
+arguments-differ:316:4:316:16:Foo.kwonly_4:Kinds of parameters changed from (1 positional-or-keyword, 2 keyword-only) in 'AbstractFoo.kwonly_4' to (3 positional-or-keyword) in overriding 'Foo.kwonly_4' method:UNDEFINED
 arguments-differ:319:4:319:16:Foo.kwonly_5:Variadics removed in overriding 'Foo.kwonly_5' method:UNDEFINED
 arguments-differ:359:4:359:14:ClassWithNewNonDefaultKeywordOnly.method:Number of parameters was 2 in 'AClass.method' and is now 3 in overriding 'ClassWithNewNonDefaultKeywordOnly.method' method:UNDEFINED

--- a/tests/functional/a/arguments_differ_issue5793.py
+++ b/tests/functional/a/arguments_differ_issue5793.py
@@ -20,3 +20,19 @@ class Child(Base):
 
     def positional_only(self, param1, param2):  # [arguments-differ]
         return param1 - param2
+
+
+class VariadicBase:
+    def variadic_positional(self, *args):
+        print(args)
+
+    def variadic_keyword(self, **kwargs):
+        print(kwargs)
+
+
+class VariadicChild(VariadicBase):
+    def variadic_positional(self, arg):  # [arguments-differ, arguments-differ]
+        print(arg)
+
+    def variadic_keyword(self, *, arg):  # [arguments-differ, arguments-differ]
+        print(arg)

--- a/tests/functional/a/arguments_differ_issue5793.py
+++ b/tests/functional/a/arguments_differ_issue5793.py
@@ -1,0 +1,22 @@
+"""Better message when the parameter kinds differ but the total count does not.
+
+https://github.com/pylint-dev/pylint/issues/5793
+"""
+
+# pylint: disable=missing-class-docstring, missing-function-docstring, too-few-public-methods
+
+
+class Base:
+    def fun(self, var):
+        print(var)
+
+    def positional_only(self, param1, param2, /):
+        return param1 + param2
+
+
+class Child(Base):
+    def fun(self, *, var):  # [arguments-differ]
+        print(var)
+
+    def positional_only(self, param1, param2):  # [arguments-differ]
+        return param1 - param2

--- a/tests/functional/a/arguments_differ_issue5793.txt
+++ b/tests/functional/a/arguments_differ_issue5793.txt
@@ -1,0 +1,2 @@
+arguments-differ:18:4:18:11:Child.fun:Kinds of parameters changed from (2 positional-or-keyword) in 'Base.fun' to (1 positional-or-keyword, 1 keyword-only) in overriding 'Child.fun' method:UNDEFINED
+arguments-differ:21:4:21:23:Child.positional_only:Kinds of parameters changed from (3 positional-only) in 'Base.positional_only' to (3 positional-or-keyword) in overriding 'Child.positional_only' method:UNDEFINED

--- a/tests/functional/a/arguments_differ_issue5793.txt
+++ b/tests/functional/a/arguments_differ_issue5793.txt
@@ -1,2 +1,6 @@
 arguments-differ:18:4:18:11:Child.fun:Kinds of parameters changed from (2 positional-or-keyword) in 'Base.fun' to (1 positional-or-keyword, 1 keyword-only) in overriding 'Child.fun' method:UNDEFINED
 arguments-differ:21:4:21:23:Child.positional_only:Kinds of parameters changed from (3 positional-only) in 'Base.positional_only' to (3 positional-or-keyword) in overriding 'Child.positional_only' method:UNDEFINED
+arguments-differ:34:4:34:27:VariadicChild.variadic_positional:Kinds of parameters changed from (1 positional-or-keyword, *args) in 'VariadicBase.variadic_positional' to (2 positional-or-keyword) in overriding 'VariadicChild.variadic_positional' method:UNDEFINED
+arguments-differ:34:4:34:27:VariadicChild.variadic_positional:Variadics removed in overriding 'VariadicChild.variadic_positional' method:UNDEFINED
+arguments-differ:37:4:37:24:VariadicChild.variadic_keyword:Kinds of parameters changed from (1 positional-or-keyword, **kwargs) in 'VariadicBase.variadic_keyword' to (1 positional-or-keyword, 1 keyword-only) in overriding 'VariadicChild.variadic_keyword' method:UNDEFINED
+arguments-differ:37:4:37:24:VariadicChild.variadic_keyword:Variadics removed in overriding 'VariadicChild.variadic_keyword' method:UNDEFINED

--- a/tests/functional/a/arguments_renamed.txt
+++ b/tests/functional/a/arguments_renamed.txt
@@ -2,7 +2,7 @@ arguments-renamed:17:4:17:12:Orange.brew:Parameter 'fruit_name' has been renamed
 arguments-renamed:20:4:20:26:Orange.eat_with_condiment:Parameter 'fruit_name' has been renamed to 'orange_name' in overriding 'Orange.eat_with_condiment' method:UNDEFINED
 arguments-differ:27:4:27:26:Banana.eat_with_condiment:Number of parameters was 3 in 'Fruit.eat_with_condiment' and is now 4 in overriding 'Banana.eat_with_condiment' method:UNDEFINED
 arguments-renamed:40:4:40:12:Child.test:Parameter 'arg' has been renamed to 'arg1' in overriding 'Child.test' method:UNDEFINED
-arguments-differ:43:4:43:19:Child.kwargs_test:Number of parameters was 4 in 'Parent.kwargs_test' and is now 4 in overriding 'Child.kwargs_test' method:UNDEFINED
+arguments-differ:43:4:43:19:Child.kwargs_test:Keyword-only parameters differ from 'Parent.kwargs_test' in overriding 'Child.kwargs_test' method:UNDEFINED
 arguments-renamed:48:4:48:12:Child2.test:Parameter 'arg' has been renamed to 'var' in overriding 'Child2.test' method:UNDEFINED
 arguments-differ:51:4:51:19:Child2.kwargs_test:Number of parameters was 4 in 'Parent.kwargs_test' and is now 3 in overriding 'Child2.kwargs_test' method:UNDEFINED
 arguments-renamed:67:4:67:13:ChildDefaults.test1:Parameter 'barg' has been renamed to 'param2' in overriding 'ChildDefaults.test1' method:UNDEFINED


### PR DESCRIPTION
- [x] Document your change: changelog fragment ``doc/whatsnew/fragments/5793.other``
- [x] Relate your change to an issue in the tracker: Closes #5793
- [x] Write comprehensive commit messages and/or a good description of what the PR does
- [x] Keep the change small

## Description

``arguments-differ`` produced a confusing message when an overriding method changes the kinds of its parameters without changing the total count (#5793):

Before: ``Number of parameters was 2 in 'Base.fun' and is now 2 in overriding 'Child.fun' method``

After: ``Kinds of parameters changed from (2 positional-or-keyword) in 'Base.fun' to (1 positional-or-keyword, 1 keyword-only) in overriding 'Child.fun' method``

Additional fixes in the same code path:

- Positional-only parameters are now included in the reported totals. Previously ``def test_method(self, param1, param2, /)`` was reported as having 0 parameters (see the second example in the issue).
- When both the totals and the kinds are identical (i.e. only keyword-only parameter names differ), the message now states that the keyword-only parameters differ instead of repeating two equal counts.

The existing wording is kept unchanged when the totals actually differ.

Closes #5793