### PR TITLE
Add functional tests for the multiple naming style census

### DIFF
--- a/tests/functional/d/disallowed_name_multi_naming_style_import.py
+++ b/tests/functional/d/disallowed_name_multi_naming_style_import.py
@@ -1,0 +1,15 @@
+"""Names that redefine an import take part in the multiple naming style detection."""
+
+try:
+    from os.path import isfile as appleJuice
+except ImportError:
+    appleJuice = None
+
+try:
+    from os.path import isdir as bananaBread
+except ImportError:
+    bananaBread = None
+
+red_fruit = 1  # [invalid-name]
+
+print(appleJuice, bananaBread, red_fruit)

--- a/tests/functional/d/disallowed_name_multi_naming_style_import.rc
+++ b/tests/functional/d/disallowed_name_multi_naming_style_import.rc
@@ -1,0 +1,3 @@
+[BASIC]
+const-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$
+variable-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$

--- a/tests/functional/d/disallowed_name_multi_naming_style_import.txt
+++ b/tests/functional/d/disallowed_name_multi_naming_style_import.txt
@@ -1,0 +1,1 @@
+invalid-name:13:0:13:9::"Constant name ""red_fruit"" doesn't conform to the `camel` group in the '(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$' pattern":HIGH

--- a/tests/functional/d/disallowed_name_multi_naming_style_loop.py
+++ b/tests/functional/d/disallowed_name_multi_naming_style_loop.py
@@ -1,0 +1,8 @@
+"""Loop-assigned names bound to a non-constant stay out of the naming style census."""
+
+for _ in range(3):
+    appleJuice = {}.keys()
+    bananaBread = {}.keys()
+    cherry_pie = {}.keys()
+
+print(appleJuice, bananaBread, cherry_pie)

--- a/tests/functional/d/disallowed_name_multi_naming_style_loop.rc
+++ b/tests/functional/d/disallowed_name_multi_naming_style_loop.rc
@@ -1,0 +1,3 @@
+[BASIC]
+const-rgx=([A-Z_][A-Z0-9_]*)$
+variable-rgx=(?:(?P<snake>[a-z_]+)|(?P<camel>[a-z]+(?:[A-Z][a-z]*)+))$


### PR DESCRIPTION
Two functional tests pinning the current behavior of the name-group census used by the multiple naming style detection. No behavior change — they only record what pylint does today, so that a future refactor of the module-level name handling has to be explicit about changing it.

`disallowed_name_multi_naming_style_import.py`: a name that redefines an import inside an `except ImportError` handler still takes part in the census. `appleJuice` and `bananaBread` establish `camel` as the winning group, so `red_fruit` is reported against it.

`disallowed_name_multi_naming_style_loop.py`: a name bound to a non-constant inside a module-level loop stays out of the census. The three loop-assigned names never elect a group, so nothing is reported even though they mix styles.
