### PR TITLE
Fix unspecified-encoding false positive when the mode is not inferable

### DIFF
--- a/doc/whatsnew/fragments/10201.false_positive
+++ b/doc/whatsnew/fragments/10201.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``unspecified-encoding`` (W1514) when the ``mode``
+argument of ``open`` cannot be inferred (e.g. it is a function parameter),
+since the mode could be binary.
+
+Closes #10201

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -864,9 +864,16 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             if mode_arg:
                 confidence = INFERENCE
 
+        # Whether a mode argument was provided but could not be inferred.
+        mode_arg_uninferable = False
         if mode_arg:
             mode_arg = utils.safe_infer(mode_arg)
-            if (
+            if mode_arg is None:
+                # The mode argument was provided but its value cannot be
+                # inferred (e.g. it is a function parameter). The mode could
+                # be binary, so we cannot safely emit unspecified-encoding.
+                mode_arg_uninferable = True
+            elif (
                 func_name in OPEN_FILES_MODE
                 and isinstance(mode_arg, nodes.Const)
                 and not _check_mode_str(mode_arg.value)
@@ -880,8 +887,11 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                     confidence=confidence,
                 )
 
-        if not mode_arg or (
-            isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
+        if not mode_arg_uninferable and (
+            mode_arg is None
+            or (
+                isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
+            )
         ):
             confidence = HIGH
             try:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -889,9 +889,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
         if not mode_arg_uninferable and (
             mode_arg is None
-            or (
-                isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
-            )
+            or (isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value))
         ):
             confidence = HIGH
             try:

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -194,3 +194,26 @@ Path(FILENAME).read_text(**KWARGS)  # [unspecified-encoding]
 
 KWARGS = {"encoding": "utf-8"}
 Path(FILENAME).read_text(**KWARGS)
+
+# The mode argument cannot be inferred: no message should be emitted
+# https://github.com/pylint-dev/pylint/issues/10201
+def open_with_unknown_mode(mode):
+    """Open a file with an unknown mode"""
+    return open(FILENAME, mode)
+
+open_with_unknown_mode("r+b")
+open_with_unknown_mode("wb")
+
+def io_open_with_unknown_mode(mode):
+    """Open a file with an unknown mode"""
+    return io.open(FILENAME, mode)
+
+io_open_with_unknown_mode("r+b")
+io_open_with_unknown_mode("wb")
+
+def path_open_with_unknown_mode(mode):
+    """Open a path with an unknown mode"""
+    return Path(FILENAME).open(mode)
+
+path_open_with_unknown_mode("r+b")
+path_open_with_unknown_mode("wb")


### PR DESCRIPTION
## Description

When the `mode` argument of `open()` is provided but its value cannot be inferred (e.g. it is a function parameter), pylint emitted `unspecified-encoding` because the uninferable mode was treated the same as no mode at all:

```python
@contextmanager
def open_file_seek_zero(file_name, mode):
    with open(file_name, mode) as f:   # W1514 false positive
        yield f

with open_file_seek_zero(foo.bin, r+b) as f:
    ...
```

Since the mode could be binary (where specifying an encoding is irrelevant), no message should be emitted when the mode is unknown.

## Changes

In `_check_open_call` (stdlib checker), track whether a mode argument was provided *before* inference. `unspecified-encoding` is now only emitted when:
- no mode argument was provided, or
- the inferred mode is a text-only mode (no `b`)

`bad-open-mode` behavior is unchanged.

Closes #10201