### PR TITLE
Fix duplicate-code false positive on placeholder-only function bodies

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -1318,7 +1318,7 @@ Standard Checkers
 
 --ignore-signatures
 """""""""""""""""""
-*Signatures are removed from the similarity computation*
+*Signatures are removed from the similarity computation. Functions whose body only contains placeholder statements (pass, ..., raise NotImplementedError, return NotImplemented) are removed entirely.*
 
 **Default:**  ``True``
 

--- a/doc/whatsnew/fragments/7213.false_positive
+++ b/doc/whatsnew/fragments/7213.false_positive
@@ -1,0 +1,11 @@
+Fix a false positive for ``duplicate-code`` (R0801) when ``ignore-signatures``
+is enabled (the default) and several functions have placeholder bodies such as
+``pass``, ``...``, ``raise NotImplementedError`` or ``return NotImplemented``.
+Stripping the signatures used to leave the placeholder bodies of unrelated
+functions on adjacent lines, so two abstract classes with enough stub methods
+were reported as duplicates of each other. Functions whose body only contains
+such placeholder statements are now ignored entirely when signatures are
+ignored. As with the other ``ignore-*`` options, duplicated code that is only
+separated by ignored lines is aggregated into a single reported block.
+
+Closes #7213

--- a/pylint/checkers/symilar.py
+++ b/pylint/checkers/symilar.py
@@ -273,6 +273,32 @@ def remove_successive(all_couples: CplIndexToCplLines_T) -> None:
                 pass
 
 
+def _is_placeholder_stmt(stmt: nodes.NodeNG) -> bool:
+    """Check whether a statement is a trivial placeholder.
+
+    Placeholder statements (``pass``, ``...``, ``raise NotImplementedError``
+    and ``return NotImplemented``) are the conventional bodies of stubs and
+    abstract methods: duplication between them carries no copy-paste signal.
+    This deliberately differs from astroid's ``FunctionDef.is_abstract()``,
+    which relies on decorators and does not recognise ``...`` or
+    ``return NotImplemented`` bodies.
+    """
+    if isinstance(stmt, nodes.Pass):
+        return True
+    if isinstance(stmt, nodes.Expr):
+        return isinstance(stmt.value, nodes.Const) and stmt.value.value is Ellipsis
+    if isinstance(stmt, nodes.Raise):
+        exc = stmt.exc
+        if isinstance(exc, nodes.Call):
+            exc = exc.func
+        return isinstance(exc, nodes.Name) and exc.name == "NotImplementedError"
+    if isinstance(stmt, nodes.Return):
+        return (
+            isinstance(stmt.value, nodes.Name) and stmt.value.name == "NotImplemented"
+        )
+    return False
+
+
 def filter_noncode_lines(
     ls_1: LineSet,
     stindex_1: Index,
@@ -579,7 +605,9 @@ def stripped_lines(
     :param ignore_comments: if true, any comment in the lines collection is removed from the result
     :param ignore_docstrings: if true, any line that is a docstring is removed from the result
     :param ignore_imports: if true, any line that is an import is removed from the result
-    :param ignore_signatures: if true, any line that is part of a function signature is removed from the result
+    :param ignore_signatures: if true, any line that is part of a function signature is removed from the result;
+           functions whose body only contains placeholder statements (``pass``, ``...``,
+           ``raise NotImplementedError``, ``return NotImplemented``) are removed entirely
     :param line_enabled_callback: If called with "R0801" and a line number, a return value of False will disregard
            the line
     :param tree: pre-parsed AST; when provided the redundant astroid.parse() call is skipped
@@ -619,15 +647,15 @@ def stripped_lines(
                 return functions
 
             functions = _get_functions([], tree)
-            ignore_lines.update(
-                chain.from_iterable(
-                    range(
-                        func.lineno,
-                        func.body[0].lineno if func.body else func.tolineno + 1,
-                    )
-                    for func in functions
-                )
-            )
+            for func in functions:
+                if func.body and all(_is_placeholder_stmt(stmt) for stmt in func.body):
+                    # The whole function is a declarative stub with no
+                    # implementation to compare: ignore it entirely, not just
+                    # its signature. See https://github.com/pylint-dev/pylint/issues/7213
+                    end_lineno = func.tolineno + 1
+                else:
+                    end_lineno = func.body[0].lineno if func.body else func.tolineno + 1
+                ignore_lines.update(range(func.lineno, end_lineno))
 
     strippedlines = []
     docstring = None
@@ -756,7 +784,11 @@ class SimilaritiesChecker(BaseRawFileChecker, Symilar):
     IGNORE_COMMENTS_HELP = "Comments are removed from the similarity computation"
     IGNORE_DOCSTRINGS_HELP = "Docstrings are removed from the similarity computation"
     IGNORE_IMPORTS_HELP = "Imports are removed from the similarity computation"
-    IGNORE_SIGNATURES_HELP = "Signatures are removed from the similarity computation"
+    IGNORE_SIGNATURES_HELP = (
+        "Signatures are removed from the similarity computation. Functions "
+        "whose body only contains placeholder statements (pass, ..., raise "
+        "NotImplementedError, return NotImplemented) are removed entirely."
+    )
     # for available dict keys/values see the option parser 'add_option' method
     options: Options = (
         (

--- a/pylintrc
+++ b/pylintrc
@@ -166,7 +166,9 @@ ignore-docstrings=yes
 # Ignore imports when computing similarities.
 ignore-imports=yes
 
-# Signatures are removed from the similarity computation
+# Signatures are removed from the similarity computation. Functions whose body
+# only contains placeholder statements (pass, ..., raise NotImplementedError,
+# return NotImplemented) are removed entirely.
 ignore-signatures=yes
 
 

--- a/tests/checkers/unittest_symilar.py
+++ b/tests/checkers/unittest_symilar.py
@@ -28,6 +28,8 @@ SIMILAR_CLS_A = str(INPUT / "similar_cls_a.py")
 SIMILAR_CLS_B = str(INPUT / "similar_cls_b.py")
 EMPTY_FUNCTION_1 = str(INPUT / "similar_empty_func_1.py")
 EMPTY_FUNCTION_2 = str(INPUT / "similar_empty_func_2.py")
+TRIVIAL_STUBS_1 = str(INPUT / "similar_trivial_stubs_1.py")
+TRIVIAL_STUBS_2 = str(INPUT / "similar_trivial_stubs_2.py")
 MULTILINE = str(INPUT / "multiline-import")
 HIDE_CODE_WITH_IMPORTS = str(INPUT / "hide_code_with_imports.py")
 
@@ -248,6 +250,62 @@ def test_ignore_signatures_empty_functions_pass() -> None:
     assert output.getvalue().strip() == """
 TOTAL lines=14 duplicates=0 percent=0.00
 """.strip()
+
+
+def test_ignore_signatures_trivial_stub_bodies_pass() -> None:
+    """Functions whose body only contains placeholder statements (``pass``,
+    ``...``, ``raise NotImplementedError``, ``return NotImplemented``) are
+    ignored entirely when signatures are ignored, while functions with a real
+    implementation are still compared.
+
+    Near-miss placeholders (``raise ValueError(...)``, ``return None``) must
+    NOT be ignored: they still participate in the similarity computation.
+
+    The fixtures also pin decorated and docstring-bearing stubs: astroid puts
+    ``FunctionDef.lineno`` on the first decorator and moves leading docstrings
+    out of ``body`` into ``doc_node``. If either invariant shifts, the
+    identical decorator or docstring lines re-enter the comparison and the
+    exact-output assertion below fails.
+
+    Regression test for https://github.com/pylint-dev/pylint/issues/7213
+    """
+    output = StringIO()
+    with redirect_stdout(output), pytest.raises(SystemExit) as ex:
+        symilar.Run(["--ignore-signatures", TRIVIAL_STUBS_1, TRIVIAL_STUBS_2])
+    assert ex.value.code == 0
+    assert output.getvalue().strip() == (f"""
+6 similar lines in 2 files
+=={TRIVIAL_STUBS_1}:[51:67]
+=={TRIVIAL_STUBS_2}:[51:67]
+           raise ValueError("not a placeholder")
+
+       def other_raise_two(self):
+           raise ValueError("not a placeholder")
+
+       def other_raise_three(self):
+           raise ValueError("not a placeholder")
+
+       def other_return_one(self):
+           return None
+
+       def other_return_two(self):
+           return None
+
+       def other_return_three(self):
+           return None
+
+5 similar lines in 2 files
+=={TRIVIAL_STUBS_1}:[39:46]
+=={TRIVIAL_STUBS_2}:[39:46]
+           total = 0
+           for value in values:
+               total += value * 2
+           total *= 3
+           return total
+
+       def divider(self):
+TOTAL lines=184 duplicates=11 percent=5.98
+""").strip()
 
 
 def test_no_hide_code_with_imports() -> None:

--- a/tests/input/similar_trivial_stubs_1.py
+++ b/tests/input/similar_trivial_stubs_1.py
@@ -1,0 +1,92 @@
+def module_stub_one():
+    raise NotImplementedError
+
+
+class Processor:
+
+    def first(self) -> None:
+        pass
+
+    def second(self) -> None:
+        pass
+
+    def third(self) -> None:
+        pass
+
+    def fourth(self) -> None:
+        pass
+
+    def fifth(self) -> None:
+        pass
+
+    def sixth(self) -> None:
+        ...
+
+    def seventh(self) -> None:
+        raise NotImplementedError
+
+    def eighth(self) -> None:
+        raise NotImplementedError(
+            "must be overridden in a subclass"
+        )
+
+    def ninth(self) -> None:
+        return NotImplemented
+
+    async def tenth(self) -> None:
+        pass
+
+    def compute(self, values) -> int:
+        total = 0
+        for value in values:
+            total += value * 2
+        total *= 3
+        return total
+
+    def separator(self):
+        left = 10
+        right = left + 5
+        return right
+
+    def near_miss_raise_one(self):
+        raise ValueError("not a placeholder")
+
+    def near_miss_raise_two(self):
+        raise ValueError("not a placeholder")
+
+    def near_miss_raise_three(self):
+        raise ValueError("not a placeholder")
+
+    def near_miss_return_one(self):
+        return None
+
+    def near_miss_return_two(self):
+        return None
+
+    def near_miss_return_three(self):
+        return None
+
+    @abstractmethod
+    def documented_stub_one(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_stub_two(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_stub_three(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_stub_four(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_stub_five(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError

--- a/tests/input/similar_trivial_stubs_2.py
+++ b/tests/input/similar_trivial_stubs_2.py
@@ -1,0 +1,92 @@
+def module_stub_two():
+    raise NotImplementedError
+
+
+class AnotherProcessor:
+
+    def alpha(self) -> None:
+        pass
+
+    def beta(self) -> None:
+        pass
+
+    def gamma(self) -> None:
+        pass
+
+    def delta(self) -> None:
+        pass
+
+    def epsilon(self) -> None:
+        pass
+
+    def zeta(self) -> None:
+        ...
+
+    def eta(self) -> None:
+        raise NotImplementedError
+
+    def theta(self) -> None:
+        raise NotImplementedError(
+            "must be overridden in a subclass"
+        )
+
+    def iota(self) -> None:
+        return NotImplemented
+
+    async def kappa(self) -> None:
+        pass
+
+    def calculate(self, values) -> int:
+        total = 0
+        for value in values:
+            total += value * 2
+        total *= 3
+        return total
+
+    def divider(self):
+        top = 99
+        bottom = top - 9
+        return bottom
+
+    def other_raise_one(self):
+        raise ValueError("not a placeholder")
+
+    def other_raise_two(self):
+        raise ValueError("not a placeholder")
+
+    def other_raise_three(self):
+        raise ValueError("not a placeholder")
+
+    def other_return_one(self):
+        return None
+
+    def other_return_two(self):
+        return None
+
+    def other_return_three(self):
+        return None
+
+    @abstractmethod
+    def documented_other_one(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_other_two(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_other_three(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_other_four(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def documented_other_five(self) -> None:
+        """To be implemented by subclasses."""
+        raise NotImplementedError


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| x   | :bug: Bug fix |

## Description

Closes #7213

### What the bug is

With `ignore-signatures` enabled (the default since pylint 2.14), two
unrelated abstract classes are reported as duplicates of each other when each
contains `min-similarity-lines + 1` or more stub methods whose bodies are just
`pass`. Reproduction from the issue: two files, each declaring a class with
five methods with `pass` bodies and completely different names, produce:

```
test2.py:1:0: R0801: Similar lines in 2 files
==test2:[3:16]
==test:[3:16]
        pass
    ...
```

This still reproduces verbatim on current `main` (pylint 4.1.0-dev0). It also
explains the `--jobs` inconsistency noted in the issue thread: with the fix,
`-j1` and `-j2` agree again.

### Root cause

In `stripped_lines()` in `pylint/checkers/symilar.py`, `ignore-signatures`
blanks every signature line, and blanked lines are dropped from the stripped
line list entirely. The `pass` bodies of five different methods therefore
become five adjacent stripped lines, and the rolling-hash window matches that
run of identical placeholder lines across files, even though nothing was
actually copy-pasted.

### The fix

When `ignore-signatures` is enabled, a function whose body consists only of
trivial placeholder statements (`pass`, `...`, `raise NotImplementedError`,
`return NotImplemented`) is now ignored entirely instead of only its
signature. Such functions are purely declarative and have no implementation
that could meaningfully be duplicated. Functions with a real implementation
are unchanged: their signatures are still stripped and their bodies still
participate in the similarity computation.

The new `_is_placeholder_stmt()` helper follows the `isinstance`-based node
checking style described in the repository's AGENTS.md. Docstrings never
interfere with the classification: astroid stores them in `doc_node`, not in
`body`, so a documented stub (`def f(): """doc"""; pass`) is ignored too,
and docstring-only functions (empty `body`) were already removed entirely by
the pre-existing empty-body branch.

The `--ignore-signatures` help text, the `stripped_lines()` docstring, the
generated `doc/user_guide/configuration/all-options.rst` (regenerated with
`doc/exts/pylint_options.py:build_options_page`; the resulting diff there is
the one help line), and the corresponding comment in the root `pylintrc`
were all synchronized to describe the new behaviour. `examples/pylintrc` and
`examples/pyproject.toml` are regenerated at release time by the tbump hooks
and were deliberately left alone.

### Known boundaries, stated explicitly

* Two sub-threshold duplicated implementations separated only by a
  placeholder stub are now aggregated into one reported block whose range
  spans the (uncompared) stub lines. This aggregation-through-elision
  behaviour is pre-existing, not new: the same splice already happens today
  through elided multi-line signatures (verified empirically on unmodified
  main with two 4-line duplicate bodies separated by functions whose
  multi-line signatures differ; R0801 reports one block spanning the
  differing signatures). This change extends the class of elided regions, it
  does not introduce the mechanism. A contiguity guard in `hash_lineset()`
  would change several existing expected outputs and is left as a possible
  follow-up.
* Only the builtin names are recognised: `raise pkg.NotImplementedError`
  (attribute form) or aliased builtins are not treated as placeholders. This
  is deliberate; recognising those would require inference.
* Byte-identical multi-line `raise NotImplementedError("...")` blocks across
  files are no longer compared either. This is the intended semantics
  (placeholder bodies carry no copy-paste signal regardless of message) and
  is pinned by the regression test.
* The placeholder set intentionally differs from astroid's
  `FunctionDef.is_abstract()` (which relies on decorators and does not
  recognise `...` or `return NotImplemented` bodies); the helper docstring
  says so to prevent an accidental "deduplication" later.

### Regression test and proof it is load-bearing

`test_ignore_signatures_trivial_stub_bodies_pass` in
`tests/checkers/unittest_symilar.py` runs symilar with `--ignore-signatures`
on two new input files (`tests/input/similar_trivial_stubs_1.py` and `_2.py`).
Each file declares:

* a module-level stub function and a class with ten stub methods covering all
  four placeholder forms, a multi-line `raise NotImplementedError(...)`, and
  an `async def` stub (these must all be ignored);
* one method with a real five-line body identical across the two files (must
  still be reported);
* six near-miss methods with identical single-statement bodies that look like
  placeholders but are not (`raise ValueError("not a placeholder")`,
  `return None`) - these pin the negative space of the classifier: they must
  STAY in the similarity computation, so a future loosening of
  `_is_placeholder_stmt()` fails the test instead of silently widening the
  ignore set;
* five `@abstractmethod`-decorated stubs with identical docstrings and
  `raise NotImplementedError` bodies - these pin the two astroid invariants
  the fix relies on (`FunctionDef.lineno` sits on the first decorator;
  leading docstrings live in `doc_node`, not `body`). If either invariant
  shifts in a future astroid, the identical decorator or docstring lines
  re-enter the comparison and the exact-output assertion fails instead of
  the bug reopening silently.

The test asserts the exact report: a 6-line block for the near-miss bodies
(`[51:67]`), a 5-line block for the real implementation (`[39:46]`), and
`TOTAL lines=184 duplicates=11 percent=5.98` - nothing else. This
simultaneously checks that stub bodies no longer match, that real duplicate
code is still detected, and that near-placeholders are not over-ignored.

Proof runs:

* With the fix reverted (`git stash` of `symilar.py`): the test FAILS; the
  report instead contains a 17-line similarity block spanning the stub
  methods.
* With the fix applied: the test PASSES.

Also verified directly: the exact reproduction from the issue goes from
R0801/exit code 8 to a 10.00/10 clean run, documented stubs
(docstring + `pass`) no longer trigger either, and `-j1`/`-j2` agree.

### Test suite status

* `tests/checkers/unittest_symilar.py` + `tests/test_similar.py`: 43 passed.
* `tests/checkers/` package: 449 passed, 2 skipped, 4 xfailed.
* `tests/test_self.py` (with the updated root `pylintrc`): 154 passed.
* Full suite (`pytest tests/ -n auto`, benchmark tests run separately without
  xdist): 2152 passed, 245 skipped, 5 xfailed, 11 benchmark tests passed,
  1 failed: `test_functional[symlink_module0]`. That failure is a
  pre-existing environment artifact on a Windows checkout without symlink
  support (verified by running the same test on a clean checkout of `main`,
  where it fails identically).
* `black --check`, `ruff check`, `isort --check-only`,
  `pydocstringformatter`, mypy, and
  `pylint --rcfile=pylintrc --fail-on=I` all clean on the changed files.
* `python -m script.check_newsfragments` passes for the new news fragment.

### Relation to the dormant fix-7213 branch

The repository contains an unopened WIP branch `fix-7213` (89d187bb) that
addresses this issue with the same semantics. This PR is an independent
implementation: it was written and reviewed before that branch's diff was
read, arrives at the same four placeholder forms, and additionally covers
multi-statement placeholder bodies, pins the behaviour with
positive/negative/invariant fixtures, adds the changelog fragment, and
regenerates `all-options.rst` as the generated-documentation CI check now
requires. Happy to reconcile with that branch however the maintainers
prefer.

### Disclosure

This fix was developed with AI assistance (Claude) and was additionally
reviewed with an automated cross-file review tool before submission. All
changes were reproduced, tested and verified locally as described above.

### Checklist items from the template

* News fragment created: `doc/whatsnew/fragments/7213.false_positive`
  (type `false_positive`).
* Change is related to tracker issue: Closes #7213.
* Change is kept minimal: one helper plus one loop in `stripped_lines()`,
  synchronized option help/doc text, one regression test, two test input
  files, one news fragment. Final diff: 7 files, +300/-13. Of the 300 added
  lines, 242 are the regression test and its two input fixtures and 15 are
  documentation and config text (news fragment, generated rst, pylintrc
  comment); the remaining 43 are in `pylint/checkers/symilar.py`, of which
  9 are help-string and docstring prose, leaving the behavioural change
  itself at a 26-line documented helper plus a 9-line rewrite of the
  existing ignore-range loop.
