### PR TITLE
Fix superfluous-parens false negative for and/or conditions

### DIFF
--- a/doc/whatsnew/fragments/10084.false_negative
+++ b/doc/whatsnew/fragments/10084.false_negative
@@ -1,0 +1,7 @@
+``superfluous-parens`` (``C0325``) no longer false-negatives on parentheses
+wrapping an entire ``and``/``or`` condition, e.g. ``if (a and b):`` or
+``while (a or b):``. Parentheses are still accepted after ``not`` (where they
+are required, e.g. ``not (a and b)``) and when the parenthesised expression is
+an operand of a following binary operator (e.g. ``(a or b) in c``).
+
+Closes #10084

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -353,7 +353,15 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                     if i == start + 2:
                         return
                     if found_and_or:
-                        return
+                        # ``and``/``or`` have lower precedence than ``not`` and
+                        # any binary operator, so the parentheses are required in
+                        # e.g. ``not (a and b)`` or ``(a or b) in c``. They are
+                        # superfluous only when they wrap the entire statement
+                        # expression, e.g. ``if (a and b):`` (#10084).
+                        if keyword_token == "not":
+                            return
+                        if tokens[i + 1].string in {")", "]", "}", "in"}:
+                            return
                     if keyword_token == "in":
                         # Parentheses around a tuple after ``in`` are required, so
                         # they were given a blanket pass in pull request #4948.

--- a/tests/functional/s/superfluous_parens.py
+++ b/tests/functional/s/superfluous_parens.py
@@ -92,3 +92,22 @@ if Z in ("a", "b"):
     pass
 if Z in ("Version " + "String"):
     pass
+
+# Parentheses wrapping an entire ``and``/``or`` condition are superfluous (#10084),
+# but they are required after ``not`` or when the parenthesised expression is an
+# operand of a following binary operator such as ``in``.
+if (A == 5 and B == 3):  # [superfluous-parens]
+    pass
+if (A is None and A is not None):  # [superfluous-parens]
+    pass
+while (A == 5 or B == 3):  # [superfluous-parens]
+    pass
+if not (A == 5 and B == 3):
+    pass
+if (A == 5 or B == 3) in (True, False):
+    pass
+if (A == 5 and B == 3) or Z == "4":
+    pass
+if (A == 5
+        and B == 3):
+    pass

--- a/tests/functional/s/superfluous_parens.txt
+++ b/tests/functional/s/superfluous_parens.txt
@@ -11,3 +11,6 @@ superfluous-parens:76:0:None:None::Unnecessary parens after 'assert' keyword:UND
 superfluous-parens:77:0:None:None::Unnecessary parens after 'assert' keyword:UNDEFINED
 superfluous-parens:79:0:None:None::Unnecessary parens after '=' keyword:UNDEFINED
 superfluous-parens:87:0:None:None::Unnecessary parens after 'in' keyword:UNDEFINED
+superfluous-parens:99:0:None:None::Unnecessary parens after 'if' keyword:UNDEFINED
+superfluous-parens:101:0:None:None::Unnecessary parens after 'if' keyword:UNDEFINED
+superfluous-parens:103:0:None:None::Unnecessary parens after 'while' keyword:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`superfluous-parens` (C0325) gave a blanket pass to any parenthesised expression containing `and`/`or`, so conditions like `if (a is None and a is not None):` were never reported — even though the same expression without boolean operators (e.g. `if (a == 5):` or `K = ("a" + "b")`) is reported. This makes the `and`/`or` exemption narrower, keeping it only where the parentheses are genuinely required:

- after `not` — `not (a and b)` parses differently without parens;
- when the parenthesised expression is an operand of a following binary operator — e.g. `(a or b) in c`.

Parentheses that wrap the entire statement expression (`if (a and b):`, `while (a or b):`) are now reported. Multiline conditions are untouched (the existing NL bail-out), as are partial groupings like `if (a and b) or c:`.

This follows the same "narrow the historical blanket pass" approach as #11081 did for `in`, which left this case explicitly out of scope. Existing functional suite passes (900 tests), and running the updated check over pylint's own source produces no new hits (the three pre-existing C0325 hits on `main` are unchanged by this PR).

Note: #10084 is assigned to @ranadheerg — I asked on the issue whether they're still working on it before opening this; happy to close this in favor of their PR if they are.

Closes #10084
