### PR TITLE
Fix false positive for invalid-name on TypedDict instances

### DIFF
--- a/doc/whatsnew/fragments/11231.false_positive
+++ b/doc/whatsnew/fragments/11231.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``invalid-name`` when a module-level variable is assigned
+an instance of a ``TypedDict`` subclass. Such a name is a value, not a type
+definition, so it is now checked against the constant or variable regex instead
+of ``class-rgx``.
+
+Closes #11231

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -581,16 +581,18 @@ class NameChecker(_BasicChecker):
     ) -> bool:
         if isinstance(inferred_assign_type, nodes.ClassDef):
             return True
-        if isinstance(inferred_assign_type, bases.Instance) and {
-            "EnumMeta",
-            "TypedDict",
-        }.intersection(
-            {
+        if isinstance(inferred_assign_type, bases.Instance):
+            if "EnumMeta" in {
                 ancestor.name
                 for ancestor in cast(InferenceResult, inferred_assign_type).mro()
-            }
-        ):
-            return True
+            }:
+                return True
+            # The functional syntax `X = TypedDict("X", {...})` defines a new type,
+            # and is inferred as an instance of `TypedDict` itself. Instantiating a
+            # `TypedDict` subclass only builds a value, so its name is not a class
+            # name.
+            if inferred_assign_type._proxied.name == "TypedDict":
+                return True
         if (
             isinstance(inferred_assign_type, nodes.FunctionDef)
             and inferred_assign_type.qname() == "typing.Annotated"

--- a/tests/functional/i/invalid/invalid_name.py
+++ b/tests/functional/i/invalid/invalid_name.py
@@ -125,3 +125,11 @@ Color = Enum('Color', [('RED', 1), ('GREEN', 2), ('BLUE', 3)])
 
 from typing import TypedDict
 MyExampleType = TypedDict("MyExampleType", {"some_field": str})
+
+
+class MyTypedDict(TypedDict):
+    some_field: str
+
+
+MY_TYPED_DICT = MyTypedDict(some_field="value")
+myTypedDict = MyTypedDict(some_field="value")  # [invalid-name]

--- a/tests/functional/i/invalid/invalid_name.txt
+++ b/tests/functional/i/invalid/invalid_name.txt
@@ -8,3 +8,4 @@ invalid-name:82:23:82:29:FooBar.__init__:"Argument name ""fooBar"" doesn't confo
 invalid-name:88:8:88:14:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
 invalid-name:108:8:108:15:FooBar.test_disable_mixed:"Argument name ""fooBar2"" doesn't conform to snake_case naming style":HIGH
 invalid-name:119:4:119:25:FooBarSubclass:"Class attribute name ""tearDownNotInAncestor"" doesn't conform to snake_case naming style":HIGH
+invalid-name:135:0:135:11::"Constant name ""myTypedDict"" doesn't conform to UPPER_CASE naming style":HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`_should_check_class_regex` returned `True` for any `bases.Instance` whose MRO contains a class named `TypedDict`, so a module-level variable holding an instance of a `TypedDict` subclass was checked against `class-rgx`:

```python
from typing import TypedDict


class Foo(TypedDict):
    value: str


_DEFAULT_VALUE = Foo(value="0")  # C0103: Class name "_DEFAULT_VALUE" ...
```

The two cases are distinguishable by the instantiated class rather than the whole MRO. With astroid 4.2, the functional syntax `X = TypedDict("X", {...})` (the case #10672 was about) infers to an instance of `TypedDict` itself, while `Foo(value="0")` infers to an instance of `Foo`. Checking `_proxied.name` therefore keeps the type-definition case checked as a class and lets plain values fall through to the constant and variable regexes. The `EnumMeta` MRO check is unchanged.

Verified on the reproducer above (no message now) and on `X = typing.TypedDict("X", {"a": int})` plus `Enum("lowercase_enum", ...)` with lowercase names (still reported as class names). A badly named instance is now reported under the right category:

```
repro_bad.py:8:0: C0103: Constant name "myTypedDict" doesn't conform to UPPER_CASE naming style (invalid-name)
```

Both shapes are added to `tests/functional/i/invalid/invalid_name.py`, next to the existing #10672 case. Full local suite: 2129 passed, 281 skipped, 5 xfailed.

Closes #11231
