### PR TITLE
Docs: add a linter aggregators page in the installation section

### DIFF
--- a/doc/user_guide/installation/index.rst
+++ b/doc/user_guide/installation/index.rst
@@ -6,6 +6,7 @@ Pylint can be installed:
 - :ref:`As a command line tool <installation>`
 - :ref:`Integrated in your editor/ide <ide-integration>`
 - :ref:`As a pre-commit hook <pre-commit-integration>`
+- :ref:`With a linter aggregator <linter-aggregators>`
 - :ref:`For multiple python interpreters in your continuous integration <continuous-integration>`
 
 .. toctree::
@@ -16,6 +17,7 @@ Pylint can be installed:
    command_line_installation.rst
    ide_integration/index
    pre-commit-integration.rst
+   linter-aggregators.rst
    with-multiple-interpreters.rst
    badge
    upgrading_pylint.rst

--- a/doc/user_guide/installation/linter-aggregators.rst
+++ b/doc/user_guide/installation/linter-aggregators.rst
@@ -1,0 +1,25 @@
+.. _linter-aggregators:
+
+Installation with a linter aggregator
+=====================================
+
+Several tools bundle pylint with other linters, so you can get pylint as part of a
+larger suite instead of installing and configuring it yourself:
+
+- `Prospector <https://prospector.landscape.io/>`_ runs pylint along with other python
+  analysis tools and merges everything into a single report.
+- `Pylama <https://github.com/klen/pylama>`_ is a code audit tool wrapping pylint and
+  several other python linters behind one command.
+- `MegaLinter <https://megalinter.io/>`_ is a continuous integration oriented aggregator
+  covering many languages, that `runs pylint out of the box
+  <https://megalinter.io/latest/descriptors/python_pylint/>`_.
+- `Super-Linter <https://github.com/super-linter/super-linter>`_ is a GitHub Action
+  bundling linters for many languages, pylint included.
+
+Code quality platforms such as `Codacy <https://www.codacy.com/>`_,
+`Code Climate <https://codeclimate.com/>`_ and
+`SonarQube <https://www.sonarsource.com/products/sonarqube/>`_ can also run pylint or
+import its reports.
+
+All those integrations are maintained by third parties: the pylint version they ship
+and the options they expose are up to them, so refer to their own documentation.

--- a/doc/user_guide/installation/pre-commit-integration.rst
+++ b/doc/user_guide/installation/pre-commit-integration.rst
@@ -7,6 +7,10 @@ Pre-commit integration
 discourage it as pylint -- due to its speed -- is more suited to a continuous integration
 job or a git ``pre-push`` hook, especially if your repository is large.
 
+If you want a ready-made continuous integration setup, `MegaLinter
+<https://megalinter.io/>`_ is an open-source linters aggregator that `runs pylint
+out of the box <https://megalinter.io/latest/descriptors/python_pylint/>`_.
+
 Since ``pylint`` needs to import modules and dependencies to work correctly, the
 hook only works with a local installation of ``pylint`` (in your environment). It means
 it can't be used with ``pre-commit.ci``, and you will need to add the following to your

--- a/doc/user_guide/installation/pre-commit-integration.rst
+++ b/doc/user_guide/installation/pre-commit-integration.rst
@@ -7,10 +7,6 @@ Pre-commit integration
 discourage it as pylint -- due to its speed -- is more suited to a continuous integration
 job or a git ``pre-push`` hook, especially if your repository is large.
 
-If you want a ready-made continuous integration setup, `MegaLinter
-<https://megalinter.io/>`_ is an open-source linters aggregator that `runs pylint
-out of the box <https://megalinter.io/latest/descriptors/python_pylint/>`_.
-
 Since ``pylint`` needs to import modules and dependencies to work correctly, the
 hook only works with a local installation of ``pylint`` (in your environment). It means
 it can't be used with ``pre-commit.ci``, and you will need to add the following to your


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Hi! I maintain MegaLinter (https://megalinter.io/), an open-source linters aggregator for CI that ships pylint out of the box. Since the pre-commit integration page already points people toward running pylint in a CI job, I added a two-line note mentioning it as a ready-made option, with a link to the pylint page of its documentation.

Docs-only, so I didn't add a news fragment — happy to add one (or adjust wording/placement) if you'd prefer.