### PR TITLE
Fix typing.NamedTuple generated member inference

### DIFF
--- a/doc/whatsnew/fragments/4070.false_positive
+++ b/doc/whatsnew/fragments/4070.false_positive
@@ -1,0 +1,4 @@
+Fix ``no-member`` false positives for generated members accessed from within a
+``typing.NamedTuple`` subclass.
+
+Closes #4070

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -70,6 +70,13 @@ CallableObjects: TypeAlias = (
 STR_FORMAT = {"builtins.str.format"}
 ASYNCIO_COROUTINE = "asyncio.coroutines.coroutine"
 BUILTIN_TUPLE = "builtins.tuple"
+TYPING_NAMEDTUPLE_MEMBERS = {
+    "_asdict",
+    "_field_defaults",
+    "_fields",
+    "_make",
+    "_replace",
+}
 TYPE_ANNOTATION_NODES_TYPES = (
     nodes.AnnAssign,
     nodes.Arguments,
@@ -447,6 +454,19 @@ def _is_enum_owner(owner: astroid.Instance | nodes.ClassDef) -> bool:
         "enum.EnumMeta",
         "enum.EnumType",
     }
+
+
+def _is_typing_namedtuple_member(owner: astroid.Instance, attrname: str) -> bool:
+    """Return whether an instance gets ``attrname`` from ``typing.NamedTuple``."""
+    if attrname not in TYPING_NAMEDTUPLE_MEMBERS:
+        return False
+    try:
+        return any(
+            ancestor.qname() == "typing.NamedTuple"
+            for ancestor in owner._proxied.ancestors()
+        )
+    except astroid.InferenceError:  # pragma: no cover
+        return False
 
 
 def _emit_no_member(
@@ -1187,6 +1207,10 @@ accessed. Python regular expressions are accepted.",
                 if (
                     isinstance(owner, (nodes.FunctionDef, astroid.BoundMethod))
                     and owner.decorators
+                ):
+                    continue
+                if isinstance(owner, astroid.Instance) and _is_typing_namedtuple_member(
+                    owner, node.attrname
                 ):
                     continue
                 # This can't be moved before the actual .getattr call,

--- a/tests/functional/n/namedtuple_member_inference.py
+++ b/tests/functional/n/namedtuple_member_inference.py
@@ -4,6 +4,7 @@ Regression test for:
 https://bitbucket.org/logilab/pylint/issue/93/pylint-crashes-on-namedtuple-attribute
 """
 from collections import namedtuple
+from typing import NamedTuple
 
 
 Thing = namedtuple('Thing', ())
@@ -18,3 +19,21 @@ def test():
     # Should not raise protected-access.
     fan2 = fan._replace(foo=2)
     print(fan2.foo)
+
+
+class Lines(NamedTuple):
+    """A typed named tuple that uses its generated API internally."""
+
+    lines: list[str]
+
+    def add_line(self, line: str) -> "Lines":
+        """Return a copy with the line added."""
+        return self._replace(lines=[*self.lines, line])
+
+    def generated_members(self) -> tuple[object, ...]:
+        """Exercise the other generated named tuple members."""
+        return self._fields, self._field_defaults, self._asdict(), self._make([])
+
+    def missing_member(self) -> None:
+        """Keep checking members that are not part of the named tuple API."""
+        print(self._missing)  # [no-member]

--- a/tests/functional/n/namedtuple_member_inference.txt
+++ b/tests/functional/n/namedtuple_member_inference.txt
@@ -1,1 +1,2 @@
-no-member:15:10:15:17:test:Class 'Thing' has no 'x' member:INFERENCE
+no-member:16:10:16:17:test:Class 'Thing' has no 'x' member:INFERENCE
+no-member:39:14:39:27:Lines.missing_member:Instance of 'Lines' has no '_missing' member:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Recognize the generated `_replace`, `_fields`, `_field_defaults`, `_asdict`, and `_make` members on `typing.NamedTuple` instances when they are accessed from methods defined on the subclass.

Astroid does not currently expose these generated members through `getattr()` in this context, so the type checker reached its `no-member` fallback even though the members exist at runtime. The fallback now checks whether the inferred instance descends from `typing.NamedTuple` and whether the missing name belongs to the documented generated API.

The functional regression test covers all five members and retains a genuinely missing member to verify that `no-member` is still emitted when appropriate.

Closes #4070

## Validation

- `python -m pytest tests/test_functional.py -k namedtuple_member_inference -q`
- `python -m pytest tests/checkers/unittest_typecheck.py -q`
- `pylint pylint/checkers/typecheck.py --persistent=n`
- `git diff --check`
