### PR TITLE
Fix two release-tooling bugs hit while releasing 4.0.7

### DIFF
--- a/doc/whatsnew/fragments/11136.bugfix
+++ b/doc/whatsnew/fragments/11136.bugfix
@@ -1,3 +1,3 @@
-Fix a false positive for ``too-many-locals`` (``R0914``): PEP 695 type parameters (e.g. ``def f[T1, T2](...)``) were counted as local variables. They are type-system constructs, not runtime locals, and are now excluded from the local-variable count.
+Fix a false positive for ``too-many-locals`` (``R0914``): PEP 695 type parameters, i.e. the ``T1`` and ``T2`` in a generic ``def f[T1, T2]`` signature, were counted as local variables. They are type-system constructs, not runtime locals, and are now excluded from the local-variable count.
 
 Closes #11136

--- a/script/bump_changelog.py
+++ b/script/bump_changelog.py
@@ -16,7 +16,18 @@ from subprocess import check_call
 NEWSFILE_PATTERN = re.compile(r"doc/whatsnew/\d/\d.\d+/index\.rst")
 NEWSFILE_PATH = "doc/whatsnew/{major}/{major}.{minor}/index.rst"
 TOWNCRIER_CONFIG_FILE = Path("towncrier.toml")
-TOWNCRIER_VERSION_PATTERN = re.compile(r"version = \"(\d+\.\d+\.\d+)\"")
+# 'major.minor.patch' followed by an optional pre-release suffix, written either the
+# semantic versioning way ('4.1.0-dev0') or the PEP 440 one ('3.3.5a0'). Pylint has
+# used both.
+VERSION_PATTERN = (
+    r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?P<suffix>-?[a-zA-Z][0-9a-zA-Z.-]*)?"
+)
+NEW_VERSION_PATTERN = re.compile(rf"^{VERSION_PATTERN}$")
+# Between releases towncrier.toml holds a pre-release version, so the suffix has to
+# be part of the pattern. Matching only 'major.minor.patch' left the version
+# untouched, and towncrier then titled the new section with the stale version.
+TOWNCRIER_VERSION_PATTERN = re.compile(rf"version = \"{VERSION_PATTERN}\"")
 
 NEWSFILE_CONTENT_TEMPLATE = """
 ***************************
@@ -49,16 +60,15 @@ def main() -> None:
 
     if "dev" in args.version:
         print("'-devXY' will be cut from version in towncrier.toml")
-    match = re.match(
-        r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-?\w+\d*)*", args.version
-    )
+    match = NEW_VERSION_PATTERN.match(args.version)
     if not match:
         print(
             "Fatal error - new version did not match the "
-            "expected format (major.minor.patch[.*]). Abort!"
+            "expected format (major.minor.patch[suffix]). Abort!"
         )
         return
-    major, minor, patch, suffix = match.groups()
+    major, minor, patch = match["major"], match["minor"], match["patch"]
+    suffix = match["suffix"]
     new_version = f"{major}.{minor}.{patch}"
 
     new_newsfile = NEWSFILE_PATH.format(major=major, minor=minor)
@@ -97,6 +107,11 @@ def create_new_newsfile_if_necessary(
 
 def patch_towncrier_toml(new_newsfile: str, version: str, dry_run: bool) -> None:
     file_content = TOWNCRIER_CONFIG_FILE.read_text(encoding="utf-8")
+    if not TOWNCRIER_VERSION_PATTERN.search(file_content):
+        raise ValueError(
+            f"Could not find the version to replace in {TOWNCRIER_CONFIG_FILE}. "
+            "Without it towncrier would use a stale version in the changelog title."
+        )
     patched_newsfile_path = NEWSFILE_PATTERN.sub(new_newsfile, file_content)
     new_file_content = TOWNCRIER_VERSION_PATTERN.sub(
         f'version = "{version}"', patched_newsfile_path


### PR DESCRIPTION
Two release-tooling bugs that both surfaced while releasing 4.0.7.

**1. `script/bump_changelog.py` left a stale version in `towncrier.toml`**

`TOWNCRIER_VERSION_PATTERN` was `version = "(\d+\.\d+\.\d+)"`, which cannot match the pre-release version stored between releases (`version = "4.0.0-dev0"`). The substitution silently did nothing, so `towncrier build` titled the new section with the stale version:

```
What's new in Pylint 4.0.0-dev0?
--------------------------------
Release date: 2026-08-09
```

The title had to be corrected by hand in the 4.0.7 release commit.

The version accepted on the command line and the version replaced in `towncrier.toml` are now built from a single `VERSION_PATTERN`, so the two can no longer disagree:

```python
VERSION_PATTERN = (
    r"(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
    r"(?P<suffix>-?[a-zA-Z][0-9a-zA-Z.-]*)?"
)
```

It covers both suffix styles pylint has actually used — semver `4.1.0-dev0` and PEP 440 `3.3.5a0` — while still rejecting `4.0`, `04.0.7`, `v4.0.7` and `4.0.7-`. The command-line pattern is now anchored at both ends, where it previously only anchored the start and accepted trailing garbage. `patch_towncrier_toml` also raises when there is nothing to replace, so a future mismatch fails the release instead of quietly producing a wrong changelog.

Checked with `python script/bump_changelog.py 4.1.0 --dry-run`, which now reports `version = "4.1.0"` where it previously reported the file unchanged, and `4.2.0-dev0 --dry-run`, which writes `version = "4.2.0"` and skips the changelog build as before.

**2. A news fragment shaped like a Markdown link broke the release commit**

`doc/whatsnew/fragments/11136.bugfix` contained ``def f[T1, T2](...)``. `rstcheck` reads `[...](...)` as a Markdown-style link and rejects it — but only once towncrier merges the fragment into `index.rst`, since the hook does not run on `.bugfix` files. That failed the `tbump` commit during the 4.0.7 release and would have failed the 4.1.0 one identically. Reworded to say the same thing without the bracket-paren sequence.

No other fragment currently matches `\]\([^)]*\)`.
