### PR TITLE
Detect setattr attributes outside init

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -57,6 +57,7 @@ classobj
 CLI
 cls
 cmp
+cnode
 codebase
 codec
 codecs

--- a/doc/whatsnew/fragments/9798.false_negative
+++ b/doc/whatsnew/fragments/9798.false_negative
@@ -1,0 +1,4 @@
+:ref:`attribute-defined-outside-init` now reports attributes assigned with
+``setattr(self, "name", value)`` outside defining methods.
+
+Closes #9798

--- a/doc/whatsnew/fragments/9798.false_negative
+++ b/doc/whatsnew/fragments/9798.false_negative
@@ -1,4 +1,6 @@
 :ref:`attribute-defined-outside-init` now reports attributes assigned with
 ``setattr(self, "name", value)`` outside defining methods.
+It no longer reports attributes assigned normally in a child class when a parent
+defining method initializes them with ``setattr``.
 
 Closes #9798

--- a/doc/whatsnew/fragments/9798.false_negative
+++ b/doc/whatsnew/fragments/9798.false_negative
@@ -1,6 +1,6 @@
 :ref:`attribute-defined-outside-init` now reports attributes assigned with
 ``setattr(self, "name", value)`` outside defining methods.
-It no longer reports attributes assigned normally in a child class when a parent
-defining method initializes them with ``setattr``.
+It no longer reports attributes assigned normally when a defining method of the
+class or of a parent initializes them with ``setattr``.
 
 Closes #9798

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1211,11 +1211,17 @@ a metaclass class method.",
             return
         defining_methods = self.linter.config.defining_attr_methods
         current_module = cnode.root()
-        instance_attrs: dict[str, list[nodes.AssignAttr | nodes.Call]] = {
-            attr: list(nodes_lst) for attr, nodes_lst in cnode.instance_attrs.items()
-        }
-        for attr, nodes_lst in self._setattr_attrs.get(cnode, {}).items():
-            instance_attrs.setdefault(attr, []).extend(nodes_lst)
+        setattr_attrs = self._setattr_attrs.get(cnode)
+        instance_attrs: Mapping[str, Sequence[nodes.NodeNG]]
+        if setattr_attrs:
+            merged: dict[str, list[nodes.NodeNG]] = {
+                attr: list(nodes_lst) for attr, nodes_lst in cnode.instance_attrs.items()
+            }
+            for attr, nodes_lst in setattr_attrs.items():
+                merged.setdefault(attr, []).extend(nodes_lst)
+            instance_attrs = merged
+        else:
+            instance_attrs = cnode.instance_attrs
         for attr, nodes_lst in instance_attrs.items():
             # Exclude `__dict__` as it is already defined.
             if attr == "__dict__":

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -848,6 +848,7 @@ a metaclass class method.",
     def __init__(self, linter: PyLinter) -> None:
         super().__init__(linter)
         self._accessed = ScopeAccessMap()
+        self._setattr_attrs: dict[nodes.ClassDef, dict[str, list[nodes.Call]]] = {}
         self._first_attrs: list[str | None] = []
 
     def open(self) -> None:
@@ -1210,7 +1211,12 @@ a metaclass class method.",
             return
         defining_methods = self.linter.config.defining_attr_methods
         current_module = cnode.root()
-        for attr, nodes_lst in cnode.instance_attrs.items():
+        instance_attrs: dict[str, list[nodes.AssignAttr | nodes.Call]] = {
+            attr: list(nodes_lst) for attr, nodes_lst in cnode.instance_attrs.items()
+        }
+        for attr, nodes_lst in self._setattr_attrs.get(cnode, {}).items():
+            instance_attrs.setdefault(attr, []).extend(nodes_lst)
+        for attr, nodes_lst in instance_attrs.items():
             # Exclude `__dict__` as it is already defined.
             if attr == "__dict__":
                 continue
@@ -1235,33 +1241,86 @@ a metaclass class method.",
             ):
                 continue
 
-            # check attribute is defined in a parent's __init__
-            for parent in cnode.instance_attr_ancestors(attr):
-                attr_defined = False
-                # check if any parent method attr is defined in is a defining method
-                for node in parent.instance_attrs[attr]:
-                    if node.frame().name in defining_methods:
-                        attr_defined = True
-                if attr_defined:
-                    # we're done :)
-                    break
-            else:
-                # check attribute is defined as a class attribute
-                try:
-                    cnode.local_attr(attr)
-                except astroid.NotFoundError:
-                    for node in nodes_lst:
-                        if node.frame().name not in defining_methods:
-                            # If the attribute was set by a call in any
-                            # of the defining methods, then don't emit
-                            # the warning.
-                            if _called_in_methods(
-                                node.frame(), cnode, defining_methods
-                            ):
-                                continue
-                            self.add_message(
-                                "attribute-defined-outside-init", args=attr, node=node
-                            )
+            # check attribute is defined as a class attribute
+            try:
+                cnode.local_attr(attr)
+                continue
+            except astroid.NotFoundError:
+                pass
+
+            if self._defined_in_parent_init(cnode, attr, defining_methods):
+                continue
+
+            for node in nodes_lst:
+                if node.frame().name not in defining_methods:
+                    # If the attribute was set by a call in any
+                    # of the defining methods, then don't emit
+                    # the warning.
+                    if _called_in_methods(node.frame(), cnode, defining_methods):
+                        continue
+                    self.add_message(
+                        "attribute-defined-outside-init", args=attr, node=node
+                    )
+
+    def _defined_in_parent_init(
+        self, cnode: nodes.ClassDef, attr: str, defining_methods: Sequence[str]
+    ) -> bool:
+        # check attribute is defined in a parent's __init__
+        for parent in cnode.instance_attr_ancestors(attr):
+            # check if any parent method attr is defined in is a defining method
+            if any(
+                node.frame().name in defining_methods
+                for node in parent.instance_attrs[attr]
+            ):
+                return True
+        for parent in cnode.ancestors():
+            if parent.root().name == "builtins":
+                continue
+            if any(
+                node.frame().name in defining_methods
+                for node in self._setattr_attrs.get(parent, {}).get(attr, [])
+            ):
+                return True
+        return False
+
+    @only_required_for_messages("attribute-defined-outside-init")
+    def visit_call(self, node: nodes.Call) -> None:
+        match node.func, node.args:
+            case (
+                nodes.Name(name="setattr") as func,
+                [
+                    nodes.Name(name=instance_name),
+                    nodes.Const(value=str() as attr),
+                    *_,
+                ],
+            ):
+                pass
+            case _:
+                return
+
+        frame = node.frame()
+        if not (
+            isinstance(frame, nodes.FunctionDef)
+            and frame.is_method()
+            and frame.type not in {"classmethod", "staticmethod"}
+            and frame.argnames()
+            and instance_name == frame.argnames()[0]
+        ):
+            return
+
+        inferred = safe_infer(func)
+        if not (
+            isinstance(inferred, nodes.FunctionDef)
+            and is_builtin_object(inferred)
+            and inferred.name == "setattr"
+        ):
+            return
+
+        frame_class = node_frame_class(node)
+        if frame_class is not None:
+            self._setattr_attrs.setdefault(frame_class, {}).setdefault(attr, []).append(
+                node
+            )
 
     # pylint: disable = too-many-branches, too-many-return-statements
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1215,7 +1215,8 @@ a metaclass class method.",
         instance_attrs: Mapping[str, Sequence[nodes.NodeNG]]
         if setattr_attrs:
             merged: dict[str, list[nodes.NodeNG]] = {
-                attr: list(nodes_lst) for attr, nodes_lst in cnode.instance_attrs.items()
+                attr: list(nodes_lst)
+                for attr, nodes_lst in cnode.instance_attrs.items()
             }
             for attr, nodes_lst in setattr_attrs.items():
                 merged.setdefault(attr, []).extend(nodes_lst)

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -455,7 +455,7 @@ def _setattr_attr_name(node: nodes.Call, frame: nodes.FunctionDef) -> str | None
     match node.func, node.args:
         case (
             nodes.Name(name="setattr"),
-            [nodes.Name(name=instance_name), nodes.Const(value=str() as attr), *_],
+            [nodes.Name(name=instance_name), nodes.Const(value=str() as attr), _, *_],
         ):
             pass
         case _:
@@ -1252,6 +1252,7 @@ a metaclass class method.",
                 self.add_message("unused-private-member", node=assign_attr, args=args)
 
     def _check_attribute_defined_outside_init(self, cnode: nodes.ClassDef) -> None:
+        setattr_attrs = self._setattr_attrs.pop(cnode, None)
         # check access to existent members on non metaclass classes
         if (
             "attribute-defined-outside-init"
@@ -1271,7 +1272,6 @@ a metaclass class method.",
             return
         defining_methods = self.linter.config.defining_attr_methods
         current_module = cnode.root()
-        setattr_attrs = self._setattr_attrs.pop(cnode, None)
         instance_attrs: Mapping[str, Sequence[nodes.NodeNG]]
         if setattr_attrs:
             merged: dict[str, list[nodes.NodeNG]] = {

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -499,6 +499,8 @@ def _setattr_in_defining_methods(
             if not isinstance(method, nodes.FunctionDef):
                 continue
             for call in method.nodes_of_class(nodes.Call):
+                if call.frame() is not method:
+                    continue
                 if _setattr_attr_name(call, method) == attr:
                     return True
     return False

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1342,20 +1342,23 @@ a metaclass class method.",
     def _defined_in_parent_init(
         self, cnode: nodes.ClassDef, attr: str, defining_methods: Sequence[str]
     ) -> bool:
-        # check attribute is defined in a parent's __init__
-        for parent in cnode.instance_attr_ancestors(attr):
-            # check if any parent method attr is defined in is a defining method
-            if any(
-                node.frame().name in defining_methods
-                for node in parent.instance_attrs[attr]
-            ):
-                return True
+        # check attribute is defined in a parent's defining method
+        return any(
+            node.frame().name in defining_methods
+            for parent in cnode.instance_attr_ancestors(attr)
+            for node in parent.instance_attrs[attr]
+        )
+
+    def _parent_setattr_names(
+        self, cnode: nodes.ClassDef, defining_methods: Sequence[str]
+    ) -> set[str]:
+        """Names an ancestor of *cnode* sets with ``setattr`` in a defining method."""
+        names: set[str] = set()
         for parent in cnode.ancestors():
             if parent.root().name == "builtins":
                 continue
-            if _setattr_in_defining_methods(parent, attr, defining_methods):
-                return True
-        return False
+            names |= _setattr_names_in_defining_methods(parent, defining_methods)
+        return names
 
     @only_required_for_messages("attribute-defined-outside-init")
     def visit_call(self, node: nodes.Call) -> None:

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property
 from itertools import chain, zip_longest
 from re import Pattern
@@ -447,6 +447,63 @@ def _called_in_methods(
     return False
 
 
+def _setattr_attr_name(node: nodes.Call, frame: nodes.FunctionDef) -> str | None:
+    """The attribute name of a literal ``setattr(self, "name", value)`` in *frame*.
+
+    Returns None when *node* is not such a call.
+    """
+    match node.func, node.args:
+        case (
+            nodes.Name(name="setattr"),
+            [nodes.Name(name=instance_name), nodes.Const(value=str() as attr), *_],
+        ):
+            pass
+        case _:
+            return None
+    if frame.type in {"classmethod", "staticmethod"}:
+        return None
+    # Same first argument logic as in '_check_first_arg_for_type': a method
+    # whose only parameter is '*args' does not receive the instance by name.
+    if frame.args.posonlyargs:
+        first_arg = frame.args.posonlyargs[0].name
+    elif frame.args.args:
+        first_arg = frame.argnames()[0]
+    else:
+        return None
+    if instance_name != first_arg:
+        return None
+    inferred = safe_infer(node.func)
+    if not (
+        isinstance(inferred, nodes.FunctionDef)
+        and is_builtin_object(inferred)
+        and inferred.name == "setattr"
+    ):
+        return None
+    return attr
+
+
+def _setattr_in_defining_methods(
+    klass: nodes.ClassDef, attr: str, defining_methods: Sequence[str]
+) -> bool:
+    """Whether *attr* is set by ``setattr(self, "attr", ...)`` in a defining method.
+
+    Only the defining methods are scanned, and only for an attribute that is
+    about to be reported, so this stays cheap. It cannot rely on state gathered
+    while walking, because *klass* may live in a module that is never walked at
+    all, or that is only walked later on.
+    """
+    if klass.type == "metaclass":
+        return False
+    for method_name in defining_methods:
+        for method in klass.locals.get(method_name, ()):
+            if not isinstance(method, nodes.FunctionDef):
+                continue
+            for call in method.nodes_of_class(nodes.Call):
+                if _setattr_attr_name(call, method) == attr:
+                    return True
+    return False
+
+
 def _is_attribute_property(name: str, klass: nodes.ClassDef) -> bool:
     """Check if the given attribute *name* is a property in the given *klass*.
 
@@ -855,6 +912,7 @@ a metaclass class method.",
         self._mixin_class_rgx = self.linter.config.mixin_class_rgx
         py_version = self.linter.config.py_version
         self._py38_plus = py_version >= (3, 8)
+        self._setattr_attrs = {}
 
     @cached_property
     def _dummy_rgx(self) -> Pattern[str]:
@@ -1211,15 +1269,15 @@ a metaclass class method.",
             return
         defining_methods = self.linter.config.defining_attr_methods
         current_module = cnode.root()
-        setattr_attrs = self._setattr_attrs.get(cnode)
+        setattr_attrs = self._setattr_attrs.pop(cnode, None)
         instance_attrs: Mapping[str, Sequence[nodes.NodeNG]]
         if setattr_attrs:
             merged: dict[str, list[nodes.NodeNG]] = {
-                attr: list(nodes_lst)
-                for attr, nodes_lst in cnode.instance_attrs.items()
+                attr: list(attr_nodes)
+                for attr, attr_nodes in cnode.instance_attrs.items()
             }
-            for attr, nodes_lst in setattr_attrs.items():
-                merged.setdefault(attr, []).extend(nodes_lst)
+            for attr, setattr_nodes in setattr_attrs.items():
+                merged.setdefault(attr, []).extend(setattr_nodes)
             instance_attrs = merged
         else:
             instance_attrs = cnode.instance_attrs
@@ -1230,18 +1288,18 @@ a metaclass class method.",
 
             # Skip nodes which are not in the current module and it may screw up
             # the output, while it's not worth it
-            nodes_lst = [
+            filtered_nodes = [
                 n
                 for n in nodes_lst
                 if not isinstance(n.statement(), (nodes.Delete, nodes.AugAssign))
                 and n.root() is current_module
             ]
-            if not nodes_lst:
+            if not filtered_nodes:
                 continue  # error detected by typechecking
 
             # Check if any method attr is defined in is a defining method
             # or if we have the attribute defined in a setter.
-            frames = (node.frame() for node in nodes_lst)
+            frames = (node.frame() for node in filtered_nodes)
             if any(
                 frame.name in defining_methods or is_property_setter(frame)
                 for frame in frames
@@ -1258,7 +1316,7 @@ a metaclass class method.",
             if self._defined_in_parent_init(cnode, attr, defining_methods):
                 continue
 
-            for node in nodes_lst:
+            for node in filtered_nodes:
                 if node.frame().name not in defining_methods:
                     # If the attribute was set by a call in any
                     # of the defining methods, then don't emit
@@ -1283,48 +1341,25 @@ a metaclass class method.",
         for parent in cnode.ancestors():
             if parent.root().name == "builtins":
                 continue
-            if any(
-                node.frame().name in defining_methods
-                for node in self._setattr_attrs.get(parent, {}).get(attr, [])
-            ):
+            if _setattr_in_defining_methods(parent, attr, defining_methods):
                 return True
         return False
 
     @only_required_for_messages("attribute-defined-outside-init")
     def visit_call(self, node: nodes.Call) -> None:
-        match node.func, node.args:
-            case (
-                nodes.Name(name="setattr") as func,
-                [
-                    nodes.Name(name=instance_name),
-                    nodes.Const(value=str() as attr),
-                    *_,
-                ],
-            ):
-                pass
-            case _:
-                return
-
+        if not (isinstance(node.func, nodes.Name) and node.func.name == "setattr"):
+            return
         frame = node.frame()
-        if not (
-            isinstance(frame, nodes.FunctionDef)
-            and frame.is_method()
-            and frame.type not in {"classmethod", "staticmethod"}
-            and frame.argnames()
-            and instance_name == frame.argnames()[0]
-        ):
+        if not (isinstance(frame, nodes.FunctionDef) and frame.is_method()):
             return
-
-        inferred = safe_infer(func)
-        if not (
-            isinstance(inferred, nodes.FunctionDef)
-            and is_builtin_object(inferred)
-            and inferred.name == "setattr"
-        ):
-            return
-
         frame_class = node_frame_class(node)
-        if frame_class is not None:
+        # In a metaclass method the first argument is the class itself, so
+        # ``setattr(cls, "name", value)`` defines a class attribute, exactly
+        # like ``cls.name = value`` does.
+        if frame_class is None or frame_class.type == "metaclass":
+            return
+        attr = _setattr_attr_name(node, frame)
+        if attr is not None:
             self._setattr_attrs.setdefault(frame_class, {}).setdefault(attr, []).append(
                 node
             )

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1321,6 +1321,13 @@ a metaclass class method.",
             if self._defined_in_parent_init(cnode, attr, defining_methods):
                 continue
 
+            if parent_setattr_names is None:
+                parent_setattr_names = self._parent_setattr_names(
+                    cnode, defining_methods
+                )
+            if attr in parent_setattr_names:
+                continue
+
             for node in filtered_nodes:
                 if node.frame().name not in defining_methods:
                     # If the attribute was set by a call in any

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1274,6 +1274,7 @@ a metaclass class method.",
             return
         defining_methods = self.linter.config.defining_attr_methods
         current_module = cnode.root()
+        parent_setattr_names: set[str] | None = None
         instance_attrs: Mapping[str, Sequence[nodes.NodeNG]]
         if setattr_attrs:
             merged: dict[str, list[nodes.NodeNG]] = {

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -482,18 +482,19 @@ def _setattr_attr_name(node: nodes.Call, frame: nodes.FunctionDef) -> str | None
     return attr
 
 
-def _setattr_in_defining_methods(
-    klass: nodes.ClassDef, attr: str, defining_methods: Sequence[str]
-) -> bool:
-    """Whether *attr* is set by ``setattr(self, "attr", ...)`` in a defining method.
+def _setattr_names_in_defining_methods(
+    klass: nodes.ClassDef, defining_methods: Sequence[str]
+) -> set[str]:
+    """Names set by ``setattr(self, "name", ...)`` in *klass*' defining methods.
 
-    Only the defining methods are scanned, and only for an attribute that is
-    about to be reported, so this stays cheap. It cannot rely on state gathered
-    while walking, because *klass* may live in a module that is never walked at
-    all, or that is only walked later on.
+    Only the defining methods are scanned, and only once a message is about to
+    be reported, so this stays cheap. It cannot rely on state gathered while
+    walking, because *klass* may live in a module that is never walked at all,
+    or that is only walked later on.
     """
     if klass.type == "metaclass":
-        return False
+        return set()
+    names: set[str] = set()
     for method_name in defining_methods:
         for method in klass.locals.get(method_name, ()):
             if not isinstance(method, nodes.FunctionDef):
@@ -501,9 +502,10 @@ def _setattr_in_defining_methods(
             for call in method.nodes_of_class(nodes.Call):
                 if call.frame() is not method:
                     continue
-                if _setattr_attr_name(call, method) == attr:
-                    return True
-    return False
+                attr = _setattr_attr_name(call, method)
+                if attr is not None:
+                    names.add(attr)
+    return names
 
 
 def _is_attribute_property(name: str, klass: nodes.ClassDef) -> bool:

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -1,0 +1,52 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+import astroid
+from astroid import nodes
+
+from pylint.checkers.classes.class_checker import (
+    ClassChecker,
+    _setattr_in_defining_methods,
+)
+from pylint.lint import PyLinter
+
+
+def test_attribute_defined_outside_init_disabled(linter: PyLinter) -> None:
+    checker = ClassChecker(linter)
+    checker.open()
+    klass = astroid.extract_node("class Example: pass")
+    assert isinstance(klass, nodes.ClassDef)
+    checker._setattr_attrs[klass] = {}
+    linter.disable("attribute-defined-outside-init")
+
+    checker._check_attribute_defined_outside_init(klass)
+
+    assert klass in checker._setattr_attrs
+
+
+def test_visit_call_ignores_setattr_outside_method(linter: PyLinter) -> None:
+    checker = ClassChecker(linter)
+    call = astroid.extract_node('setattr(object(), "banana", 1)')
+    assert isinstance(call, nodes.Call)
+
+    checker.visit_call(call)
+
+    assert not checker._setattr_attrs
+
+
+def test_setattr_in_defining_methods_ignores_metaclass() -> None:
+    module = astroid.parse("""
+        class Meta(type):
+            def __init__(cls):
+                setattr(cls, "banana", 1)
+
+        class Plain:
+            def __init__(self):
+                setattr(self, "banana", 1)
+        """)
+    meta, plain = module.body[0], module.body[1]
+
+    assert isinstance(meta, nodes.ClassDef) and isinstance(plain, nodes.ClassDef)
+    assert not _setattr_in_defining_methods(meta, "banana", ("__init__",))
+    assert _setattr_in_defining_methods(plain, "banana", ("__init__",))

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -22,7 +22,7 @@ def test_attribute_defined_outside_init_disabled(linter: PyLinter) -> None:
 
     checker._check_attribute_defined_outside_init(klass)
 
-    assert klass in checker._setattr_attrs
+    assert klass not in checker._setattr_attrs
 
 
 def test_visit_call_ignores_setattr_outside_method(linter: PyLinter) -> None:

--- a/tests/checkers/unittest_classes.py
+++ b/tests/checkers/unittest_classes.py
@@ -7,7 +7,7 @@ from astroid import nodes
 
 from pylint.checkers.classes.class_checker import (
     ClassChecker,
-    _setattr_in_defining_methods,
+    _setattr_names_in_defining_methods,
 )
 from pylint.lint import PyLinter
 
@@ -35,7 +35,7 @@ def test_visit_call_ignores_setattr_outside_method(linter: PyLinter) -> None:
     assert not checker._setattr_attrs
 
 
-def test_setattr_in_defining_methods_ignores_metaclass() -> None:
+def test_setattr_names_in_defining_methods_ignores_metaclass() -> None:
     module = astroid.parse("""
         class Meta(type):
             def __init__(cls):
@@ -48,5 +48,5 @@ def test_setattr_in_defining_methods_ignores_metaclass() -> None:
     meta, plain = module.body[0], module.body[1]
 
     assert isinstance(meta, nodes.ClassDef) and isinstance(plain, nodes.ClassDef)
-    assert not _setattr_in_defining_methods(meta, "banana", ("__init__",))
-    assert _setattr_in_defining_methods(plain, "banana", ("__init__",))
+    assert _setattr_names_in_defining_methods(meta, ("__init__",)) == set()
+    assert _setattr_names_in_defining_methods(plain, ("__init__",)) == {"banana"}

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -88,7 +88,7 @@ class SetattrAttributeDefinitions:
     class_attr = None
 
     def __init__(self):
-        setattr(self, "defined_in_init", 1)  # noqa: B010
+        setattr(self, "defined_in_init", 1)
 
     def later(self, name):
         setattr(self, "set_by_setattr", 1)  # [attribute-defined-outside-init]  # noqa: B010

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -82,3 +82,38 @@ class Mine:
 class DataClass:
     def __post_init__(self):
         self.a = 42
+
+
+class SetattrAttributeDefinitions:
+    class_attr = None
+
+    def __init__(self):
+        setattr(self, "defined_in_init", 1)  # noqa: B010
+
+    def later(self, name):
+        setattr(self, "set_by_setattr", 1)  # [attribute-defined-outside-init]  # noqa: B010
+        setattr(self, "defined_in_init", 2)  # noqa: B010
+        setattr(self, "class_attr", 1)  # noqa: B010
+        setattr(self, name, 1)
+
+    def shadowed(self):
+        def setattr(obj, name, value):  # pylint: disable=redefined-builtin,unused-argument
+            return None
+
+        setattr(self, "shadowed", 1)
+
+    @classmethod
+    def class_later(cls):
+        setattr(cls, "class_attr", 1)  # noqa: B010
+
+
+class ParentAttrInInit:
+    def __init__(self):
+        self.parent_attr = 1
+        setattr(self, "defined_by_parent", 1)  # noqa: B010
+
+
+class ChildSetattrForParentAttr(ParentAttrInInit):
+    def later(self):
+        setattr(self, "parent_attr", 2)  # noqa: B010
+        setattr(self, "defined_by_parent", 2)  # noqa: B010

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -104,7 +104,7 @@ class SetattrAttributeDefinitions:
 
     @classmethod
     def class_later(cls):
-        setattr(cls, "class_attr", 1)  # noqa: B010
+        setattr(cls, "class_attr", 1)
 
 
 class ParentAttrInInit:

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -91,9 +91,9 @@ class SetattrAttributeDefinitions:
         setattr(self, "defined_in_init", 1)
 
     def later(self, name):
-        setattr(self, "set_by_setattr", 1)  # [attribute-defined-outside-init]  # noqa: B010
-        setattr(self, "defined_in_init", 2)  # noqa: B010
-        setattr(self, "class_attr", 1)  # noqa: B010
+        setattr(self, "set_by_setattr", 1)  # [attribute-defined-outside-init]
+        setattr(self, "defined_in_init", 2)
+        setattr(self, "class_attr", 1)
         setattr(self, name, 1)
 
     def shadowed(self):

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -115,5 +115,5 @@ class ParentAttrInInit:
 
 class ChildSetattrForParentAttr(ParentAttrInInit):
     def later(self):
-        setattr(self, "parent_attr", 2)  # noqa: B010
-        setattr(self, "defined_by_parent", 2)  # noqa: B010
+        setattr(self, "parent_attr", 2)
+        setattr(self, "defined_by_parent", 2)

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -146,3 +146,21 @@ class NonMethodDefiningParent:
 class ChildOfNonMethodDefiningParent(NonMethodDefiningParent):
     def later(self):
         setattr(self, "not_defined_by_parent", 1)  # [attribute-defined-outside-init]
+
+
+class ChildAssignmentForParentSetattr(ParentAttrInInit):
+    def later(self):
+        self.defined_by_parent = 2
+
+
+class ParentWithNestedSetattr:
+    def __init__(self):
+        def rename(self):
+            setattr(self, "nested_attr", 1)
+
+        rename(object())
+
+
+class ChildOfParentWithNestedSetattr(ParentWithNestedSetattr):
+    def later(self):
+        setattr(self, "nested_attr", 2)  # [attribute-defined-outside-init]

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -110,10 +110,39 @@ class SetattrAttributeDefinitions:
 class ParentAttrInInit:
     def __init__(self):
         self.parent_attr = 1
-        setattr(self, "defined_by_parent", 1)  # noqa: B010
+        setattr(self, "defined_by_parent", 1)
 
 
 class ChildSetattrForParentAttr(ParentAttrInInit):
     def later(self):
         setattr(self, "parent_attr", 2)
         setattr(self, "defined_by_parent", 2)
+
+
+class AttributeMeta(type):
+    def add_attribute(cls):
+        setattr(cls, "class_attr", 1)
+
+
+class StarArgs:
+    def star(*args):  # pylint: disable=no-self-argument
+        setattr(args, "grape", 4)
+
+
+class PositionalOnlySetattr:
+    def later(self, /):
+        setattr(self, "positional_only", 1)  # [attribute-defined-outside-init]
+
+
+class OtherInstanceSetattr:
+    def later(self, other):
+        setattr(other, "not_self", 1)
+
+
+class NonMethodDefiningParent:
+    __init__ = None
+
+
+class ChildOfNonMethodDefiningParent(NonMethodDefiningParent):
+    def later(self):
+        setattr(self, "not_defined_by_parent", 1)  # [attribute-defined-outside-init]

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -164,3 +164,37 @@ class ParentWithNestedSetattr:
 class ChildOfParentWithNestedSetattr(ParentWithNestedSetattr):
     def later(self):
         setattr(self, "nested_attr", 2)  # [attribute-defined-outside-init]
+
+
+class TwoArgumentSetattr:
+    def __init__(self):
+        setattr(self, "two_arg")  # TypeError at runtime, defines nothing
+
+    def later(self):
+        setattr(self, "two_arg", 1)  # [attribute-defined-outside-init]
+
+
+class ClassAndStaticSetattr:
+    @classmethod
+    def from_class(cls):
+        setattr(cls, "made_in_classmethod", 1)
+
+    @staticmethod
+    def from_static(self):  # pylint: disable=bad-staticmethod-argument
+        setattr(self, "made_in_staticmethod", 1)
+
+
+class ShadowedSetattr:
+    def later(self):
+        def setattr(obj, name, value):  # pylint: disable=redefined-builtin,unused-argument
+            return None
+
+        setattr(self, "not_really_set", 1)
+
+
+class SameClassSetattrThenAssign:
+    def __init__(self):
+        setattr(self, "from_init", 1)
+
+    def later(self):
+        self.from_init = 2

--- a/tests/functional/a/attribute_defined_outside_init.txt
+++ b/tests/functional/a/attribute_defined_outside_init.txt
@@ -1,2 +1,3 @@
 attribute-defined-outside-init:16:8:16:14:A.set_z:Attribute 'z' defined outside __init__:UNDEFINED
 attribute-defined-outside-init:26:8:26:14:B.test:Attribute 'z' defined outside __init__:UNDEFINED
+attribute-defined-outside-init:94:8:94:42:SetattrAttributeDefinitions.later:Attribute 'set_by_setattr' defined outside __init__:UNDEFINED

--- a/tests/functional/a/attribute_defined_outside_init.txt
+++ b/tests/functional/a/attribute_defined_outside_init.txt
@@ -3,3 +3,4 @@ attribute-defined-outside-init:26:8:26:14:B.test:Attribute 'z' defined outside _
 attribute-defined-outside-init:94:8:94:42:SetattrAttributeDefinitions.later:Attribute 'set_by_setattr' defined outside __init__:UNDEFINED
 attribute-defined-outside-init:134:8:134:43:PositionalOnlySetattr.later:Attribute 'positional_only' defined outside __init__:UNDEFINED
 attribute-defined-outside-init:148:8:148:49:ChildOfNonMethodDefiningParent.later:Attribute 'not_defined_by_parent' defined outside __init__:UNDEFINED
+attribute-defined-outside-init:166:8:166:39:ChildOfParentWithNestedSetattr.later:Attribute 'nested_attr' defined outside __init__:UNDEFINED

--- a/tests/functional/a/attribute_defined_outside_init.txt
+++ b/tests/functional/a/attribute_defined_outside_init.txt
@@ -4,3 +4,4 @@ attribute-defined-outside-init:94:8:94:42:SetattrAttributeDefinitions.later:Attr
 attribute-defined-outside-init:134:8:134:43:PositionalOnlySetattr.later:Attribute 'positional_only' defined outside __init__:UNDEFINED
 attribute-defined-outside-init:148:8:148:49:ChildOfNonMethodDefiningParent.later:Attribute 'not_defined_by_parent' defined outside __init__:UNDEFINED
 attribute-defined-outside-init:166:8:166:39:ChildOfParentWithNestedSetattr.later:Attribute 'nested_attr' defined outside __init__:UNDEFINED
+attribute-defined-outside-init:174:8:174:35:TwoArgumentSetattr.later:Attribute 'two_arg' defined outside __init__:UNDEFINED

--- a/tests/functional/a/attribute_defined_outside_init.txt
+++ b/tests/functional/a/attribute_defined_outside_init.txt
@@ -1,3 +1,5 @@
 attribute-defined-outside-init:16:8:16:14:A.set_z:Attribute 'z' defined outside __init__:UNDEFINED
 attribute-defined-outside-init:26:8:26:14:B.test:Attribute 'z' defined outside __init__:UNDEFINED
 attribute-defined-outside-init:94:8:94:42:SetattrAttributeDefinitions.later:Attribute 'set_by_setattr' defined outside __init__:UNDEFINED
+attribute-defined-outside-init:134:8:134:43:PositionalOnlySetattr.later:Attribute 'positional_only' defined outside __init__:UNDEFINED
+attribute-defined-outside-init:148:8:148:49:ChildOfNonMethodDefiningParent.later:Attribute 'not_defined_by_parent' defined outside __init__:UNDEFINED

--- a/tests/regrtest_data/attribute_defined_setattr_parent/child.py
+++ b/tests/regrtest_data/attribute_defined_setattr_parent/child.py
@@ -1,0 +1,6 @@
+from parent import Parent
+
+
+class Child(Parent):
+    def set_fruit(self):
+        setattr(self, "fruit", 2)

--- a/tests/regrtest_data/attribute_defined_setattr_parent/parent.py
+++ b/tests/regrtest_data/attribute_defined_setattr_parent/parent.py
@@ -1,0 +1,3 @@
+class Parent:
+    def __init__(self):
+        setattr(self, "fruit", 1)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1079,6 +1079,33 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
         )
         self._test_output([path, "-j2"], expected_output="")
 
+    @pytest.mark.parametrize(
+        "jobs,modules",
+        [
+            ("1", ["child.py", "parent.py"]),
+            pytest.param(
+                "2",
+                ["parent.py", "child.py"],
+                marks=pytest.mark.needs_two_cores,
+            ),
+        ],
+        ids=["child-first", "parallel"],
+    )
+    def test_setattr_defined_in_parent_is_order_independent(
+        self, jobs: str, modules: list[str]
+    ) -> None:
+        path = join(HERE, "regrtest_data", "attribute_defined_setattr_parent")
+        with _test_cwd(path):
+            self._runtest(
+                [
+                    f"--jobs={jobs}",
+                    "--disable=all",
+                    "--enable=attribute-defined-outside-init",
+                    *modules,
+                ],
+                code=0,
+            )
+
     @pytest.mark.needs_two_cores
     @pytest.mark.parametrize(
         "args",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description

<!-- If this PR references an issue without fixing it: -->
`attribute-defined-outside-init` now reports attributes assigned with literal `setattr(self, "name", value)` calls outside defining methods.

The check stays conservative and does not warn for dynamic attribute names, shadowed `setattr`, attributes initialized in `__init__`, or attributes initialized by a parent class.

Added functional regression coverage for the new warning and no-warning cases.

Closes #9798
- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
