### PR TITLE
Skip unspecified-encoding for unknown open modes

### DIFF
--- a/doc/whatsnew/fragments/10201.false_positive
+++ b/doc/whatsnew/fragments/10201.false_positive
@@ -1,0 +1,4 @@
+Fix ``unspecified-encoding`` false positive when an ``open`` call uses a mode
+argument that cannot be inferred.
+
+Closes #10201

--- a/doc/whatsnew/fragments/10201.false_positive
+++ b/doc/whatsnew/fragments/10201.false_positive
@@ -1,4 +1,4 @@
-Fix ``unspecified-encoding`` false positive when an ``open`` call uses a mode
+Fix ``ref:unspecified-encoding`` false positive when an ``open`` call uses a mode
 argument that cannot be inferred.
 
 Closes #10201

--- a/doc/whatsnew/fragments/10201.false_positive
+++ b/doc/whatsnew/fragments/10201.false_positive
@@ -1,4 +1,5 @@
-Fix ``ref:unspecified-encoding`` false positive when an ``open`` call uses a mode
-argument that cannot be inferred.
+Fix a false positive for :ref:`unspecified-encoding` when an ``open`` call uses a mode
+argument that cannot be inferred, including when the mode is a parameter with a default
+value.
 
 Closes #10201

--- a/doc/whatsnew/fragments/10201.false_positive
+++ b/doc/whatsnew/fragments/10201.false_positive
@@ -1,5 +1,4 @@
 Fix a false positive for :ref:`unspecified-encoding` when an ``open`` call uses a mode
-argument that cannot be inferred, including when the mode is a parameter with a default
-value.
+argument that cannot be inferred.
 
 Closes #10201

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -887,10 +887,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
         if not mode_arg_is_unknown and (
             not mode_arg
-            or (
-                isinstance(mode_arg, nodes.Const)
-                and "b" not in str(mode_arg.value)
-            )
+            or (isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value))
         ):
             confidence = HIGH
             try:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -849,6 +849,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     ) -> None:
         """Various checks for an open call."""
         mode_arg = None
+        mode_arg_is_unknown = False
         confidence = HIGH
         try:
             if open_module == "_io":
@@ -866,6 +867,10 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
         if mode_arg:
             mode_arg = utils.safe_infer(mode_arg)
+            if func_name in OPEN_FILES_MODE and (
+                mode_arg is None or isinstance(mode_arg, util.UninferableBase)
+            ):
+                mode_arg_is_unknown = True
             if (
                 func_name in OPEN_FILES_MODE
                 and isinstance(mode_arg, nodes.Const)
@@ -880,8 +885,12 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                     confidence=confidence,
                 )
 
-        if not mode_arg or (
-            isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
+        if not mode_arg_is_unknown and (
+            not mode_arg
+            or (
+                isinstance(mode_arg, nodes.Const)
+                and "b" not in str(mode_arg.value)
+            )
         ):
             confidence = HIGH
             try:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -849,7 +849,6 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     ) -> None:
         """Various checks for an open call."""
         mode_arg = None
-        mode_arg_is_unknown = False
         confidence = HIGH
         try:
             if open_module == "_io":
@@ -867,27 +866,21 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
         if mode_arg:
             mode_arg = utils.safe_infer(mode_arg)
-            if func_name in OPEN_FILES_MODE and (
-                mode_arg is None or isinstance(mode_arg, util.UninferableBase)
-            ):
-                mode_arg_is_unknown = True
-            if (
-                func_name in OPEN_FILES_MODE
-                and isinstance(mode_arg, nodes.Const)
-                and not _check_mode_str(mode_arg.value)
-            ):
-                self.add_message(
-                    "bad-open-mode",
-                    node=node,
-                    # avoid a boolean context on the constant ``bool(NotImplemented)``
-                    # raises a TypeError on Python >= 3.14
-                    args=str(mode_arg.value),
-                    confidence=confidence,
-                )
+            if func_name in OPEN_FILES_MODE:
+                if not isinstance(mode_arg, nodes.Const):
+                    return  # mode may be binary - don't guess
+                if not _check_mode_str(mode_arg.value):
+                    self.add_message(
+                        "bad-open-mode",
+                        node=node,
+                        # avoid a boolean context on the constant ``bool(NotImplemented)``
+                        # raises a TypeError on Python >= 3.14
+                        args=str(mode_arg.value),
+                        confidence=confidence,
+                    )
 
-        if not mode_arg_is_unknown and (
-            not mode_arg
-            or (isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value))
+        if not mode_arg or (
+            isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
         ):
             confidence = HIGH
             try:

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -194,3 +194,10 @@ Path(FILENAME).read_text(**KWARGS)  # [unspecified-encoding]
 
 KWARGS = {"encoding": "utf-8"}
 Path(FILENAME).read_text(**KWARGS)
+
+
+def open_with_unknown_mode(mode):
+    """Don't emit unspecified-encoding when the mode might be binary."""
+    open(FILENAME, mode)
+    open(FILENAME, mode=mode)
+    Path(FILENAME).open(mode)

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -201,4 +201,5 @@ def open_with_unknown_mode(mode):
     open(FILENAME, mode)
     open(FILENAME, mode=mode)
     Path(FILENAME).open(mode)
-    open(f, mode, encoding=None)
+    Path(FILENAME).open(mode=mode)
+    open(FILENAME, mode, encoding=None)

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -201,3 +201,4 @@ def open_with_unknown_mode(mode):
     open(FILENAME, mode)
     open(FILENAME, mode=mode)
     Path(FILENAME).open(mode)
+    open(f, mode, encoding=None)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|    | :sparkles: New feature |
|    | :hammer: Refactoring   |
|    | :scroll: Docs          |

## Description
`unspecified-encoding` no longer emits when an `open`-style call receives a mode argument that Pylint cannot infer.

This avoids a false positive when the mode may be binary, for example when it is passed through a function parameter. Known text modes still emit `unspecified-encoding`, and known invalid modes still emit `bad-open-mode`.

Added regression coverage for `open(...)`, keyword `mode=...`, and `Path.open(...)` calls with an unknown mode.

Closes #10201


- [x] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [x] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [x] Write comprehensive commit messages and/or a good description of what the PR does.
- [x] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
