### PR TITLE
Fix repeated output formats writing only to the last file

### DIFF
--- a/doc/whatsnew/fragments/8147.bugfix
+++ b/doc/whatsnew/fragments/8147.bugfix
@@ -1,1 +1,3 @@
 Repeated ``--output-format`` options now write reports to every requested file instead of only the last one.
+
+Closes #8147

--- a/doc/whatsnew/fragments/8147.bugfix
+++ b/doc/whatsnew/fragments/8147.bugfix
@@ -1,0 +1,1 @@
+Repeated ``--output-format`` options now write reports to every requested file instead of only the last one.

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -24,6 +24,7 @@ from pylint.config.argument import (
     _StoreOldNamesArgument,
     _StoreTrueArgument,
 )
+from pylint.config.callback_actions import _CallbackAction
 from pylint.config.exceptions import (
     UnrecognizedArgumentAction,
     _UnrecognizedOptionError,
@@ -206,6 +207,7 @@ class _ArgumentsManager:
 
     def _parse_configuration_file(self, arguments: list[str]) -> None:
         """Parse the arguments found in a configuration file into the namespace."""
+        self._reset_callback_actions()
         try:
             self.config, parsed_args = self._arg_parser.parse_known_args(
                 arguments, self.config
@@ -225,11 +227,19 @@ class _ArgumentsManager:
         """Parse the arguments found on the command line into the namespace."""
         arguments = sys.argv[1:] if arguments is None else arguments
 
+        self._reset_callback_actions()
+
         self.config, parsed_args = self._arg_parser.parse_known_args(
             arguments, self.config
         )
 
         return parsed_args
+
+    def _reset_callback_actions(self) -> None:
+        """Start a fresh accumulation scope for callback actions."""
+        for action in self._arg_parser._actions:
+            if isinstance(action, _CallbackAction):
+                action.reset()
 
     def _generate_config(
         self, stream: TextIO | None = None, skipsections: tuple[str, ...] = ()

--- a/pylint/config/arguments_manager.py
+++ b/pylint/config/arguments_manager.py
@@ -406,6 +406,7 @@ class _ArgumentsManager:
 
     def set_option(self, optname: str, value: Any) -> None:
         """Set an option on the namespace object."""
+        self._reset_callback_actions()
         self.config = self._arg_parser.parse_known_args(
             [f"--{optname.replace('_', '-')}", _parse_rich_type_value(value)],
             self.config,

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -26,10 +26,6 @@ if TYPE_CHECKING:
 class _CallbackAction(argparse.Action):
     """Custom callback action."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.reset()
-
     def reset(self) -> None:
         """Reset state retained while parsing one source of arguments."""
 

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
 class _CallbackAction(argparse.Action):
     """Custom callback action."""
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.reset()
+
     def reset(self) -> None:
         """Reset state retained while parsing one source of arguments."""
 

--- a/pylint/config/callback_actions.py
+++ b/pylint/config/callback_actions.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
 class _CallbackAction(argparse.Action):
     """Custom callback action."""
 
+    def reset(self) -> None:
+        """Reset state retained while parsing one source of arguments."""
+
     @abc.abstractmethod
     def __call__(
         self,
@@ -411,6 +414,9 @@ class _EnableAction(_XableAction):
 class _OutputFormatAction(_AccessLinterObjectAction):
     """Callback action for setting the output format."""
 
+    def reset(self) -> None:
+        self._reporter_names: list[str] = []
+
     def __call__(
         self,
         parser: argparse.ArgumentParser,
@@ -422,7 +428,8 @@ class _OutputFormatAction(_AccessLinterObjectAction):
         assert isinstance(
             values[0], str
         ), "'output-format' should be a comma separated string of reporters"
-        self.linter._load_reporters(values[0])
+        self._reporter_names.append(values[0])
+        self.linter._load_reporters(",".join(self._reporter_names))
 
 
 class _AccessParserAction(_CallbackAction):

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1291,9 +1291,9 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             cwd=str(tmp_path),
         )
 
-        assert process.returncode == MSG_TYPES_STATUS["W"], (
-            f"{process.stdout!r}\n{process.stderr!r}"
-        )
+        assert (
+            process.returncode == MSG_TYPES_STATUS["W"]
+        ), f"{process.stdout!r}\n{process.stderr!r}"
         for output_file in output_files:
             assert "Unused variable 'variable'" in output_file.read_text(
                 encoding="utf-8"

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1263,6 +1263,39 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             expected_output.format(path="tests/regrtest_data/unused_variable.py"),
         )
 
+    def test_repeated_output_format_options_write_to_all_files(
+        self, tmp_path: Path
+    ) -> None:
+        path = join(HERE, "regrtest_data", "unused_variable.py")
+        output_files = [tmp_path / "first.txt", tmp_path / "second.txt"]
+        arguments = _add_rcfile_default_pylintrc(
+            [
+                path,
+                *(
+                    f"--output-format=text:{output_file}"
+                    for output_file in output_files
+                ),
+            ]
+        )
+
+        process = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pylint",
+                *arguments,
+                "--persistent=no",
+            ],
+            capture_output=True,
+            check=False,
+        )
+
+        assert process.returncode == MSG_TYPES_STATUS["W"]
+        for output_file in output_files:
+            assert "Unused variable 'variable'" in output_file.read_text(
+                encoding="utf-8"
+            )
+
     def test_output_file_can_be_combined_with_custom_reporter(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1288,9 +1288,12 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             ],
             capture_output=True,
             check=False,
+            cwd=str(tmp_path),
         )
 
-        assert process.returncode == MSG_TYPES_STATUS["W"]
+        assert process.returncode == MSG_TYPES_STATUS["W"], (
+            f"{process.stdout!r}\n{process.stderr!r}"
+        )
         for output_file in output_files:
             assert "Unused variable 'variable'" in output_file.read_text(
                 encoding="utf-8"


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Closes #8147

Each occurrence of `--output-format` currently replaces the reporter created by the previous occurrence. That leaves every earlier output file open but unused, so only the final file receives the report.

This change lets callback actions reset their per-source parsing state, then makes the output-format action accumulate repeated values within that source. Configuration-file parsing and command-line parsing still have separate scopes, so an explicit CLI format continues to override the configured format.

The regression test runs Pylint in a subprocess with two output-format destinations and verifies that both files contain the diagnostic.

## Validation

- `pytest tests/test_self.py -q` — 155 passed, 1 skipped, 1 xfailed
- Ruff checks on the changed Python files
- Black 26.5.1 formatting check
- `towncrier check --compare-with origin/main`

AI-assisted (LLM used for implementation and drafting); the change and tests were reviewed and run by me.