### PR TITLE
Detect repeated attribute chains in comparison-with-itself

### DIFF
--- a/doc/whatsnew/fragments/10713.false_negative
+++ b/doc/whatsnew/fragments/10713.false_negative
@@ -1,0 +1,4 @@
+``comparison-with-itself`` now detects repeated attribute chains such as
+``object.attribute == object.attribute``.
+
+Closes #10713

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -22,6 +22,19 @@ def _is_one_arg_pos_call(call: nodes.NodeNG) -> bool:
     return isinstance(call, nodes.Call) and len(call.args) == 1 and not call.keywords
 
 
+def _same_attribute_chain(left: nodes.Attribute, right: nodes.Attribute) -> bool:
+    if left.attrname != right.attrname:
+        return False
+
+    match left.expr, right.expr:
+        case nodes.Name(name=left_name), nodes.Name(name=right_name):
+            return bool(left_name == right_name)
+        case nodes.Attribute() as left_attribute, nodes.Attribute() as right_attribute:
+            return _same_attribute_chain(left_attribute, right_attribute)
+        case _:
+            return False
+
+
 class ComparisonChecker(_BasicChecker):
     """Checks for comparisons.
 
@@ -245,6 +258,13 @@ class ComparisonChecker(_BasicChecker):
         ):
             left_operand = left_operand.name
             right_operand = right_operand.name
+        elif (
+            isinstance(left_operand, nodes.Attribute)
+            and isinstance(right_operand, nodes.Attribute)
+            and _same_attribute_chain(left_operand, right_operand)
+        ):
+            left_operand = left_operand.as_string()
+            right_operand = right_operand.as_string()
 
         if left_operand == right_operand:
             suggestion = f"{left_operand} {operator} {right_operand}"

--- a/tests/checkers/base/unittest_base.py
+++ b/tests/checkers/base/unittest_base.py
@@ -6,11 +6,6 @@
 
 import unittest
 
-import astroid
-
-from pylint.checkers.base.comparison_checker import ComparisonChecker
-from pylint.testutils import CheckerTestCase, MessageTest
-
 
 class TestNoSix(unittest.TestCase):
     @unittest.skip("too many dependencies need six :(")
@@ -21,32 +16,3 @@ class TestNoSix(unittest.TestCase):
             has_six = False
 
         self.assertFalse(has_six, "pylint must be able to run without six")
-
-
-class TestComparisonChecker(CheckerTestCase):
-    CHECKER_CLASS = ComparisonChecker
-
-    def test_attribute_comparison_with_itself(self) -> None:
-        node = astroid.extract_node("obj.child.value != obj.child.value")
-
-        with self.assertAddsMessages(
-            MessageTest(
-                "comparison-with-itself",
-                node=node,
-                args=("obj.child.value != obj.child.value",),
-            ),
-            ignore_position=True,
-        ):
-            self.checker.visit_compare(node)
-
-    def test_non_identical_attribute_comparisons(self) -> None:
-        expressions = (
-            "obj.left == obj.right",
-            "left.value == right.value",
-            "factory().value == factory().value",
-        )
-
-        for expression in expressions:
-            node = astroid.extract_node(expression)
-            with self.assertNoMessages():
-                self.checker.visit_compare(node)

--- a/tests/checkers/base/unittest_base.py
+++ b/tests/checkers/base/unittest_base.py
@@ -6,6 +6,11 @@
 
 import unittest
 
+import astroid
+
+from pylint.checkers.base.comparison_checker import ComparisonChecker
+from pylint.testutils import CheckerTestCase, MessageTest
+
 
 class TestNoSix(unittest.TestCase):
     @unittest.skip("too many dependencies need six :(")
@@ -16,3 +21,32 @@ class TestNoSix(unittest.TestCase):
             has_six = False
 
         self.assertFalse(has_six, "pylint must be able to run without six")
+
+
+class TestComparisonChecker(CheckerTestCase):
+    CHECKER_CLASS = ComparisonChecker
+
+    def test_attribute_comparison_with_itself(self) -> None:
+        node = astroid.extract_node("obj.child.value != obj.child.value")
+
+        with self.assertAddsMessages(
+            MessageTest(
+                "comparison-with-itself",
+                node=node,
+                args=("obj.child.value != obj.child.value",),
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_compare(node)
+
+    def test_non_identical_attribute_comparisons(self) -> None:
+        expressions = (
+            "obj.left == obj.right",
+            "left.value == right.value",
+            "factory().value == factory().value",
+        )
+
+        for expression in expressions:
+            node = astroid.extract_node(expression)
+            with self.assertNoMessages():
+                self.checker.visit_compare(node)

--- a/tests/functional/l/logical_tautology.py
+++ b/tests/functional/l/logical_tautology.py
@@ -5,7 +5,11 @@ def foo(obj):
     arg = 786
     if arg == arg: # [comparison-with-itself]
         return True
+    elif arg != arg: # [comparison-with-itself]
+        return True
     elif obj.child.value != obj.child.value: # [comparison-with-itself]
+        return True
+    elif arg > arg: # [comparison-with-itself]
         return True
     elif arg.real > arg.real: # [comparison-with-itself]
         return True

--- a/tests/functional/l/logical_tautology.py
+++ b/tests/functional/l/logical_tautology.py
@@ -1,13 +1,13 @@
 """Check for logical tautology, when a value is compared against itself."""
 # pylint: disable=missing-docstring, disallowed-name, singleton-comparison, too-many-return-statements, inconsistent-return-statements, no-else-return, too-many-branches, literal-comparison
 
-def foo():
+def foo(obj):
     arg = 786
     if arg == arg: # [comparison-with-itself]
         return True
-    elif arg != arg: # [comparison-with-itself]
+    elif obj.child.value != obj.child.value: # [comparison-with-itself]
         return True
-    elif arg > arg: # [comparison-with-itself]
+    elif arg.real > arg.real: # [comparison-with-itself]
         return True
     elif arg <= arg: # [comparison-with-itself]
         return True
@@ -38,3 +38,11 @@ def bar():
 def foobar():
     arg = 786
     return arg > 786
+
+
+def compare_attributes(obj, other):
+    return (
+        obj.left == obj.right
+        or obj.value == other.value
+        or obj.factory().value == obj.factory().value
+    )

--- a/tests/functional/l/logical_tautology.txt
+++ b/tests/functional/l/logical_tautology.txt
@@ -1,18 +1,20 @@
 comparison-with-itself:6:7:6:17:foo:Redundant comparison - arg == arg:UNDEFINED
-comparison-with-itself:8:9:8:43:foo:Redundant comparison - obj.child.value != obj.child.value:UNDEFINED
-comparison-with-itself:10:9:10:28:foo:Redundant comparison - arg.real > arg.real:UNDEFINED
-comparison-with-itself:12:9:12:19:foo:Redundant comparison - arg <= arg:UNDEFINED
-comparison-of-constants:14:9:14:21:foo:"Comparison between constants: ""None == None"" has a constant value":HIGH
-comparison-with-itself:14:9:14:21:foo:Redundant comparison - None == None:UNDEFINED
-comparison-of-constants:16:9:16:19:foo:"Comparison between constants: ""786 == 786"" has a constant value":HIGH
-comparison-with-itself:16:9:16:19:foo:Redundant comparison - 786 == 786:UNDEFINED
-comparison-of-constants:18:9:18:19:foo:"Comparison between constants: ""786 is 786"" has a constant value":HIGH
-comparison-with-itself:18:9:18:19:foo:Redundant comparison - 786 is 786:UNDEFINED
-comparison-of-constants:20:9:20:23:foo:"Comparison between constants: ""786 is not 786"" has a constant value":HIGH
-comparison-with-itself:20:9:20:23:foo:Redundant comparison - 786 is not 786:UNDEFINED
-comparison-with-itself:22:9:22:19:foo:Redundant comparison - arg is arg:UNDEFINED
-comparison-with-itself:24:9:24:23:foo:Redundant comparison - arg is not arg:UNDEFINED
-comparison-of-constants:26:9:26:21:foo:"Comparison between constants: ""True is True"" has a constant value":HIGH
-comparison-with-itself:26:9:26:21:foo:Redundant comparison - True is True:UNDEFINED
-comparison-of-constants:28:9:28:19:foo:"Comparison between constants: ""666 == 786"" has a constant value":HIGH
-comparison-with-itself:36:18:36:28:bar:Redundant comparison - arg != arg:UNDEFINED
+comparison-with-itself:8:9:8:19:foo:Redundant comparison - arg != arg:UNDEFINED
+comparison-with-itself:10:9:10:43:foo:Redundant comparison - obj.child.value != obj.child.value:UNDEFINED
+comparison-with-itself:12:9:12:18:foo:Redundant comparison - arg > arg:UNDEFINED
+comparison-with-itself:14:9:14:28:foo:Redundant comparison - arg.real > arg.real:UNDEFINED
+comparison-with-itself:16:9:16:19:foo:Redundant comparison - arg <= arg:UNDEFINED
+comparison-of-constants:18:9:18:21:foo:"Comparison between constants: ""None == None"" has a constant value":HIGH
+comparison-with-itself:18:9:18:21:foo:Redundant comparison - None == None:UNDEFINED
+comparison-of-constants:20:9:20:19:foo:"Comparison between constants: ""786 == 786"" has a constant value":HIGH
+comparison-with-itself:20:9:20:19:foo:Redundant comparison - 786 == 786:UNDEFINED
+comparison-of-constants:22:9:22:19:foo:"Comparison between constants: ""786 is 786"" has a constant value":HIGH
+comparison-with-itself:22:9:22:19:foo:Redundant comparison - 786 is 786:UNDEFINED
+comparison-of-constants:24:9:24:23:foo:"Comparison between constants: ""786 is not 786"" has a constant value":HIGH
+comparison-with-itself:24:9:24:23:foo:Redundant comparison - 786 is not 786:UNDEFINED
+comparison-with-itself:26:9:26:19:foo:Redundant comparison - arg is arg:UNDEFINED
+comparison-with-itself:28:9:28:23:foo:Redundant comparison - arg is not arg:UNDEFINED
+comparison-of-constants:30:9:30:21:foo:"Comparison between constants: ""True is True"" has a constant value":HIGH
+comparison-with-itself:30:9:30:21:foo:Redundant comparison - True is True:UNDEFINED
+comparison-of-constants:32:9:32:19:foo:"Comparison between constants: ""666 == 786"" has a constant value":HIGH
+comparison-with-itself:40:18:40:28:bar:Redundant comparison - arg != arg:UNDEFINED

--- a/tests/functional/l/logical_tautology.txt
+++ b/tests/functional/l/logical_tautology.txt
@@ -1,6 +1,6 @@
 comparison-with-itself:6:7:6:17:foo:Redundant comparison - arg == arg:UNDEFINED
-comparison-with-itself:8:9:8:19:foo:Redundant comparison - arg != arg:UNDEFINED
-comparison-with-itself:10:9:10:18:foo:Redundant comparison - arg > arg:UNDEFINED
+comparison-with-itself:8:9:8:43:foo:Redundant comparison - obj.child.value != obj.child.value:UNDEFINED
+comparison-with-itself:10:9:10:28:foo:Redundant comparison - arg.real > arg.real:UNDEFINED
 comparison-with-itself:12:9:12:19:foo:Redundant comparison - arg <= arg:UNDEFINED
 comparison-of-constants:14:9:14:21:foo:"Comparison between constants: ""None == None"" has a constant value":HIGH
 comparison-with-itself:14:9:14:21:foo:Redundant comparison - None == None:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`comparison-with-itself` currently normalizes constants and names before comparing
operands, so it misses repeated attribute chains such as
`value.member == value.member`.

This recognizes structurally identical attribute chains rooted in the same name.
Call-rooted chains such as `factory().member == factory().member` remain excluded
because the calls can return different objects.

Attribute descriptors can also be dynamic, but this follows the syntactic
redundancy behavior requested in #10713 and already used for repeated names.

Regression tests cover nested chains, differing attributes, differing roots, and
call-rooted chains.

Closes #10713

## Tests

- `pytest tests/checkers/base tests/test_functional.py::test_functional[logical_tautology] -q`
- `ruff check pylint/checkers/base/comparison_checker.py tests/checkers/base/unittest_base.py`
- `mypy pylint/checkers/base/comparison_checker.py tests/checkers/base/unittest_base.py`
- `pyright pylint/checkers/base/comparison_checker.py tests/checkers/base/unittest_base.py`
- `python -m pylint --persistent=no pylint/checkers/base/comparison_checker.py tests/checkers/base/unittest_base.py`
