### PR TITLE
Recognize math.nan, numpy.nan and Decimal("nan") in nan-comparison

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -41,6 +41,7 @@ boundmethod
 builtins
 bw
 callables
+callee
 cardinality
 cd
 cfg
@@ -228,6 +229,7 @@ mymodule
 mypy
 namedtuple
 namespace
+NaN
 newsfile
 newstyle
 nl

--- a/doc/data/messages/n/nan-comparison/bad.py
+++ b/doc/data/messages/n/nan-comparison/bad.py
@@ -1,5 +1,8 @@
+import math
+
 import numpy as np
 
 
-def both_nan(x, y) -> bool:
-    return x == np.NaN and y == float("nan")  # [nan-comparison, nan-comparison]
+def both_unknown(apple, banana) -> bool:
+    # Nothing equals NaN, not even NaN itself, so this is always False
+    return apple == math.nan and banana == np.nan  # [nan-comparison, nan-comparison]

--- a/doc/data/messages/n/nan-comparison/good.py
+++ b/doc/data/messages/n/nan-comparison/good.py
@@ -1,5 +1,7 @@
+import math
+
 import numpy as np
 
 
-def both_nan(x, y) -> bool:
-    return np.isnan(x) and np.isnan(y)
+def both_unknown(apple, banana) -> bool:
+    return math.isnan(apple) and np.isnan(banana)

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -188,7 +188,7 @@ Basic checker Messages
   a try...finally block: the exceptions raised in the try clause will be
   silently swallowed instead of being re-raised.
 :nan-comparison (W0177): *Comparison %s should be %s*
-  Used when an expression is compared to NaN values like numpy.NaN and
+  Used when an expression is compared to NaN values like math.nan, numpy.nan or
   float('nan').
 :assert-on-tuple (W0199): *Assert called on a populated tuple. Did you mean 'assert x,y'?*
   A call of assert on a tuple will always evaluate to true if the tuple is not

--- a/doc/whatsnew/fragments/11219.bugfix
+++ b/doc/whatsnew/fragments/11219.bugfix
@@ -1,0 +1,7 @@
+``nan-comparison`` now also recognizes ``math.nan``, ``numpy.nan``, ``Decimal("nan")``
+and any name or attribute that pylint can infer to a NaN constant, such as a module
+level constant defined as ``math.nan``. Only ``numpy.NaN`` -- removed in numpy 2.0 --
+and ``float("nan")`` were detected before. Infinities are still not reported, as
+comparing against them is meaningful.
+
+Refs #11219

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -4,6 +4,8 @@
 
 """Comparison checker from the basic checker."""
 
+import math
+
 import astroid
 from astroid import nodes
 
@@ -77,7 +79,7 @@ class ComparisonChecker(_BasicChecker):
             "Comparison %s should be %s",
             "nan-comparison",
             "Used when an expression is compared to NaN "
-            "values like numpy.NaN and float('nan').",
+            "values like math.nan, numpy.nan or float('nan').",
         ),
     }
 
@@ -144,6 +146,8 @@ class ComparisonChecker(_BasicChecker):
         checking_for_absence: bool = False,
     ) -> None:
         def _is_float_nan(node: nodes.NodeNG) -> bool:
+            # ``float('nan')`` infers to an *instance* of float, which carries no
+            # value to inspect, so this branch has to stay shape-based.
             try:
                 match node:
                     case nodes.Call(args=[nodes.Const(value=str() as value)]) if (
@@ -154,14 +158,53 @@ class ComparisonChecker(_BasicChecker):
             except AttributeError:
                 return False
 
-        def _is_numpy_nan(node: nodes.NodeNG) -> bool:
+        def _is_decimal_nan(node: nodes.NodeNG) -> bool:
+            # ``decimal`` NaNs compare just like float ones, but ``Decimal('nan')``
+            # is not inferable without the call being evaluated, hence the
+            # shape-based match on the callee name.
             match node:
-                case nodes.Attribute(attrname="NaN", expr=nodes.Name(name=name)):
+                case nodes.Call(
+                    func=nodes.Name(name="Decimal")
+                    | nodes.Attribute(attrname="Decimal"),
+                    args=[nodes.Const(value=str() as value)],
+                ):
+                    return value.lower() == "nan"
+            return False
+
+        def _is_inferred_nan(node: nodes.NodeNG) -> bool:
+            """Whether ``node`` infers to a NaN constant, e.g. ``math.nan``.
+
+            Only names and attributes are inferred: those are the shapes a NaN
+            constant can hide behind, and inferring every operand of every
+            comparison would be needlessly expensive.
+            """
+            if not isinstance(node, (nodes.Name, nodes.Attribute)):
+                return False
+            # ``math.inf`` also infers to a float constant, so the value itself
+            # has to be checked with ``isnan`` and not merely be 'special'.
+            match utils.safe_infer(node):
+                case nodes.Const(value=float() as value):
+                    return math.isnan(value)
+            return False
+
+        def _is_numpy_nan(node: nodes.NodeNG) -> bool:
+            # Purely syntactic on purpose: numpy need not be installed for the
+            # analysed code to be checked, in which case ``np.nan`` is
+            # uninferable. ``NaN``/``NAN`` were removed in numpy 2.0.
+            match node:
+                case nodes.Attribute(
+                    attrname="nan" | "NaN" | "NAN", expr=nodes.Name(name=name)
+                ):
                     return name in {"numpy", "np"}
             return False
 
         def _is_nan(node: nodes.NodeNG) -> bool:
-            return _is_float_nan(node) or _is_numpy_nan(node)
+            return (
+                _is_numpy_nan(node)
+                or _is_inferred_nan(node)
+                or _is_float_nan(node)
+                or _is_decimal_nan(node)
+            )
 
         nan_left = _is_nan(left_value)
         if not nan_left and not _is_nan(right_value):

--- a/tests/functional/n/nan_comparison_check.py
+++ b/tests/functional/n/nan_comparison_check.py
@@ -1,6 +1,11 @@
 # pylint: disable=missing-docstring, invalid-name
 # pylint: disable=literal-comparison,comparison-with-itself, import-error, comparison-of-constants
 """Test detection of NaN value comparison."""
+import decimal
+import math
+from decimal import Decimal
+from math import nan
+
 import numpy
 
 x = 42
@@ -22,3 +27,26 @@ assert x is not float("nan")  # [nan-comparison]
 if x == numpy.NaN:  # [nan-comparison]
     pass
 z = bool(x is numpy.NaN)  # [nan-comparison]
+
+# NaN spellings other than 'numpy.NaN' and 'float("nan")'
+m1 = x == math.nan  # [nan-comparison]
+m2 = x is not math.nan  # [nan-comparison]
+m3 = x != nan  # [nan-comparison]
+n1 = x == numpy.nan  # [nan-comparison]
+n2 = x == numpy.NAN  # [nan-comparison]
+n3 = x is numpy.nan  # [nan-comparison]
+d1 = x == Decimal("nan")  # [nan-comparison]
+d2 = x != decimal.Decimal("NaN")  # [nan-comparison]
+
+# A NaN hidden behind a module level constant is still a NaN
+MY_NAN = math.nan
+c1 = x == MY_NAN  # [nan-comparison]
+
+# Infinity is not NaN: comparing against it is meaningful, so stay silent
+o1 = x == math.inf
+o2 = x != float("inf")
+o3 = x is numpy.inf
+o4 = x == -math.inf
+o5 = x == math.pi
+o6 = x == Decimal("1.5")
+o7 = x == Decimal(x)

--- a/tests/functional/n/nan_comparison_check.txt
+++ b/tests/functional/n/nan_comparison_check.txt
@@ -1,14 +1,23 @@
-nan-comparison:7:4:7:18::Comparison 'x is numpy.NaN' should be 'math.isnan(x)':UNDEFINED
-nan-comparison:8:4:8:18::Comparison 'x == numpy.NaN' should be 'math.isnan(x)':UNDEFINED
-nan-comparison:9:4:9:21::Comparison 'x == float('nan')' should be 'math.isnan(x)':UNDEFINED
-nan-comparison:10:4:10:21::Comparison 'x is float('nan')' should be 'math.isnan(x)':UNDEFINED
-nan-comparison:11:4:11:26::Comparison 'numpy.NaN == numpy.NaN' should be 'math.isnan(numpy.NaN)':UNDEFINED
-nan-comparison:14:4:14:22::Comparison 'numpy.NaN is not x' should be 'not math.isnan(x)':UNDEFINED
-nan-comparison:15:4:15:18::Comparison 'numpy.NaN != x' should be 'not math.isnan(x)':UNDEFINED
-nan-comparison:17:4:17:18::Comparison 'x != numpy.NaN' should be 'not math.isnan(x)':UNDEFINED
-nan-comparison:18:5:18:22::Comparison 'x != float('nan')' should be 'not math.isnan(x)':UNDEFINED
-nan-comparison:19:4:19:22::Comparison 'x is not numpy.NaN' should be 'not math.isnan(x)':UNDEFINED
-nan-comparison:20:7:20:21::Comparison 'x == numpy.NaN' should be 'math.isnan(x)':UNDEFINED
-nan-comparison:21:7:21:28::Comparison 'x is not float('nan')' should be 'not math.isnan(x)':UNDEFINED
-nan-comparison:22:3:22:17::Comparison 'x == numpy.NaN' should be 'math.isnan(x)':UNDEFINED
-nan-comparison:24:9:24:23::Comparison 'x is numpy.NaN' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:12:4:12:18::Comparison 'x is numpy.NaN' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:13:4:13:18::Comparison 'x == numpy.NaN' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:14:4:14:21::Comparison 'x == float('nan')' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:15:4:15:21::Comparison 'x is float('nan')' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:16:4:16:26::Comparison 'numpy.NaN == numpy.NaN' should be 'math.isnan(numpy.NaN)':UNDEFINED
+nan-comparison:19:4:19:22::Comparison 'numpy.NaN is not x' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:20:4:20:18::Comparison 'numpy.NaN != x' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:22:4:22:18::Comparison 'x != numpy.NaN' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:23:5:23:22::Comparison 'x != float('nan')' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:24:4:24:22::Comparison 'x is not numpy.NaN' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:25:7:25:21::Comparison 'x == numpy.NaN' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:26:7:26:28::Comparison 'x is not float('nan')' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:27:3:27:17::Comparison 'x == numpy.NaN' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:29:9:29:23::Comparison 'x is numpy.NaN' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:32:5:32:18::Comparison 'x == math.nan' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:33:5:33:22::Comparison 'x is not math.nan' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:34:5:34:13::Comparison 'x != nan' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:35:5:35:19::Comparison 'x == numpy.nan' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:36:5:36:19::Comparison 'x == numpy.NAN' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:37:5:37:19::Comparison 'x is numpy.nan' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:38:5:38:24::Comparison 'x == Decimal('nan')' should be 'math.isnan(x)':UNDEFINED
+nan-comparison:39:5:39:32::Comparison 'x != decimal.Decimal('NaN')' should be 'not math.isnan(x)':UNDEFINED
+nan-comparison:43:5:43:16::Comparison 'x == MY_NAN' should be 'math.isnan(x)':UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |


## Description

Only `numpy.NaN` and `float("nan")` were detected. `numpy.NaN` was removed in numpy 2.0, so the check recognized a dead alias while missing the live `numpy.nan` and the most common stdlib spelling, `math.nan`.

Will probably need a better handling of numpy in astroid to be done properly.

Infinities infer to a float constant too, so the value is checked with `math.isnan` rather than for being a special float.
