### PR TITLE
Recreate the venv on cache miss in the primer comment workflow

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -54,6 +54,16 @@ jobs:
             env.KEY_PREFIX }}-${{ env.CACHE_VERSION }}-${{ hashFiles('pyproject.toml',
             'requirements_test.txt', 'requirements_test_min.txt',
             'requirements_test_pre_commit.txt') }}
+      # The cache can be evicted between the moment it is created on 'main'
+      # and the moment this job runs, so recreate the virtual environment
+      # if it is missing.
+      - name: Create Python virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install --upgrade --requirement requirements_test.txt
       # The cached venv contains the pylint that was installed when the cache was
       # created, which can be stale. Reinstall from the current checkout so the
       # comparison and comment rendering use the right code (see #11153).


### PR DESCRIPTION
## Type of Changes

|   | Type |
| - | ---- |
| ✓ | 🔨 Refactoring |

## Description

Every `Primer / Comment` run since 2026-08-05 failed with `venv/bin/activate: No such file or directory` ([example](https://github.com/pylint-dev/pylint/actions/runs/31247999153)), so primer comments are no longer posted on PRs (e.g. #11234 got none).

Timeline of the breakage:
- The venv cache for main's key was last used successfully on 2026-08-03 (last push to `main`).
- GitHub evicted it before 2026-08-05 (LRU eviction, no push to `main` since to recreate it).
- `primer_comment.yaml` restores the cache but — unlike `primer_run_main.yaml` and `primer_run_pr.yaml` — has no fallback step creating the venv on a cache miss, so it fails at `. venv/bin/activate` and keeps failing until the next push to `main`.

The fix copies the `Create Python virtual environment` step from the other primer workflows, guarded by `cache-hit != 'true'`. The job uses `actions/cache` (restore + automatic save), so the recreated venv also repopulates the cache for subsequent runs.

No changelog fragment: CI-only change.