### PR TITLE
Fix recursive discovery below package roots

### DIFF
--- a/doc/whatsnew/fragments/9187.bugfix
+++ b/doc/whatsnew/fragments/9187.bugfix
@@ -1,0 +1,4 @@
+Fix ``--recursive`` discovery when the supplied directory is a package. Python
+files below non-package subdirectories are now linted as expected.
+
+Closes #9187

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -667,21 +667,28 @@ class PyLinter(
         """
         for something in files_or_modules:
             if os.path.isdir(something):
-                skip_subtrees: list[str] = []
                 package_directories: set[str] = set()
-                for root, _, files in os.walk(something):
-                    if any(root.startswith(s) for s in skip_subtrees):
-                        # Skip ignored sub-trees.
-                        continue
-
+                for root, dirnames, files in os.walk(something, topdown=True):
                     if _is_ignored_file(
                         root,
                         self.config.ignore,
                         self.config.ignore_patterns,
                         self.config.ignore_paths,
                     ):
-                        skip_subtrees.append(root + os.sep)
+                        dirnames.clear()
                         continue
+
+                    dirnames[:] = [
+                        dirname
+                        for dirname in dirnames
+                        if not _is_ignored_file(
+                            os.path.join(root, dirname),
+                            self.config.ignore,
+                            self.config.ignore_patterns,
+                            self.config.ignore_paths,
+                        )
+                    ]
+                    dirnames.sort()
 
                     if "__init__.py" in files:
                         package_directory = os.path.normpath(root)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -671,7 +671,7 @@ class PyLinter(
                 package_directories: set[str] = set()
                 for root, _, files in os.walk(something):
                     if any(root.startswith(s) for s in skip_subtrees):
-                        # Skip ignored subtrees.
+                        # Skip ignored sub-trees.
                         continue
 
                     if _is_ignored_file(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -666,13 +666,12 @@ class PyLinter(
         Returns iterator of paths to discovered modules and packages.
         """
         for something in files_or_modules:
-            if os.path.isdir(something) and not os.path.isfile(
-                os.path.join(something, "__init__.py")
-            ):
+            if os.path.isdir(something):
                 skip_subtrees: list[str] = []
+                package_directories: set[str] = set()
                 for root, _, files in os.walk(something):
                     if any(root.startswith(s) for s in skip_subtrees):
-                        # Skip subtree of already discovered package.
+                        # Skip ignored subtrees.
                         continue
 
                     if _is_ignored_file(
@@ -685,8 +684,13 @@ class PyLinter(
                         continue
 
                     if "__init__.py" in files:
-                        skip_subtrees.append(root + os.sep)
-                        yield root
+                        package_directory = os.path.normpath(root)
+                        if (
+                            os.path.dirname(package_directory)
+                            not in package_directories
+                        ):
+                            yield root
+                        package_directories.add(package_directory)
                     else:
                         yield from (
                             os.path.join(root, file)

--- a/tests/lint/unittest_discover_files.py
+++ b/tests/lint/unittest_discover_files.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -17,6 +18,81 @@ def _initialized_linter(linter: PyLinter) -> PyLinter:
     return linter
 
 
+@pytest.fixture(name="package_with_non_package_subdirectories")
+def _package_with_non_package_subdirectories(tmp_path: Path) -> tuple[Path, set[Path]]:
+    package = tmp_path / "root_package"
+    files = {
+        package / "__init__.py",
+        package / "module.py",
+        package / "nested_package" / "__init__.py",
+        package / "nested_package" / "module.py",
+        package / "nested_package" / "tools" / "tool.py",
+        package / "scripts" / "script.py",
+        package / "scripts" / "helper.pyi",
+        package / "scripts" / "extra_package" / "__init__.py",
+        package / "scripts" / "extra_package" / "module.py",
+        package / "scripts" / "extra_package" / "resources" / "data.py",
+    }
+    for file in files:
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.touch()
+    return package, files
+
+
+def test_discover_files_below_package_root(
+    initialized_linter: PyLinter,
+    package_with_non_package_subdirectories: tuple[Path, set[Path]],
+) -> None:
+    package, _ = package_with_non_package_subdirectories
+
+    discovered = {
+        Path(path) for path in initialized_linter._discover_files([str(package)])
+    }
+
+    assert discovered == {
+        package,
+        package / "nested_package" / "tools" / "tool.py",
+        package / "scripts" / "script.py",
+        package / "scripts" / "helper.pyi",
+        package / "scripts" / "extra_package",
+        package / "scripts" / "extra_package" / "resources" / "data.py",
+    }
+
+
+@pytest.mark.parametrize("trailing_separator", [False, True])
+def test_expanded_files_below_package_root_are_not_duplicated(
+    initialized_linter: PyLinter,
+    package_with_non_package_subdirectories: tuple[Path, set[Path]],
+    trailing_separator: bool,
+) -> None:
+    package, expected_files = package_with_non_package_subdirectories
+    package_argument = str(package) + (os.sep if trailing_separator else "")
+
+    discovered = tuple(initialized_linter._discover_files([package_argument]))
+    file_descriptions = tuple(initialized_linter._iterate_file_descrs(discovered))
+    expanded_files = [Path(item.filepath) for item in file_descriptions]
+
+    assert set(expanded_files) == expected_files
+    assert len(expanded_files) == len(expected_files)
+
+
+def test_ignore_non_package_subdirectory_below_package_root(
+    initialized_linter: PyLinter,
+    package_with_non_package_subdirectories: tuple[Path, set[Path]],
+) -> None:
+    package, _ = package_with_non_package_subdirectories
+    initialized_linter.config.ignore = ["scripts"]
+
+    discovered = {
+        Path(path) for path in initialized_linter._discover_files([str(package)])
+    }
+
+    assert discovered == {
+        package,
+        package / "nested_package" / "tools" / "tool.py",
+    }
+
+
 def mock_isdir(path: str) -> bool:
     """
     Mock of os.path.isdir() for the following tests:
@@ -26,19 +102,6 @@ def mock_isdir(path: str) -> bool:
     if path == ".":
         return True
     raise ValueError(f"Not expecting an isdir call on {path}")
-
-
-def mock_isfile(path: str) -> bool:
-    """
-    Mock of os.path.isfile() for the following tests:
-    - test_discover_files_does_not_ignore_similarly_named_package
-    - test_discover_files_does_not_ignore_similarly_named_package_even_if_first_is_ignored
-    """
-    if path == f".{os.sep}__init__.py":
-        return False
-    if path == f".{os.sep}manage.py":
-        return True
-    raise ValueError(f"Not expecting an isfile call on {path}")
 
 
 @pytest.fixture(name="mock_tree")
@@ -81,21 +144,13 @@ def test_does_not_ignore_similarly_named_package(
     first and does not match an ignore config value.
     """
     with mock.patch("os.walk") as mock_walk:
-        with mock.patch.multiple(
-            "os.path", isdir=mock.DEFAULT, isfile=mock.DEFAULT
-        ) as mock_path:
+        with mock.patch("os.path.isdir", side_effect=mock_isdir) as mock_isdir_method:
             mock_walk.return_value = mock_tree
-            mock_path["isdir"].side_effect = mock_isdir
-            mock_path["isfile"].side_effect = mock_isfile
 
             results = tuple(initialized_linter._discover_files(["."]))
 
-            assert mock_path["isdir"].call_count == 1
-            assert mock_path["isdir"].call_args_list == [mock.call(".")]
-            assert mock_path["isfile"].call_count == 1
-            assert mock_path["isfile"].call_args_list == [
-                mock.call(f".{os.sep}__init__.py"),
-            ]
+            assert mock_isdir_method.call_count == 1
+            assert mock_isdir_method.call_args_list == [mock.call(".")]
 
     assert len(results) == 3
     assert results == (
@@ -116,9 +171,7 @@ def test_does_not_ignore_similarly_named_package_even_if_first_ignored(
     NOTE: manage.py probably should be ignored.
     """
     with mock.patch("os.walk") as mock_walk:
-        with mock.patch.multiple(
-            "os.path", isdir=mock.DEFAULT, isfile=mock.DEFAULT
-        ) as mock_path:
+        with mock.patch("os.path.isdir", side_effect=mock_isdir) as mock_isdir_method:
             initialized_linter.config.ignore = [
                 ".venv",
                 "applications",
@@ -126,17 +179,11 @@ def test_does_not_ignore_similarly_named_package_even_if_first_ignored(
                 "manage.py",
             ]
             mock_walk.return_value = mock_tree
-            mock_path["isdir"].side_effect = mock_isdir
-            mock_path["isfile"].side_effect = mock_isfile
 
             results = tuple(initialized_linter._discover_files(["."]))
 
-            assert mock_path["isdir"].call_count == 1
-            assert mock_path["isdir"].call_args_list == [mock.call(".")]
-            assert mock_path["isfile"].call_count == 1
-            assert mock_path["isfile"].call_args_list == [
-                mock.call(f".{os.sep}__init__.py"),
-            ]
+            assert mock_isdir_method.call_count == 1
+            assert mock_isdir_method.call_args_list == [mock.call(".")]
 
     assert len(results) == 2
     assert results == (f".{os.sep}manage.py", f".{os.sep}applications_api")

--- a/tests/lint/unittest_discover_files.py
+++ b/tests/lint/unittest_discover_files.py
@@ -106,6 +106,20 @@ def test_ignore_non_package_subdirectory_below_package_root(
     mock_walk.assert_called_once_with(str(package), topdown=True)
 
 
+def test_ignore_supplied_package_root(
+    initialized_linter: PyLinter,
+    package_with_non_package_subdirectories: tuple[Path, set[Path]],
+) -> None:
+    package, _ = package_with_non_package_subdirectories
+    initialized_linter.config.ignore = [package.name]
+
+    with mock.patch("os.walk", wraps=os.walk) as mock_walk:
+        discovered = tuple(initialized_linter._discover_files([str(package)]))
+
+    assert not discovered
+    mock_walk.assert_called_once_with(str(package), topdown=True)
+
+
 def test_discover_files_sorts_directories(
     initialized_linter: PyLinter, tmp_path: Path
 ) -> None:

--- a/tests/lint/unittest_discover_files.py
+++ b/tests/lint/unittest_discover_files.py
@@ -3,6 +3,7 @@
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
 
 import os
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from unittest import mock
 
@@ -82,15 +83,49 @@ def test_ignore_non_package_subdirectory_below_package_root(
 ) -> None:
     package, _ = package_with_non_package_subdirectories
     initialized_linter.config.ignore = ["scripts"]
+    walked_directories: list[Path] = []
+    original_walk = os.walk
 
-    discovered = {
-        Path(path) for path in initialized_linter._discover_files([str(package)])
-    }
+    def recording_walk(
+        top: str, *, topdown: bool
+    ) -> Iterator[tuple[str, list[str], list[str]]]:
+        for root, dirnames, files in original_walk(top, topdown=topdown):
+            walked_directories.append(Path(root))
+            yield root, dirnames, files
+
+    with mock.patch("os.walk", side_effect=recording_walk) as mock_walk:
+        discovered = {
+            Path(path) for path in initialized_linter._discover_files([str(package)])
+        }
 
     assert discovered == {
         package,
         package / "nested_package" / "tools" / "tool.py",
     }
+    assert package / "scripts" not in walked_directories
+    mock_walk.assert_called_once_with(str(package), topdown=True)
+
+
+def test_discover_files_sorts_directories(
+    initialized_linter: PyLinter, tmp_path: Path
+) -> None:
+    def unsorted_walk(
+        root: str, *, topdown: bool
+    ) -> Iterator[tuple[str, list[str], list[str]]]:
+        assert topdown
+        dirnames = ["z_package", "a_package"]
+        yield root, dirnames, []
+        for dirname in dirnames:
+            yield os.path.join(root, dirname), [], ["__init__.py"]
+
+    with mock.patch("os.walk", side_effect=unsorted_walk) as mock_walk:
+        discovered = tuple(initialized_linter._discover_files([str(tmp_path)]))
+
+    assert discovered == (
+        str(tmp_path / "a_package"),
+        str(tmp_path / "z_package"),
+    )
+    mock_walk.assert_called_once_with(str(tmp_path), topdown=True)
 
 
 def mock_isdir(path: str) -> bool:
@@ -135,6 +170,28 @@ def _mock_tree() -> list[tuple[str, list[str], list[str]]]:
     ]
 
 
+def mock_os_walk(
+    tree: list[tuple[str, list[str], list[str]]],
+) -> Callable[..., Iterator[tuple[str, list[str], list[str]]]]:
+    tree_by_root = {root: (dirnames, files) for root, dirnames, files in tree}
+
+    def walk(
+        root: str, *, topdown: bool
+    ) -> Iterator[tuple[str, list[str], list[str]]]:
+        assert root == "."
+        assert topdown
+
+        def visit(current_root: str) -> Iterator[tuple[str, list[str], list[str]]]:
+            dirnames, files = tree_by_root[current_root]
+            yield current_root, dirnames, files
+            for dirname in dirnames:
+                yield from visit(os.path.join(current_root, dirname))
+
+        yield from visit(root)
+
+    return walk
+
+
 def test_does_not_ignore_similarly_named_package(
     initialized_linter: PyLinter,
     mock_tree: list[tuple[str, list[str], list[str]]],
@@ -145,7 +202,7 @@ def test_does_not_ignore_similarly_named_package(
     """
     with mock.patch("os.walk") as mock_walk:
         with mock.patch("os.path.isdir", side_effect=mock_isdir) as mock_isdir_method:
-            mock_walk.return_value = mock_tree
+            mock_walk.side_effect = mock_os_walk(mock_tree)
 
             results = tuple(initialized_linter._discover_files(["."]))
 
@@ -178,7 +235,7 @@ def test_does_not_ignore_similarly_named_package_even_if_first_ignored(
                 "node_modules",
                 "manage.py",
             ]
-            mock_walk.return_value = mock_tree
+            mock_walk.side_effect = mock_os_walk(mock_tree)
 
             results = tuple(initialized_linter._discover_files(["."]))
 

--- a/tests/lint/unittest_discover_files.py
+++ b/tests/lint/unittest_discover_files.py
@@ -175,9 +175,7 @@ def mock_os_walk(
 ) -> Callable[..., Iterator[tuple[str, list[str], list[str]]]]:
     tree_by_root = {root: (dirnames, files) for root, dirnames, files in tree}
 
-    def walk(
-        root: str, *, topdown: bool
-    ) -> Iterator[tuple[str, list[str], list[str]]]:
+    def walk(root: str, *, topdown: bool) -> Iterator[tuple[str, list[str], list[str]]]:
         assert root == "."
         assert topdown
 


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Fix recursive discovery when the supplied directory is itself a package.

`_discover_files` now walks package roots and yields one expansion root for each
contiguous package chain. This preserves normal package expansion while discovering
standalone `.py` and `.pyi` files below non-package directories, including package
islands reached after those boundaries. Normalized package-directory keys prevent
duplicate linting when the supplied path has a trailing separator, and existing
ignored-subtree behavior remains unchanged.

Regression coverage uses a real directory tree to verify the discovered argument
units, the exact final file set without duplicates, trailing-separator behavior,
nested packages, standalone stubs, and ignored non-package descendants.

Closes #9187

## Tests

- `pytest tests/lint/unittest_discover_files.py tests/lint/unittest_expand_modules.py -q`
- `pytest tests/lint -q`
- `pylint pylint/lint/pylinter.py tests/lint/unittest_discover_files.py`
- `towncrier build --draft`
