### PR TITLE
Do not flag ungrouped imports inside OS platform guards

### DIFF
--- a/doc/whatsnew/fragments/10460.false_positive
+++ b/doc/whatsnew/fragments/10460.false_positive
@@ -1,0 +1,5 @@
+``ungrouped-imports`` no longer reports imports inside mutually exclusive
+OS guard branches (``if os.name == "nt":`` / ``if sys.platform == "win32":``),
+matching the existing behavior for ``sys.version_info`` guards.
+
+Closes #10460

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -29,6 +29,7 @@ from pylint.checkers.utils import (
     in_type_checking_block,
     is_from_fallback_block,
     is_module_ignored,
+    is_platform_guard,
     is_sys_guard,
     node_ignores_exception,
 )
@@ -622,7 +623,10 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 and not in_type_checking_block(import_node)
                 and not (
                     isinstance(import_node.parent, nodes.If)
-                    and is_sys_guard(import_node.parent)
+                    and (
+                        is_sys_guard(import_node.parent)
+                        or is_platform_guard(import_node.parent)
+                    )
                 )
             ):
                 self.add_message("ungrouped-imports", node=import_node, args=package)

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1874,10 +1874,10 @@ def is_platform_guard(node: nodes.If) -> bool:
         value = node.test.left
         if isinstance(value, nodes.Subscript):
             value = value.value
-        if (
-            isinstance(value, nodes.Attribute)
-            and value.as_string() in {"os.name", "sys.platform"}
-        ):
+        if isinstance(value, nodes.Attribute) and value.as_string() in {
+            "os.name",
+            "sys.platform",
+        }:
             return True
     return False
 

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1864,6 +1864,24 @@ def is_sys_guard(node: nodes.If) -> bool:
     return False
 
 
+def is_platform_guard(node: nodes.If) -> bool:
+    """Return True if IF stmt is a os.name or sys.platform guard.
+
+    These guards split imports by OS/environment; the branches are
+    mutually exclusive so imports inside them cannot be grouped.
+    """
+    if isinstance(node.test, nodes.Compare):
+        value = node.test.left
+        if isinstance(value, nodes.Subscript):
+            value = value.value
+        if (
+            isinstance(value, nodes.Attribute)
+            and value.as_string() in {"os.name", "sys.platform"}
+        ):
+            return True
+    return False
+
+
 def _is_node_in_same_scope(
     candidate: nodes.NodeNG, node_scope: nodes.LocalsDictNodeNG
 ) -> bool:

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -385,6 +385,52 @@ def test_if_sys_guard() -> None:
     assert utils.is_sys_guard(code[5]) is False
 
 
+def test_if_platform_guard() -> None:
+    code = astroid.extract_node("""
+    import os
+    if os.name == "nt":  #@
+        pass
+
+    if os.name != "posix":  #@
+        pass
+
+    if os.something_else:  #@
+        pass
+
+    import sys
+    if sys.platform == "win32":  #@
+        pass
+
+    if sys.platform != "linux":  #@
+        pass
+
+    if sys.platformish:  #@
+        pass
+
+    if sys.version_info > (3, 8):  #@
+        pass
+    """)
+    assert isinstance(code, list) and len(code) == 7
+
+    assert isinstance(code[0], nodes.If)
+    assert utils.is_platform_guard(code[0]) is True
+    assert isinstance(code[1], nodes.If)
+    assert utils.is_platform_guard(code[1]) is True
+
+    assert isinstance(code[2], nodes.If)
+    assert utils.is_platform_guard(code[2]) is False
+
+    assert isinstance(code[3], nodes.If)
+    assert utils.is_platform_guard(code[3]) is True
+    assert isinstance(code[4], nodes.If)
+    assert utils.is_platform_guard(code[4]) is True
+
+    assert isinstance(code[5], nodes.If)
+    assert utils.is_platform_guard(code[5]) is False
+    assert isinstance(code[6], nodes.If)
+    assert utils.is_platform_guard(code[6]) is False
+
+
 def test_if_typing_guard() -> None:
     code = astroid.extract_node("""
     import typing

--- a/tests/functional/u/ungrouped_imports.py
+++ b/tests/functional/u/ungrouped_imports.py
@@ -1,6 +1,6 @@
 """Checks import order rule"""
 # pylint: disable=unused-import,wrong-import-position,wrong-import-order,using-constant-test
-# pylint: disable=import-error
+# pylint: disable=import-error,reimported,invalid-name
 import six
 import logging.config
 import os.path
@@ -32,3 +32,20 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import re
     from typing import List
+
+
+# https://github.com/pylint-dev/pylint/issues/10460
+# Imports in mutually exclusive OS guard branches (`os.name` / `sys.platform`)
+# should not trigger `ungrouped-imports`
+if os.name == "nt":
+    from os import sep as nt_sep
+    from os.path import abspath as nt_abspath
+else:
+    from os import pardir as nt_pardir
+    from os.path import isabs as nt_isabs
+import sys
+if sys.platform == "win32":
+    import re as win_re
+else:
+    import re as posix_re
+from unittest import skip  # [ungrouped-imports]

--- a/tests/functional/u/ungrouped_imports.txt
+++ b/tests/functional/u/ungrouped_imports.txt
@@ -3,3 +3,4 @@ ungrouped-imports:11:4:11:13::Imports from package os are not grouped:UNDEFINED
 ungrouped-imports:17:0:17:30::Imports from package astroid are not grouped:UNDEFINED
 ungrouped-imports:19:4:19:27::Imports from package logging are not grouped:UNDEFINED
 ungrouped-imports:20:0:20:24::Imports from package os are not grouped:UNDEFINED
+ungrouped-imports:51:0:51:25::Imports from package unittest are not grouped:UNDEFINED


### PR DESCRIPTION
## Description

Closes #10460 (also referenced in #7735 / #3382)

`ungrouped-imports` reported imports inside mutually exclusive OS guard branches:

```python
if os.name == "nt":
    from math import pi
    from pathlib import PurePosixPath
else:
    from math import e
    from pathlib import PureWindowsPath
```

The branches cannot be grouped, so the message is a false positive — the same rationale as the existing `sys.version_info` guard skip.

Rather than extending the shared `is_sys_guard` (which is also used by the deprecated checker to *intentionally* keep reporting deprecated classes inside platform guards — see `tests/functional/d/deprecated/deprecated_class_sys_guard.py`), this adds a dedicated `is_platform_guard` util for `os.name` / `sys.platform` comparisons and uses it only in the `ungrouped-imports` check.

## Verification

- Repro from the issue is clean (was C0412 × 2)
- `sys.platform` guards fixed the same way
- Non-guard conditional imports (`if some_condition:`) still flagged
- New functional cases in `tests/functional/u/ungrouped_imports.py` (guards skipped, plain condition still flagged)
- New unit test `test_if_platform_guard` in `tests/checkers/unittest_utils.py`
- Full checkers + functional suites: only the 4 known pre-existing failures unchanged

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |