### PR TITLE
Fix false positive for missing-kwoa when **kwargs dict keys are inferable

### DIFF
--- a/doc/whatsnew/fragments/10029.false_positive
+++ b/doc/whatsnew/fragments/10029.false_positive
@@ -1,0 +1,3 @@
+Fix false positive for ``missing-kwoa`` when keyword-only arguments are provided through a ``**kwargs`` dict whose keys are inferable (e.g. built up via subscript assignments like ``someargs["c"] = 3``).
+
+Closes #10029

--- a/doc/whatsnew/fragments/10201.false_positive
+++ b/doc/whatsnew/fragments/10201.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``unspecified-encoding`` (W1514) when the ``mode``
+argument of ``open`` cannot be inferred (e.g. it is a function parameter),
+since the mode could be binary.
+
+Closes #10201

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -864,9 +864,16 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             if mode_arg:
                 confidence = INFERENCE
 
+        # Whether a mode argument was provided but could not be inferred.
+        mode_arg_uninferable = False
         if mode_arg:
             mode_arg = utils.safe_infer(mode_arg)
-            if (
+            if mode_arg is None:
+                # The mode argument was provided but its value cannot be
+                # inferred (e.g. it is a function parameter). The mode could
+                # be binary, so we cannot safely emit unspecified-encoding.
+                mode_arg_uninferable = True
+            elif (
                 func_name in OPEN_FILES_MODE
                 and isinstance(mode_arg, nodes.Const)
                 and not _check_mode_str(mode_arg.value)
@@ -880,8 +887,11 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                     confidence=confidence,
                 )
 
-        if not mode_arg or (
-            isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
+        if not mode_arg_uninferable and (
+            mode_arg is None
+            or (
+                isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
+            )
         ):
             confidence = HIGH
             try:

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -889,9 +889,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
 
         if not mode_arg_uninferable and (
             mode_arg is None
-            or (
-                isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
-            )
+            or (isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value))
         ):
             confidence = HIGH
             try:

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -708,6 +708,29 @@ def _has_parent_of_type(
     return isinstance(parent, node_type)
 
 
+def _dict_keys_from_subscript_assignments(name_node: nodes.Name) -> set[str]:
+    """Return the constant string keys assigned to ``name`` via subscripts.
+
+    e.g. for ``someargs['c'] = 3`` with ``someargs`` a ``Name`` node, this
+    returns ``{"c"}``.
+    """
+    keys: set[str] = set()
+    scope = name_node.scope()
+    for assign in scope.nodes_of_class(nodes.Assign):
+        if assign.scope() is not scope:
+            continue
+        for target in assign.targets:
+            if (
+                isinstance(target, nodes.Subscript)
+                and isinstance(target.value, nodes.Name)
+                and target.value.name == name_node.name
+                and isinstance(target.slice, nodes.Const)
+                and isinstance(target.slice.value, str)
+            ):
+                keys.add(target.slice.value)
+    return keys
+
+
 def _no_context_variadic_keywords(node: nodes.Call, scope: nodes.Lambda) -> bool:
     statement = node.statement()
     variadics = []
@@ -1696,6 +1719,23 @@ accessed. Python regular expressions are accepted.",
                 else:
                     # **kwargs can't assign to tuples.
                     pass
+            # Keyword-only parameters can also be provided through a
+            # **kwargs dict whose keys are inferable.
+            for starred in node.kwargs:
+                if isinstance(starred.value, nodes.Name):
+                    for key in _dict_keys_from_subscript_assignments(starred.value):
+                        if key in kwparams:
+                            kwparams[key][1] = True
+                inferred = safe_infer(starred.value)
+                if not isinstance(inferred, nodes.Dict):
+                    continue
+                for key, _value in inferred.items:
+                    if (
+                        isinstance(key, nodes.Const)
+                        and isinstance(key.value, str)
+                        and key.value in kwparams
+                    ):
+                        kwparams[key.value][1] = True
 
         # Check that any parameters without a default have been assigned
         # values.

--- a/tests/functional/m/missing/missing_kwoa.py
+++ b/tests/functional/m/missing/missing_kwoa.py
@@ -90,3 +90,23 @@ def test_context_managers(**kw):
 
 
 test_context_managers(a=1)
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/10029
+# Keyword-only arguments provided through a **kwargs dict whose keys are
+# inferable should not be reported as missing.
+def fun_with_kwargs(a, b, *, c, d, **kwargs):
+    """function with kwargs"""
+    return a + b + c + d
+
+
+someargs = {}
+someargs["c"] = 3
+someargs["d"] = 4
+someargs["e"] = 5
+someargs["f"] = 6
+
+rval = fun_with_kwargs(1, 2, **someargs)
+
+# Control: the dict does not contain the required keyword-only arguments.
+otherargs = {"e": 5}
+rval2 = fun_with_kwargs(1, 2, **otherargs)  # [missing-kwoa, missing-kwoa]

--- a/tests/functional/m/missing/missing_kwoa.txt
+++ b/tests/functional/m/missing/missing_kwoa.txt
@@ -2,3 +2,5 @@ missing-kwoa:23:4:23:17:not_forwarding_kwargs:Missing mandatory keyword argument
 missing-kwoa:29:0:29:16::Missing mandatory keyword argument 'keyword' in function call:INFERENCE
 too-many-function-args:29:0:29:16::Too many positional arguments for function call:UNDEFINED
 missing-kwoa:88:20:88:25:test_context_managers:Missing mandatory keyword argument 'a' in function call:INFERENCE
+missing-kwoa:112:8:112:42::Missing mandatory keyword argument 'c' in function call:INFERENCE
+missing-kwoa:112:8:112:42::Missing mandatory keyword argument 'd' in function call:INFERENCE

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -194,3 +194,26 @@ Path(FILENAME).read_text(**KWARGS)  # [unspecified-encoding]
 
 KWARGS = {"encoding": "utf-8"}
 Path(FILENAME).read_text(**KWARGS)
+
+# The mode argument cannot be inferred: no message should be emitted
+# https://github.com/pylint-dev/pylint/issues/10201
+def open_with_unknown_mode(mode):
+    """Open a file with an unknown mode"""
+    return open(FILENAME, mode)
+
+open_with_unknown_mode("r+b")
+open_with_unknown_mode("wb")
+
+def io_open_with_unknown_mode(mode):
+    """Open a file with an unknown mode"""
+    return io.open(FILENAME, mode)
+
+io_open_with_unknown_mode("r+b")
+io_open_with_unknown_mode("wb")
+
+def path_open_with_unknown_mode(mode):
+    """Open a path with an unknown mode"""
+    return Path(FILENAME).open(mode)
+
+path_open_with_unknown_mode("r+b")
+path_open_with_unknown_mode("wb")


### PR DESCRIPTION
## Type of Changes
Bug fix

## Description
Closes #10029

When a call like `fun(1, 2, **someargs)` is checked for missing keyword-only arguments, pylint always reported the keyword-only parameters as missing unless the call site used a context variadic.

With this change, the `**kwargs` dict is inferred when possible and keyword-only parameters whose keys are present in the dict are considered satisfied. This covers both:
- dict literals with constant keys passed directly (`fun(1, 2, **{'c': 3, 'd': 4})` or `someargs = {'c': 3, 'd': 4}`)
- dicts built up via subscript assignments (`someargs['c'] = 3`)

A control case in the functional test confirms that dicts genuinely missing required keyword-only arguments are still reported.