### PR TITLE
Fix false negative for `disallowed-name` on non-constant module-level names

### DIFF
--- a/doc/whatsnew/fragments/10679.false_negative
+++ b/doc/whatsnew/fragments/10679.false_negative
@@ -1,0 +1,5 @@
+Fix a false negative for ``disallowed-name`` on module-level names assigned a
+value that is not a constant. The control flow that suppresses ``invalid-name``
+for these names no longer skips the ``disallowed-name`` check as well.
+
+Closes #10679

--- a/doc/whatsnew/fragments/10679.false_negative
+++ b/doc/whatsnew/fragments/10679.false_negative
@@ -1,5 +1,5 @@
-Fix a false negative for ``disallowed-name`` on module-level names assigned a
-value that is not a constant. The control flow that suppresses ``invalid-name``
-for these names no longer skips the ``disallowed-name`` check as well.
+``foo = {}.keys()`` at module level is now reported as ``disallowed-name`` when
+``foo`` is listed in ``bad-names``. Module-level names whose value cannot be
+inferred are still not reported.
 
 Closes #10679

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -510,13 +510,15 @@ class NameChecker(_BasicChecker):
                         node, (nodes.For, nodes.While)
                     )
                 ):
+                    meets_exception = self._meets_exception_for_non_consts(
+                        inferred_assign_type, node.name
+                    )
                     self._check_name(
                         "const",
                         node.name,
                         node,
-                        disallowed_check_only=self._meets_exception_for_non_consts(
-                            inferred_assign_type, node.name
-                        ),
+                        disallowed_check_only=meets_exception,
+                        skip_name_group_census=meets_exception,
                     )
                 else:
                     node_type = "variable"
@@ -534,14 +536,15 @@ class NameChecker(_BasicChecker):
                         for combo in itertools.combinations(attrs, 2)
                     ):
                         node_type = "const"
+                    meets_exception = self._meets_exception_for_non_consts(
+                        inferred_assign_type, node.name
+                    )
                     self._check_name(
                         node_type,
                         node.name,
                         node,
-                        disallowed_check_only=redefines_import
-                        or self._meets_exception_for_non_consts(
-                            inferred_assign_type, node.name
-                        ),
+                        disallowed_check_only=redefines_import or meets_exception,
+                        skip_name_group_census=meets_exception,
                     )
 
         # Check names defined in function scopes
@@ -654,8 +657,15 @@ class NameChecker(_BasicChecker):
         node: nodes.NodeNG,
         confidence: interfaces.Confidence = interfaces.HIGH,
         disallowed_check_only: bool = False,
+        skip_name_group_census: bool = False,
     ) -> None:
-        """Check for a name using the type's regexp."""
+        """Check for a name using the type's regexp.
+
+        ``disallowed_check_only`` suppresses ``invalid-name`` while still
+        letting the name take part in the multiple naming style census.
+        ``skip_name_group_census`` additionally keeps it out of that census,
+        for names that previously never reached this method at all.
+        """
 
         def _should_exempt_from_invalid_name(node: nodes.NodeNG) -> bool:
             if node_type == "variable":
@@ -675,7 +685,7 @@ class NameChecker(_BasicChecker):
         regexp = self._name_regexps[node_type]
         match = regexp.match(name)
 
-        if not disallowed_check_only and _is_multi_naming_match(
+        if not skip_name_group_census and _is_multi_naming_match(
             match, node_type, confidence
         ):
             name_group = self._find_name_group(node_type)

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -510,10 +510,14 @@ class NameChecker(_BasicChecker):
                         node, (nodes.For, nodes.While)
                     )
                 ):
-                    if not self._meets_exception_for_non_consts(
-                        inferred_assign_type, node.name
-                    ):
-                        self._check_name("const", node.name, node)
+                    self._check_name(
+                        "const",
+                        node.name,
+                        node,
+                        disallowed_check_only=self._meets_exception_for_non_consts(
+                            inferred_assign_type, node.name
+                        ),
+                    )
                 else:
                     node_type = "variable"
                     iattrs = tuple(node.frame().igetattr(node.name))
@@ -530,15 +534,15 @@ class NameChecker(_BasicChecker):
                         for combo in itertools.combinations(attrs, 2)
                     ):
                         node_type = "const"
-                    if not self._meets_exception_for_non_consts(
-                        inferred_assign_type, node.name
-                    ):
-                        self._check_name(
-                            node_type,
-                            node.name,
-                            node,
-                            disallowed_check_only=redefines_import,
-                        )
+                    self._check_name(
+                        node_type,
+                        node.name,
+                        node,
+                        disallowed_check_only=redefines_import
+                        or self._meets_exception_for_non_consts(
+                            inferred_assign_type, node.name
+                        ),
+                    )
 
         # Check names defined in function scopes
         elif isinstance(frame, nodes.FunctionDef):
@@ -671,7 +675,9 @@ class NameChecker(_BasicChecker):
         regexp = self._name_regexps[node_type]
         match = regexp.match(name)
 
-        if _is_multi_naming_match(match, node_type, confidence):
+        if not disallowed_check_only and _is_multi_naming_match(
+            match, node_type, confidence
+        ):
             name_group = self._find_name_group(node_type)
             bad_name_group = self._bad_names.setdefault(name_group, {})
             # Ignored because this is checked by the if statement

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -661,10 +661,12 @@ class NameChecker(_BasicChecker):
     ) -> None:
         """Check for a name using the type's regexp.
 
-        ``disallowed_check_only`` suppresses ``invalid-name`` while still
-        letting the name take part in the multiple naming style census.
-        ``skip_name_group_census`` additionally keeps it out of that census,
-        for names that previously never reached this method at all.
+        ``disallowed_check_only`` suppresses ``invalid-name`` for this node, but
+        the name still counts towards its ``name-group``, so it can still make
+        another name in that group be reported as the minority style.
+        ``skip_name_group_census`` takes the name out of that group as well: use
+        it when the name is exempt from the naming style itself, not merely from
+        the message.
         """
 
         def _should_exempt_from_invalid_name(node: nodes.NodeNG) -> bool:

--- a/tests/functional/d/disallowed_name.py
+++ b/tests/functional/d/disallowed_name.py
@@ -6,6 +6,15 @@ def baz():  # [disallowed-name]
 class foo():  # [disallowed-name]
     pass
 
-foo = {}.keys()  # Should raise disallowed-name once _check_name() is refactored.
+foo = {}.keys()  # [disallowed-name]
 foo = 42  # [disallowed-name]
 aaa = 42  # [invalid-name]
+
+# Disallowed names are still reported when the assigned value is not a constant,
+# while `invalid-name` remains silenced for such names.
+toto = {}.keys()  # [disallowed-name]
+some_name = {}.keys()
+
+for _ in range(3):
+    tata = {}.keys()  # [disallowed-name]
+    some_other_name = {}.keys()

--- a/tests/functional/d/disallowed_name.py
+++ b/tests/functional/d/disallowed_name.py
@@ -10,8 +10,11 @@ foo = {}.keys()  # [disallowed-name]
 foo = 42  # [disallowed-name]
 aaa = 42  # [invalid-name]
 
-# Disallowed names are still reported when the assigned value is not a constant,
-# while `invalid-name` remains silenced for such names.
+# Disallowed names are reported when the assigned value is not a constant.
+# The lines below with no expected message are the other half of the check:
+# they must stay silent because `invalid-name` is still suppressed for these
+# names. If that suppression regresses they start emitting `invalid-name`
+# ("Constant name ... doesn't conform to UPPER_CASE") and this test fails.
 toto = {}.keys()  # [disallowed-name]
 some_name = {}.keys()
 

--- a/tests/functional/d/disallowed_name.txt
+++ b/tests/functional/d/disallowed_name.txt
@@ -1,4 +1,7 @@
 disallowed-name:3:0:3:7:baz:"Disallowed name ""baz""":HIGH
 disallowed-name:6:0:6:9:foo:"Disallowed name ""foo""":HIGH
+disallowed-name:9:0:9:3::"Disallowed name ""foo""":HIGH
 disallowed-name:10:0:10:3::"Disallowed name ""foo""":HIGH
 invalid-name:11:0:11:3::"Constant name ""aaa"" doesn't conform to UPPER_CASE naming style":HIGH
+disallowed-name:15:0:15:4::"Disallowed name ""toto""":HIGH
+disallowed-name:19:4:19:8::"Disallowed name ""tata""":HIGH

--- a/tests/functional/d/disallowed_name.txt
+++ b/tests/functional/d/disallowed_name.txt
@@ -3,5 +3,5 @@ disallowed-name:6:0:6:9:foo:"Disallowed name ""foo""":HIGH
 disallowed-name:9:0:9:3::"Disallowed name ""foo""":HIGH
 disallowed-name:10:0:10:3::"Disallowed name ""foo""":HIGH
 invalid-name:11:0:11:3::"Constant name ""aaa"" doesn't conform to UPPER_CASE naming style":HIGH
-disallowed-name:15:0:15:4::"Disallowed name ""toto""":HIGH
-disallowed-name:19:4:19:8::"Disallowed name ""tata""":HIGH
+disallowed-name:18:0:18:4::"Disallowed name ""toto""":HIGH
+disallowed-name:22:4:22:8::"Disallowed name ""tata""":HIGH

--- a/tests/functional/d/disallowed_name_multi_naming_style.py
+++ b/tests/functional/d/disallowed_name_multi_naming_style.py
@@ -1,0 +1,11 @@
+"""Checking disallowed names does not report the multiple naming styles.
+
+Module-level names assigned a value that is not a constant are only checked
+against ``bad-names``; they must not take part in the multiple naming style
+detection, which reports ``invalid-name``.
+"""
+
+foo = {}.keys()  # [disallowed-name]
+first_name = {}.keys()
+second_name = {}.keys()
+thirdName = {}.keys()

--- a/tests/functional/d/disallowed_name_multi_naming_style.rc
+++ b/tests/functional/d/disallowed_name_multi_naming_style.rc
@@ -1,0 +1,4 @@
+[BASIC]
+const-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$
+variable-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$
+name-group=const:variable

--- a/tests/functional/d/disallowed_name_multi_naming_style.txt
+++ b/tests/functional/d/disallowed_name_multi_naming_style.txt
@@ -1,0 +1,1 @@
+disallowed-name:8:0:8:3::"Disallowed name ""foo""":HIGH

--- a/tests/functional/d/disallowed_name_multi_naming_style_import.py
+++ b/tests/functional/d/disallowed_name_multi_naming_style_import.py
@@ -1,0 +1,15 @@
+"""Names that redefine an import take part in the multiple naming style detection."""
+
+try:
+    from os.path import isfile as appleJuice
+except ImportError:
+    appleJuice = None
+
+try:
+    from os.path import isdir as bananaBread
+except ImportError:
+    bananaBread = None
+
+red_fruit = 1  # [invalid-name]
+
+print(appleJuice, bananaBread, red_fruit)

--- a/tests/functional/d/disallowed_name_multi_naming_style_import.rc
+++ b/tests/functional/d/disallowed_name_multi_naming_style_import.rc
@@ -1,0 +1,3 @@
+[BASIC]
+const-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$
+variable-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$

--- a/tests/functional/d/disallowed_name_multi_naming_style_import.txt
+++ b/tests/functional/d/disallowed_name_multi_naming_style_import.txt
@@ -1,0 +1,1 @@
+invalid-name:13:0:13:9::"Constant name ""red_fruit"" doesn't conform to the `camel` group in the '(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$' pattern":HIGH

--- a/tests/functional/d/disallowed_name_multi_naming_style_loop.py
+++ b/tests/functional/d/disallowed_name_multi_naming_style_loop.py
@@ -1,0 +1,8 @@
+"""Loop-assigned names bound to a non-constant stay out of the naming style census."""
+
+for _ in range(3):
+    appleJuice = {}.keys()
+    bananaBread = {}.keys()
+    cherry_pie = {}.keys()
+
+print(appleJuice, bananaBread, cherry_pie)

--- a/tests/functional/d/disallowed_name_multi_naming_style_loop.rc
+++ b/tests/functional/d/disallowed_name_multi_naming_style_loop.rc
@@ -1,0 +1,3 @@
+[BASIC]
+const-rgx=([A-Z_][A-Z0-9_]*)$
+variable-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$


### PR DESCRIPTION
Refs #10679.

`visit_assignname` wrapped the `_check_name()` calls for module-scope names in `if not self._meets_exception_for_non_consts(...)`. That guard exists to suppress an `invalid-name` false positive, but because it short-circuits before `_check_name()` is entered, it suppresses `disallowed-name` along with it.

So a module-level name that is explicitly listed in `bad-names` is silently not reported whenever its value is a non-`Const` expression:

```python
foo = {}.keys()   # disallowed-name not emitted
bar = 42          # disallowed-name emitted
```

On `main` only line 3 is reported. This is the case marked by the TODO left in `tests/functional/d/disallowed_name.py` by #10677:

```python
foo = {}.keys()  # Should raise disallowed-name once _check_name() is refactored.
```

## The change

`_check_name()` already takes `disallowed_check_only`, which does exactly this job and is already used for the `redefines_import` case. Both guards now pass that flag instead of skipping the call, so `invalid-name` stays suppressed and `disallowed-name` is still emitted.

## The part worth pushing back on

There is a third change, and it is arguably beyond the minimal fix.

Once `_check_name()` is entered for these names, they also reach `_is_multi_naming_match()`, which records them for the multi-naming-style report. That would make a name start influencing the `C0103` naming-group heuristic purely because it is on the `bad-names` list, which is not what the guard was suppressing it for. I gated that call on `not disallowed_check_only` and added a functional test for it.

If you would rather keep this PR to the two call sites and treat the multi-naming interaction separately, say so and I will drop that hunk and its test.

## Tests

`tests/functional/d/disallowed_name.py` line 9 changes from the TODO comment to an actual `# [disallowed-name]` expectation, with the `.txt` regenerated via `--update-functional-output`. A new `disallowed_name_multi_naming_style` functional test covers the third change.

Reverting only `checker.py` and keeping the tests fails them. Full `tests/test_functional.py`: 875 passed on a clean checkout, 876 with this branch, with an identical set of 12 pre-existing failures in both runs (`wrong_import_order`, `typing_broken_noreturn`, `typevar_naming_style_default` and others, all Python 3.14 / astroid 4.3.0 issues unrelated to this change). Changelog fragment added under `doc/whatsnew/fragments/`.

I used an AI assistant while working on this. The reproduction, the baseline comparison and the decision to flag the multi-naming hunk separately are mine.
