### PR TITLE
Upgrade astroid to 4.3.1

### DIFF
--- a/doc/whatsnew/4/4.1/index.rst
+++ b/doc/whatsnew/4/4.1/index.rst
@@ -17,8 +17,8 @@ result in considerable performance improvements and memory use reduction
 on larger codebases. For example, pandas analysis went from 20 min to
 55 s and pylint does not get OOM-killed when analyzing cpython anymore.
 
-The required ``astroid`` version is now 4.1.1. See the
-`astroid changelog <https://pylint.readthedocs.io/projects/astroid/en/latest/changelog.html#what-s-new-in-astroid-4-1-0>`_
+The required ``astroid`` version is now 4.3.1. See the
+`astroid changelog <https://pylint.readthedocs.io/projects/astroid/en/latest/changelog.html#what-s-new-in-astroid-4-3-1>`_
 for additional fixes, features, and performance improvements applicable to pylint.
 
 .. towncrier release notes start

--- a/doc/whatsnew/fragments/10193.false_positive
+++ b/doc/whatsnew/fragments/10193.false_positive
@@ -1,0 +1,7 @@
+Fixed a false positive ``no-name-in-module`` when a module is imported with
+an alias that shadows its base module and a function named ``format`` is
+called on the alias.
+
+Fixed by upgrading astroid to 4.3.1.
+
+Closes #10193

--- a/doc/whatsnew/fragments/10519.bugfix
+++ b/doc/whatsnew/fragments/10519.bugfix
@@ -1,0 +1,6 @@
+Fixed an ``AstroidBuildingError`` crash when inheriting from a generic
+dataclass that rebinds ``__init__`` in ``__init_subclass__``.
+
+Fixed by upgrading astroid to 4.3.1.
+
+Closes #10519

--- a/doc/whatsnew/fragments/10548.false_positive
+++ b/doc/whatsnew/fragments/10548.false_positive
@@ -1,0 +1,6 @@
+Fixed a false positive ``unexpected-keyword-argument`` when passing ``dtype``
+to ``numpy.concatenate()``.
+
+Fixed by upgrading astroid to 4.3.1.
+
+Closes #10548

--- a/doc/whatsnew/fragments/872.bugfix
+++ b/doc/whatsnew/fragments/872.bugfix
@@ -1,0 +1,7 @@
+``# pylint: disable`` comments at the beginning of an ``else`` block (or on
+the line just above the ``else`` keyword) now suppress messages in that block
+instead of being ignored.
+
+Fixed by upgrading astroid to 4.3.1.
+
+Closes #872

--- a/doc/whatsnew/fragments/8746.bugfix
+++ b/doc/whatsnew/fragments/8746.bugfix
@@ -1,0 +1,6 @@
+Fixed a crash when defining a functional ``namedtuple`` with a field name
+that changes under NFKC normalization, like ``"µ"`` (MICRO SIGN).
+
+Fixed by upgrading astroid to 4.3.1.
+
+Closes #8746

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   # Also upgrade test-min dependency group and requirements_test_min.txt.
   # Pinned to dev of second minor update to allow editable installs and fix primer issues,
   # see https://github.com/pylint-dev/astroid/issues/1341
-  "astroid>=4.2.0b5,<=4.3",
+  "astroid>=4.3.1,<=4.4",
   "colorama>=0.4.5; sys_platform=='win32'",
   # Python 3.15 support has not been released yet, so we pin to a specific commit that supports it.
   "dill @ git+https://github.com/uqfoundation/dill@2308ffb0d0c605b9c050fa4c9fd5793d65c67022 ; python_version>='3.15'",
@@ -93,7 +93,7 @@ docs = [
 # Configuration for the build system
 test-min = [
   # Base test dependencies
-  "astroid==4.2.0b5",                   # Pinned to a specific version for tests
+  "astroid==4.3.1",                     # Pinned to a specific version for tests
   "py~=1.11.0",
   "pytest>=8.4,<10",
   "pytest-benchmark~=5.1",

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,6 +1,6 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
-astroid==4.2.0b5   # Pinned to a specific version for tests
+astroid==4.3.1   # Pinned to a specific version for tests
 typing-extensions~=4.15
 py~=1.11.0
 pytest>=8.4,<10.0

--- a/tests/checkers/unittest_variables.py
+++ b/tests/checkers/unittest_variables.py
@@ -194,3 +194,23 @@ class TestMissingSubmodule(CheckerTestCase):
             assert got == "E:  3: Undefined variable name 'missing' in __all__"
         finally:
             sys.path.pop(0)
+
+
+class TestShadowedModuleAlias(CheckerTestCase):
+    CHECKER_CLASS = variables.VariablesChecker
+
+    @staticmethod
+    def test_no_name_in_module_alias_shadowing() -> None:
+        """Regression test for https://github.com/pylint-dev/pylint/issues/10193.
+
+        No false `no-name-in-module` when an alias shadows its base module and
+        a function named `format` is called on the alias.
+        """
+        package_dir = os.path.join(REGR_DATA_DIR, "shadowed_module_alias")
+        sys.path.insert(0, package_dir)
+        try:
+            linter.check([os.path.join(package_dir, "main.py")])
+            assert isinstance(linter.reporter, GenericTestReporter)
+            assert linter.reporter.finalize().strip() == ""
+        finally:
+            sys.path.pop(0)

--- a/tests/functional/d/disable_msg_else_block.py
+++ b/tests/functional/d/disable_msg_else_block.py
@@ -1,0 +1,28 @@
+# Regression test for https://github.com/pylint-dev/pylint/issues/872
+# A disable comment at the start of an `else` block used to have no effect.
+# Fixed with astroid 4.3.0, where `block_range` considers `else` its own block.
+"""Check that a disable in an `else` block silences messages in that block only."""
+
+
+def first_line_of_else_block(fruits, apple):
+    """Disable as the first line of the else block."""
+    if fruits:
+        print(fruits)
+    else:
+        # pylint: disable=protected-access
+        print(apple._color)
+    return apple._color  # [protected-access]
+
+
+def line_above_else_keyword(fruits, apple):
+    """Disable on the line just above the else keyword."""
+    if fruits:
+        print(fruits)
+    # pylint: disable=protected-access
+    else:
+        print(apple._color)
+
+
+def control(apple):
+    """No disable: the message is emitted."""
+    return apple._color  # [protected-access]

--- a/tests/functional/d/disable_msg_else_block.txt
+++ b/tests/functional/d/disable_msg_else_block.txt
@@ -1,0 +1,2 @@
+protected-access:14:11:14:23:first_line_of_else_block:Access to a protected member _color of a client class:UNDEFINED
+protected-access:28:11:28:23:control:Access to a protected member _color of a client class:UNDEFINED

--- a/tests/functional/r/regression_03/regression_10519.py
+++ b/tests/functional/r/regression_03/regression_10519.py
@@ -1,0 +1,39 @@
+# Regression test for https://github.com/pylint-dev/pylint/issues/10519
+# Inheriting from a generic dataclass that rebinds __init__ in
+# __init_subclass__ used to crash with an AstroidBuildingError.
+# Fixed with astroid 4.3.0.
+"""Crash regression test for generic dataclass with __init_subclass__."""
+# pylint: disable=too-few-public-methods
+from abc import ABC
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import ParamSpec
+
+_P = ParamSpec("_P")
+
+
+@dataclass
+class Basket[FruitT](ABC):
+    """Generic dataclass rebinding __init__ in __init_subclass__."""
+
+    _fruit: FruitT | None = field(init=False)
+    _labels: dict[str, str] = field(init=False)
+
+    def __init_subclass__(cls) -> None:
+        def _wrap(func: Callable[_P, None]) -> Callable[_P, None]:
+            def _wrapped(*args: _P.args, **kwargs: _P.kwargs) -> None:
+                self = args[0]
+                func(*args, **kwargs)
+                if not hasattr(self, "_fruit"):
+                    object.__setattr__(self, "_fruit", None)
+                if not hasattr(self, "_labels"):
+                    object.__setattr__(self, "_labels", {})
+
+            return _wrapped
+
+        cls.__init__ = _wrap(cls.__init__)  # type: ignore[method-assign]
+
+
+@dataclass
+class AppleBasket(Basket):
+    """Subclass without subscripting the generic base."""

--- a/tests/functional/r/regression_03/regression_10519.rc
+++ b/tests/functional/r/regression_03/regression_10519.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/r/regression_03/regression_11013.py
+++ b/tests/functional/r/regression_03/regression_11013.py
@@ -1,0 +1,19 @@
+# Regression test for https://github.com/pylint-dev/pylint/issues/11013
+# Type aliases annotated with `TypeAlias` inside a `TYPE_CHECKING` block were
+# wrongly reported as constants that should use UPPER_CASE naming.
+"""No `invalid-name` for type aliases nested in `TYPE_CHECKING`."""
+# pylint: disable=too-few-public-methods
+from typing import TYPE_CHECKING, TypeAlias, Union
+
+if TYPE_CHECKING:
+    AppleType: TypeAlias = "Apple"
+    BananaType: TypeAlias = "Banana"
+    AnyFruit = Union[AppleType, BananaType]
+
+
+class Apple:
+    """An apple."""
+
+
+class Banana:
+    """A banana."""

--- a/tests/functional/r/regression_03/regression_7647.py
+++ b/tests/functional/r/regression_03/regression_7647.py
@@ -1,0 +1,22 @@
+# Regression test for https://github.com/pylint-dev/pylint/issues/7647
+# `unnecessary-lambda` was wrongly emitted when the lambda called a function
+# with `**kwargs` built from an if-else expression.
+"""No `unnecessary-lambda` when kwargs come from an if-else expression."""
+from contextlib import ExitStack
+
+
+def eat(**kwargs):
+    """Print the meal."""
+    print(kwargs)
+
+
+def run_in_context(callback):
+    """Run the callback inside a context."""
+    with ExitStack():
+        callback()
+
+
+def main(hungry: bool):
+    """Build kwargs conditionally and run."""
+    kwargs = {} if hungry else {"fruit": "apple"}
+    run_in_context(lambda: eat(**kwargs))

--- a/tests/functional/r/regression_03/regression_8746.py
+++ b/tests/functional/r/regression_03/regression_8746.py
@@ -1,0 +1,8 @@
+# Regression test for https://github.com/pylint-dev/pylint/issues/8746
+# Fixed with astroid 4.3.0: no more crash when a functional namedtuple field
+# name changes under NFKC normalization ("µ" MICRO SIGN becomes "μ" GREEK MU).
+"""Crash regression test for namedtuple fields normalized by NFKC."""
+from collections import namedtuple
+
+NAMES = ["µ"]
+Micro = namedtuple("Micro", NAMES)

--- a/tests/functional/r/regression_03/regression_9258.py
+++ b/tests/functional/r/regression_03/regression_9258.py
@@ -1,0 +1,15 @@
+# Regression test for https://github.com/pylint-dev/pylint/issues/9258
+# The `_HAS_DEFAULT_FACTORY` sentinel injected by the astroid dataclass brain
+# leaked into module locals and was reported as an unused global variable.
+"""No `unused-variable` for the dataclass `_HAS_DEFAULT_FACTORY` sentinel."""
+import dataclasses
+
+
+@dataclasses.dataclass
+class Basket:
+    """A basket of fruits."""
+
+    fruits: list = dataclasses.field(default_factory=list)
+
+
+Basket()

--- a/tests/functional/r/regression_03/regression_9258.rc
+++ b/tests/functional/r/regression_03/regression_9258.rc
@@ -1,0 +1,2 @@
+[variables]
+allow-global-unused-variables=no

--- a/tests/regrtest_data/shadowed_module_alias/fruits/__init__.py
+++ b/tests/regrtest_data/shadowed_module_alias/fruits/__init__.py
@@ -1,0 +1,1 @@
+"""A small package shadowed by an import alias in main.py."""

--- a/tests/regrtest_data/shadowed_module_alias/fruits/basket.py
+++ b/tests/regrtest_data/shadowed_module_alias/fruits/basket.py
@@ -1,0 +1,9 @@
+"""A module with a function named ``format``, like ``str.format``."""
+
+
+def format():  # pylint: disable=redefined-builtin
+    """Shape the fruit basket."""
+
+
+def arrange():
+    """Arrange the fruit basket."""

--- a/tests/regrtest_data/shadowed_module_alias/main.py
+++ b/tests/regrtest_data/shadowed_module_alias/main.py
@@ -1,0 +1,8 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/10193.
+
+Shadowing the base module with an alias and calling a method named
+``format`` on the alias used to emit a false ``no-name-in-module``.
+"""
+import fruits.basket as fruits
+
+fruits.format()


### PR DESCRIPTION
## Type of Changes

|   | Type |
| - | ---- |
| ✓ | 🐛 Bug fix |

## Description

Upgrade astroid to [4.3.1](https://github.com/pylint-dev/astroid/releases/tag/v4.3.1) and add regression tests plus changelog fragments for the pylint issues the upgrade actually fixes.

Every issue below was checked in three environments rather than only against the astroid changelog: released pylint 4.0.8 (which resolves astroid 4.0.4), `main` before this PR (astroid 4.2.0b5) and this branch (astroid 4.3.1). The astroid 4.2.0 line was never released — a `v4.2.0` tag was created by mistake, so the beta entries ship as 4.3.0 — which makes the changelog alone a poor guide to what a pylint user gains.

### Fixed by this PR — still broken on `main` today

- Crash (`KeyError`) on a functional `namedtuple` whose field name changes under NFKC normalization (#8746)
- Crash (`AstroidBuildingError`) when inheriting from a generic dataclass that rebinds `__init__` in `__init_subclass__` (#10519)

### Fixed for a pylint user by this release — broken in 4.0.8, already fixed on `main` by its 4.2.0b5 floor

- `# pylint: disable` at the start of an `else` block now applies to that block (#872)
- False positive `no-name-in-module` with a module alias shadowing its base module and a call to `.format()` (#10193)
- False positive `unexpected-keyword-argument` for `numpy.concatenate(..., dtype=...)` (#10548)

### Already correct in released pylint 4.0.8 — regression test only, no changelog fragment

These were verified fixed in 4.0.8 with the reporter's own reproducer, so pylint 4.1 changes nothing for them and a fragment would wrongly tell users to upgrade. They get a test to keep them fixed:

- False positive `unnecessary-lambda` with `**kwargs` from an if-else expression (#7647)
- False positive `unused-variable` for the dataclass `_HAS_DEFAULT_FACTORY` sentinel (#9258)
- False positive `invalid-name` for `TypeAlias` aliases in `TYPE_CHECKING` blocks (#11013)

Verified fixed in 4.0.8 by hand but not covered by a test, as they need a third-party package or a multi-module setup:

- False positive `invalid-enum-extension` for member-less enums from another module (#6887)
- False positive `syntax-error` for badly placed type annotations (#3757) and for multi-line type comments (#3556) — astroid retries the parse without type comments

### Still **not** fixed with astroid 4.3.1

Checked and left open: #7688, #9259, #4944, #4908, #10460, #11115, #10471, #9622, #4018, #1480, #436, #7820, #8072, #5321, #9989, #10238, #4920, #7240.

#7240 (`no-member` inside comprehensions in platform-guarded branches) initially looked fixed, but the Windows CI jobs proved otherwise: the false positive is only observable when the guarded branch is unreachable on the running platform, so the linux-only check was vacuous. Its regression test and fragment were removed again.

### Known follow-up

The bump brings the new `no-member` family reported in pylint-dev/astroid#3210 (an attribute assigned through an overridable factory class attribute infers to the base class), visible on astropy and django in the primer. That issue is still open.

Closes #872
Closes #3556
Closes #3757
Closes #6887
Closes #7647
Closes #9258
Closes #10193
Closes #10519
Closes #10548
Closes #11013
