### PR TITLE
Fix crash in comparison-with-callable on a proxied lambda

### DIFF
--- a/doc/whatsnew/fragments/11175.bugfix
+++ b/doc/whatsnew/fragments/11175.bugfix
@@ -1,0 +1,3 @@
+Fixed a crash in ``comparison-with-callable`` when comparing a lambda assigned as a class attribute.
+
+Closes #11175

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -279,13 +279,16 @@ class ComparisonChecker(_BasicChecker):
         number_of_bare_callables = 0
         for operand in left_operand, right_operand:
             inferred = utils.safe_infer(operand)
-            # Bound and unbound methods proxy the function they were built from.
-            # Unwrap them so that a lambda assigned as a class attribute is seen
-            # as the ``Lambda`` it is: a ``Lambda`` has no ``decoratornames()``
-            # and its ``body`` is a single expression instead of a list of
-            # statements, so it is not a bare callable for this check.
-            while isinstance(inferred, (astroid.BoundMethod, astroid.UnboundMethod)):
+            # An unbound method on its own is not a bare callable here, but a
+            # bound method proxies the function it was built from, so unwrap it.
+            # This matters because a lambda assigned as a class attribute also
+            # infers to a ``BoundMethod``, and a ``Lambda`` has no
+            # ``decoratornames()`` and its ``body`` is a single expression
+            # instead of a list of statements.
+            while isinstance(inferred, astroid.BoundMethod):
                 inferred = inferred._proxied  # pylint: disable=protected-access
+                if isinstance(inferred, astroid.UnboundMethod):
+                    inferred = inferred._proxied  # pylint: disable=protected-access
             if not isinstance(inferred, nodes.FunctionDef):
                 continue
             # Ignore callables that raise, as well as typing constants

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -280,12 +280,19 @@ class ComparisonChecker(_BasicChecker):
         number_of_bare_callables = 0
         for operand in left_operand, right_operand:
             inferred = utils.safe_infer(operand)
+            if not isinstance(inferred, bare_callables):
+                continue
+            # A ``BoundMethod`` can proxy a ``Lambda`` (a lambda assigned as a
+            # class attribute). A ``Lambda`` has no ``decoratornames()`` and its
+            # ``body`` is a single expression instead of a list of statements,
+            # so neither check below applies to it. Lambdas are not reported by
+            # this message today, so skip them rather than crashing.
+            if not hasattr(inferred, "decoratornames"):
+                continue
             # Ignore callables that raise, as well as typing constants
             # implemented as functions (that raise via their decorator)
-            if (
-                isinstance(inferred, bare_callables)
-                and "typing._SpecialForm" not in inferred.decoratornames()
-                and not any(isinstance(x, nodes.Raise) for x in inferred.body)
+            if "typing._SpecialForm" not in inferred.decoratornames() and not any(
+                isinstance(x, nodes.Raise) for x in inferred.body
             ):
                 number_of_bare_callables += 1
         if number_of_bare_callables == 1:

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -273,21 +273,20 @@ class ComparisonChecker(_BasicChecker):
         if operator not in COMPARISON_OPERATORS:
             return
 
-        bare_callables = (nodes.FunctionDef, astroid.BoundMethod)
         left_operand, right_operand = node.left, node.ops[0][1]
         # this message should be emitted only when there is comparison of bare callable
         # with non bare callable.
         number_of_bare_callables = 0
         for operand in left_operand, right_operand:
             inferred = utils.safe_infer(operand)
-            if not isinstance(inferred, bare_callables):
-                continue
-            # A ``BoundMethod`` can proxy a ``Lambda`` (a lambda assigned as a
-            # class attribute). A ``Lambda`` has no ``decoratornames()`` and its
-            # ``body`` is a single expression instead of a list of statements,
-            # so neither check below applies to it. Lambdas are not reported by
-            # this message today, so skip them rather than crashing.
-            if not hasattr(inferred, "decoratornames"):
+            # Bound and unbound methods proxy the function they were built from.
+            # Unwrap them so that a lambda assigned as a class attribute is seen
+            # as the ``Lambda`` it is: a ``Lambda`` has no ``decoratornames()``
+            # and its ``body`` is a single expression instead of a list of
+            # statements, so it is not a bare callable for this check.
+            while isinstance(inferred, (astroid.BoundMethod, astroid.UnboundMethod)):
+                inferred = inferred._proxied  # pylint: disable=protected-access
+            if not isinstance(inferred, nodes.FunctionDef):
                 continue
             # Ignore callables that raise, as well as typing constants
             # implemented as functions (that raise via their decorator)

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -286,9 +286,9 @@ class ComparisonChecker(_BasicChecker):
             # ``decoratornames()`` and its ``body`` is a single expression
             # instead of a list of statements.
             while isinstance(inferred, astroid.BoundMethod):
-                inferred = inferred._proxied  # pylint: disable=protected-access
+                inferred = inferred._proxied
                 if isinstance(inferred, astroid.UnboundMethod):
-                    inferred = inferred._proxied  # pylint: disable=protected-access
+                    inferred = inferred._proxied
             if not isinstance(inferred, nodes.FunctionDef):
                 continue
             # Ignore callables that raise, as well as typing constants

--- a/tests/functional/c/comparison_with_callable.py
+++ b/tests/functional/c/comparison_with_callable.py
@@ -79,3 +79,10 @@ class LambdaAttribute:  # pylint: disable=too-few-public-methods
         # ``self.lam`` infers to a BoundMethod proxying a Lambda, which has
         # neither ``decoratornames()`` nor a list ``body``.
         return self.lam == 1
+
+
+def compare_unbound_methods(obj):
+    # ``object.__init__`` infers to a bare ``UnboundMethod``, which is not a
+    # bare callable here: this is a legitimate identity check.
+    init = getattr(obj, "__init__", None)
+    return init != object.__init__

--- a/tests/functional/c/comparison_with_callable.py
+++ b/tests/functional/c/comparison_with_callable.py
@@ -69,3 +69,13 @@ if a == eventually_raise:
     # Does not emit comparison-with-callable because the
     # function (eventually) raises
     pass
+
+
+class LambdaAttribute:  # pylint: disable=too-few-public-methods
+    # https://github.com/pylint-dev/pylint/issues/11175
+    lam = lambda self: 1  # pylint: disable=unnecessary-lambda-assignment
+
+    def check(self):
+        # ``self.lam`` infers to a BoundMethod proxying a Lambda, which has
+        # neither ``decoratornames()`` nor a list ``body``.
+        return self.lam == 1


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

A lambda assigned as a class attribute and read through an instance (`self.lam`) infers to a `BoundMethod` whose `_proxied` node is a `Lambda`. That passes `isinstance(inferred, bare_callables)`, but `Lambda` has no `decoratornames()`, so the proxy lookup raised `AttributeError` and aborted the whole module walk with `F0002` (astroid-error). Guarding only that call is not enough: `Lambda.body` is a single expression rather than a list, so the following `for x in inferred.body` would raise `TypeError` next.

Lambdas are not reported by `comparison-with-callable` today, so they are now skipped rather than crashing.

Closes #11175
