### PR TITLE
fix(docparams): ignore non-exception inferences

### DIFF
--- a/doc/whatsnew/fragments/11228.bugfix
+++ b/doc/whatsnew/fragments/11228.bugfix
@@ -1,0 +1,3 @@
+Avoid a crash in the ``docparams`` extension when a raised expression cannot be inferred as an exception class.
+
+Closes #11228

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -150,7 +150,8 @@ def possible_exc_types(node: nodes.NodeNG) -> set[nodes.ClassDef]:
         return {
             exc
             for exc in exceptions
-            if not utils.node_ignores_exception(node, exc.name)
+            if isinstance(exc, nodes.ClassDef)
+            and not utils.node_ignores_exception(node, exc.name)
         }
     except astroid.InferenceError:
         return set()

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -113,7 +113,10 @@ def possible_exc_types(node: nodes.NodeNG) -> set[nodes.ClassDef]:
     if isinstance(node.exc, nodes.Name):
         inferred = utils.safe_infer(node.exc)
         if inferred:
-            exceptions = [inferred]
+            if isinstance(inferred, astroid.Instance):
+                exceptions = [inferred.getattr("__class__")[0]]
+            else:
+                exceptions = [inferred]
     elif node.exc is None:
         handler = node.parent
         while handler and not isinstance(handler, nodes.ExceptHandler):

--- a/tests/extensions/test_check_docs_utils.py
+++ b/tests/extensions/test_check_docs_utils.py
@@ -117,6 +117,13 @@ def test_space_indentation(string: str, count: int) -> None:
     """,
             set(),
         ),
+        (
+            """
+    def my_func():
+        raise sum #@
+    """,
+            set(),
+        ),
     ],
 )
 def test_exception(code: str, expected: set[str]) -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| :white_check_mark: | :bug: Bug fix          |

## Description

The docparams extension assumes that every inferred raised expression is an exception class. For code such as “raise sum”, astroid can infer a FunctionDef; accessing expected.ancestors() then crashes Pylint instead of reporting normally.

The inference helper now keeps only ClassDef results, matching its declared contract and preventing non-exception inferences from reaching the docparams checker. A regression case covers the reported shape.

Closes #11228

## Testing

- python -m pytest tests/extensions/test_check_docs_utils.py -q — 16 passed
- python -m compileall -q pylint/extensions/_check_docs_utils.py tests/extensions/test_check_docs_utils.py
- git diff --check