### PR TITLE
Fix crash for non-string enum names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ build-stamp
 .pytest_cache/
 .mypy_cache/
 .benchmarks/
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build-stamp
 .pytest_cache/
 .mypy_cache/
 .benchmarks/
+.DS_Store

--- a/doc/whatsnew/fragments/11229.bugfix
+++ b/doc/whatsnew/fragments/11229.bugfix
@@ -1,0 +1,4 @@
+Fix a crash in the typecheck checker when a dynamically created class has a
+non-string name.
+
+Closes #11229

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -476,7 +476,11 @@ def _emit_no_member(
         return False
     if is_super(owner) or getattr(owner, "type", None) == "metaclass":
         return False
-    if owner_name and ignored_mixins and mixin_class_rgx.match(owner_name):
+    if (
+        isinstance(owner_name, str)
+        and ignored_mixins
+        and mixin_class_rgx.match(owner_name)
+    ):
         return False
     if isinstance(owner, nodes.FunctionDef) and (
         owner.decorators or owner.is_abstract()
@@ -513,7 +517,7 @@ def _emit_no_member(
             return False
         except astroid.NotFoundError:
             pass
-    if owner_name and node.attrname.startswith("_" + owner_name):
+    if isinstance(owner_name, str) and node.attrname.startswith("_" + owner_name):
         # Test if an attribute has been mangled ('private' attribute)
         unmangled_name = node.attrname.split("_" + owner_name)[-1]
         try:

--- a/tests/functional/r/regression_03/regression_11229.py
+++ b/tests/functional/r/regression_03/regression_11229.py
@@ -1,0 +1,8 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11229."""
+
+from enum import Enum
+
+# pylint: disable=invalid-name
+
+enum_instance = Enum(1, "")
+_ = enum_instance.missing  # [no-member]

--- a/tests/functional/r/regression_03/regression_11229.txt
+++ b/tests/functional/r/regression_03/regression_11229.txt
@@ -1,0 +1,1 @@
+no-member:8:4:8:25::Instance of 1 has no 'missing' member:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Astroid can expose a non-string `name` for a class created dynamically with `Enum`. The `no-member` checker used that value in regular-expression and private-name string operations, which raised `TypeError`.

Only apply those string-specific operations when the inferred owner name is a string. The existing `no-member` diagnostic is preserved, and a functional regression test covers the reported reproducer.

Closes #11229

## Verification

- `python -m pytest tests/checkers/unittest_typecheck.py -q` — 7 passed
- `python -m pytest tests/test_functional.py -k "member or enum or regression_11229" -q` — 55 passed
- All configured pre-commit hooks passed on the changed files
- Full functional suite: 890 passed, 12 skipped; the remaining `unbalanced_tuple_unpacking` failure is also present on the unchanged default branch