### PR TITLE
Extend comparison-with-itself to identical attribute accesses

### DIFF
--- a/doc/whatsnew/fragments/10713.false_negative
+++ b/doc/whatsnew/fragments/10713.false_negative
@@ -1,0 +1,5 @@
+``comparison-with-itself`` now also flags redundant comparisons of the same
+attribute access, e.g. ``a.b == a.b``, when the receiver is a plain name and
+the attribute is not a property (properties are not idempotent).
+
+Closes #10713

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -245,10 +245,53 @@ class ComparisonChecker(_BasicChecker):
         ):
             left_operand = left_operand.name
             right_operand = right_operand.name
+        elif isinstance(left_operand, nodes.Attribute) and isinstance(
+            right_operand, nodes.Attribute
+        ):
+            # Compare identical attribute accesses, e.g. ``a.b == a.b``.
+            # Only flag when the receiver is a plain name (a call or an
+            # attribute chain may evaluate to different objects) and the
+            # attribute is not a property (which is not idempotent).
+            if (
+                left_operand.attrname == right_operand.attrname
+                and isinstance(left_operand.expr, nodes.Name)
+                and isinstance(right_operand.expr, nodes.Name)
+                and left_operand.expr.name == right_operand.expr.name
+                and not self._is_property_attribute(left_operand)
+            ):
+                left_operand = left_operand.as_string()
+                right_operand = right_operand.as_string()
+            else:
+                return
 
         if left_operand == right_operand:
             suggestion = f"{left_operand} {operator} {right_operand}"
             self.add_message("comparison-with-itself", node=node, args=(suggestion,))
+
+    def _is_property_attribute(self, node: nodes.Attribute) -> bool:
+        """Return True when the attribute access resolves to a property.
+
+        Properties are not idempotent, so ``a.prop == a.prop`` may be a
+        meaningful comparison. ``functools.cached_property`` is excluded:
+        it evaluates once per instance, so two accesses compare the same
+        value.
+        """
+        receiver = utils.safe_infer(node.expr)
+        if receiver is None:
+            return True
+        try:
+            attrs = receiver.getattr(node.attrname)
+        except astroid.exceptions.AttributeInferenceError:
+            return True
+        if attrs is astroid.Uninferable:
+            return True
+        return any(
+            isinstance(attr, nodes.FunctionDef)
+            and {"builtins.property", "abc.abstractproperty"}.intersection(
+                attr.decoratornames()
+            )
+            for attr in attrs
+        )
 
     def _check_constants_comparison(self, node: nodes.Compare) -> None:
         """When two constants are being compared it is always a logical tautology."""

--- a/tests/functional/l/logical_tautology.py
+++ b/tests/functional/l/logical_tautology.py
@@ -38,3 +38,21 @@ def bar():
 def foobar():
     arg = 786
     return arg > 786
+
+
+class TestClass:
+    def __init__(self):
+        self.x = 1
+
+    @property
+    def prop(self):
+        return 42
+
+    def method(self):
+        if self.x == self.x:  # [comparison-with-itself]
+            return True
+        if self.prop == self.prop:  # property is not idempotent, no message
+            return True
+        if self.x != self.x:  # [comparison-with-itself]
+            return True
+        return None

--- a/tests/functional/l/logical_tautology.txt
+++ b/tests/functional/l/logical_tautology.txt
@@ -16,3 +16,5 @@ comparison-of-constants:26:9:26:21:foo:"Comparison between constants: ""True is 
 comparison-with-itself:26:9:26:21:foo:Redundant comparison - True is True:UNDEFINED
 comparison-of-constants:28:9:28:19:foo:"Comparison between constants: ""666 == 786"" has a constant value":HIGH
 comparison-with-itself:36:18:36:28:bar:Redundant comparison - arg != arg:UNDEFINED
+comparison-with-itself:52:11:52:27:TestClass.method:Redundant comparison - self.x == self.x:UNDEFINED
+comparison-with-itself:56:11:56:27:TestClass.method:Redundant comparison - self.x != self.x:UNDEFINED


### PR DESCRIPTION
## Description

Closes #10713

`comparison-with-itself` previously only flagged redundant comparisons of plain names (`a == a`) and constants. This extends it to identical attribute accesses like `a.b == a.b` / `self.x != self.x`, following the discussion in #10713.

To avoid false positives:
- the receiver must be a plain `Name` — a call (`f().b == f().b`) or an attribute chain (`a.b.c == a.b.c`) may evaluate to different objects;
- the attribute must not be a property (`builtins.property`, `abc.abstractproperty`), since property accesses are not idempotent (e.g. `a.now == a.now` where `now` is a property may be a meaningful comparison). `functools.cached_property` is intentionally excluded: it evaluates once per instance, so repeated accesses compare the same value.

## Verification

- New cases in `tests/functional/l/logical_tautology.py`: `self.x == self.x` and `self.x != self.x` flagged, `self.prop == self.prop` (property) not flagged
- Full functional suite + checkers: only the 4 known pre-existing failures (`dataclass_with_field`, `no_name_in_module`, `recursion_error_3152`, `recursion_error_3159`), unchanged from baseline

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |