### PR TITLE
Fix crash in consider-using-dict-items on non-name loop targets

### DIFF
--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -278,6 +278,13 @@ class RecommendationChecker(checkers.BaseChecker):
         if iterating_object_name is None:
             return
 
+        # ``consider-using-dict-items`` only applies to a simple loop variable.
+        # An attribute or subscript target (e.g. ``for self.key in d``) cannot be
+        # rewritten with ``.items()``, and accessing ``node.target.name`` on such
+        # a target raises AttributeError (#11173).
+        if not isinstance(node.target, nodes.AssignName):
+            return
+
         # Verify that the body of the for loop uses a subscript
         # with the object that was iterated. This uses some heuristics
         # in order to make sure that the same object is used in the
@@ -333,6 +340,11 @@ class RecommendationChecker(checkers.BaseChecker):
         """Add message when accessing dict values by index lookup."""
         iterating_object_name = utils.get_iterating_dictionary_name(node)
         if iterating_object_name is None:
+            return
+
+        # See ``_check_consider_using_dict_items``: a non-name target crashes on
+        # ``node.target.name`` and cannot be rewritten with ``.items()`` (#11173).
+        if not isinstance(node.target, nodes.AssignName):
             return
 
         for child in node.parent.get_children():

--- a/tests/checkers/unittest_refactoring.py
+++ b/tests/checkers/unittest_refactoring.py
@@ -4,9 +4,13 @@
 
 import os
 
+import astroid
 import pytest
+from astroid import nodes
 
+from pylint.checkers.refactoring.recommendation_checker import RecommendationChecker
 from pylint.reporters.text import TextReporter
+from pylint.testutils import CheckerTestCase
 from pylint.testutils._run import _Run as Run
 
 PARENT_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -36,3 +40,44 @@ def test_issue_5724() -> None:
             reporter=TextReporter(),
         )
     assert cm.value.code == 0
+
+
+class TestConsiderUsingDictItems(CheckerTestCase):
+    """Non-name loop targets must not crash ``consider-using-dict-items``.
+
+    The ``other[index]`` subscript in each body is required to reach the code
+    path that crashed: the checker only inspects bodies that subscript a name.
+    https://github.com/pylint-dev/pylint/issues/11173
+    """
+
+    CHECKER_CLASS = RecommendationChecker
+
+    def test_attribute_target_does_not_crash(self) -> None:
+        node = astroid.extract_node("""
+        D = {"a": 1}
+        def run(obj, other, index):
+            for obj.key in D:  #@
+                print(other[index])
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_for(node)
+
+    def test_subscript_target_does_not_crash(self) -> None:
+        node = astroid.extract_node("""
+        D = {"a": 1}
+        def run(target, other, index):
+            for target[0] in D:  #@
+                print(other[index])
+        """)
+        with self.assertNoMessages():
+            self.checker.visit_for(node)
+
+    def test_comprehension_attribute_target_does_not_crash(self) -> None:
+        node = astroid.extract_node("""
+        D = {"a": 1}
+        def run(obj, other, index):
+            return [other[index] for obj.key in D]  #@
+        """)
+        comprehension = next(node.nodes_of_class(nodes.Comprehension))
+        with self.assertNoMessages():
+            self.checker.visit_comprehension(comprehension)


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`_check_consider_using_dict_items` and its comprehension counterpart read `node.target.name` without checking that the target is a plain name, so a `for` loop or comprehension whose target is an attribute or a subscript crashed the checker with `AttributeError: 'AssignAttr' object has no attribute 'name'`.

A non-name target cannot be rewritten with `.items()`, so both sites now return early when the target is not an `AssignName` — mirroring the fix already applied to the sibling `consider-using-enumerate` check in #10099.

I did not add a news fragment, since I could not tell whether this warrants one separately from #10099; happy to add `doc/whatsnew/fragments/11173.bugfix` if you'd like it.

Closes #11173
