### PR TITLE
Fix pyreverse crash for uninferable named classes

### DIFF
--- a/doc/whatsnew/fragments/9797.bugfix
+++ b/doc/whatsnew/fragments/9797.bugfix
@@ -1,1 +1,3 @@
 Fix a crash in :program:`pyreverse` when a requested class cannot be inferred.
+
+Closes #9797

--- a/doc/whatsnew/fragments/9797.bugfix
+++ b/doc/whatsnew/fragments/9797.bugfix
@@ -1,0 +1,1 @@
+Fix a crash in :program:`pyreverse` when a requested class cannot be inferred.

--- a/doc/whatsnew/fragments/9797.bugfix
+++ b/doc/whatsnew/fragments/9797.bugfix
@@ -1,3 +1,3 @@
-Fix a crash in :program:`pyreverse` when a requested class cannot be inferred.
+Fix a crash in ``pyreverse`` when a requested class cannot be inferred.
 
 Closes #9797

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -246,7 +246,7 @@ class ClassDiadefGenerator(DiaDefGenerator):
     given class.
     """
 
-    def class_diagram(self, project: Project, klass: nodes.ClassDef) -> ClassDiagram:
+    def class_diagram(self, project: Project, klass: str) -> ClassDiagram:
         """Return a class diagram definition for the class and related classes."""
         self.classdiagram = ClassDiagram(klass, self.config.mode, self.linker)
         if len(project.modules) > 1:
@@ -256,6 +256,9 @@ class ClassDiadefGenerator(DiaDefGenerator):
             module = project.modules[0]
             klass = klass.split(".")[-1]
         klass = next(module.ilookup(klass))
+
+        if not isinstance(klass, nodes.ClassDef):
+            return self.classdiagram
 
         anc_level, association_level = self._get_levels()
         self.extract_classes(klass, anc_level, association_level)

--- a/pylint/pyreverse/diadefslib.py
+++ b/pylint/pyreverse/diadefslib.py
@@ -248,6 +248,7 @@ class ClassDiadefGenerator(DiaDefGenerator):
 
     def class_diagram(self, project: Project, klass: str) -> ClassDiagram:
         """Return a class diagram definition for the class and related classes."""
+        klass_name = klass
         self.classdiagram = ClassDiagram(klass, self.config.mode, self.linker)
         if len(project.modules) > 1:
             module, klass = klass.rsplit(".", 1)
@@ -258,6 +259,10 @@ class ClassDiadefGenerator(DiaDefGenerator):
         klass = next(module.ilookup(klass))
 
         if not isinstance(klass, nodes.ClassDef):
+            warnings.warn(
+                f"Unable to infer requested class {klass_name!r}; generated diagram will be empty.",
+                stacklevel=2,
+            )
             return self.classdiagram
 
         anc_level, association_level = self._get_levels()

--- a/tests/pyreverse/test_diadefs.py
+++ b/tests/pyreverse/test_diadefs.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-from astroid import extract_node, nodes
+from astroid import extract_node, nodes, parse
 
 from pylint.pyreverse.diadefslib import (
     ClassDiadefGenerator,
@@ -282,6 +282,18 @@ def test_known_values4(HANDLER: DiadefsHandler, PROJECT: Project) -> None:
         (True, "DoNothing2"),
         (True, "Specialization"),
     ]
+
+
+def test_class_diagram_ignores_uninferable_target(HANDLER: DiadefsHandler) -> None:
+    module = parse("from unresolved import Target", module_name="sample")
+    project = Project("sample")
+    project.add_module(module)
+
+    diagram = ClassDiadefGenerator(Linker(project), HANDLER).class_diagram(
+        project, "Target"
+    )
+
+    assert diagram.objects == []
 
 
 def test_regression_dataclasses_inference(

--- a/tests/pyreverse/test_diadefs.py
+++ b/tests/pyreverse/test_diadefs.py
@@ -291,7 +291,9 @@ def test_class_diagram_warns_for_uninferable_target(HANDLER: DiadefsHandler) -> 
 
     with pytest.warns(
         UserWarning,
-        match=re.escape("Unable to infer requested class 'Target'; generated diagram will be empty."),
+        match=re.escape(
+            "Unable to infer requested class 'Target'; generated diagram will be empty."
+        ),
     ):
         diagram = ClassDiadefGenerator(Linker(project), HANDLER).class_diagram(
             project, "Target"

--- a/tests/pyreverse/test_diadefs.py
+++ b/tests/pyreverse/test_diadefs.py
@@ -284,14 +284,18 @@ def test_known_values4(HANDLER: DiadefsHandler, PROJECT: Project) -> None:
     ]
 
 
-def test_class_diagram_ignores_uninferable_target(HANDLER: DiadefsHandler) -> None:
+def test_class_diagram_warns_for_uninferable_target(HANDLER: DiadefsHandler) -> None:
     module = parse("from unresolved import Target", module_name="sample")
     project = Project("sample")
     project.add_module(module)
 
-    diagram = ClassDiadefGenerator(Linker(project), HANDLER).class_diagram(
-        project, "Target"
-    )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape("Unable to infer requested class 'Target'; generated diagram will be empty."),
+    ):
+        diagram = ClassDiadefGenerator(Linker(project), HANDLER).class_diagram(
+            project, "Target"
+        )
 
     assert diagram.objects == []
 


### PR DESCRIPTION
## Type of Changes

|     | Type |
| --- | ---- |
| ✓   | :bug: Bug fix |

## Description

Closes #9797.

When a requested class name resolves to `Uninferable` instead of a `ClassDef`, pyreverse now returns an empty class diagram instead of passing the inferred placeholder into class processing.

The regression test covers an unresolved imported target and the change includes a bugfix news fragment.

## Validation

- `python -m pytest tests/pyreverse -q` — 154 passed
- `python -m pylint pylint/pyreverse/diadefslib.py`
- `python -m ruff check pylint/pyreverse/diadefslib.py tests/pyreverse/test_diadefs.py`
- direct reproduction of the unresolved-import lookup path