### PR TITLE
Fix crash on NaN comparison with an uninferable call

### DIFF
--- a/doc/whatsnew/fragments/11224.bugfix
+++ b/doc/whatsnew/fragments/11224.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the comparison checker when a NaN comparison operand is a call to a name that cannot be inferred, such as ``1 == b('nan')``.
+
+Closes #11224

--- a/pylint/checkers/base/comparison_checker.py
+++ b/pylint/checkers/base/comparison_checker.py
@@ -168,7 +168,7 @@ class ComparisonChecker(_BasicChecker):
                     ):
                         return node.inferred()[0].pytype() == "builtins.float"  # type: ignore[no-any-return]
                 return False
-            except AttributeError:
+            except (AttributeError, astroid.InferenceError):
                 return False
 
         def _is_decimal_nan(node: nodes.NodeNG) -> bool:

--- a/tests/functional/n/nan_comparison_check.py
+++ b/tests/functional/n/nan_comparison_check.py
@@ -50,3 +50,6 @@ o4 = x == -math.inf
 o5 = x == math.pi
 o6 = x == Decimal("1.5")
 o7 = x == Decimal(x)
+
+# A call to a name that cannot be inferred is checked without crashing
+p1 = x == undefined_callee("nan")  # [undefined-variable]

--- a/tests/functional/n/nan_comparison_check.txt
+++ b/tests/functional/n/nan_comparison_check.txt
@@ -21,3 +21,4 @@ nan-comparison:37:5:37:19::Comparison 'x is numpy.nan' should be 'math.isnan(x)'
 nan-comparison:38:5:38:24::Comparison 'x == Decimal('nan')' should be 'math.isnan(x)':UNDEFINED
 nan-comparison:39:5:39:32::Comparison 'x != decimal.Decimal('NaN')' should be 'not math.isnan(x)':UNDEFINED
 nan-comparison:43:5:43:16::Comparison 'x == MY_NAN' should be 'math.isnan(x)':UNDEFINED
+undefined-variable:55:10:55:26::Undefined variable 'undefined_callee':UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`_check_nan_comparison` resolves `float('nan')` by inferring the call:

```python
return node.inferred()[0].pytype() == "builtins.float"
```

`inferred()` raises `NameInferenceError` when the callee is not defined, and the
surrounding handler only covers `AttributeError`. The exception escapes the
checker, so a single unresolved call in a comparison aborts the whole file:

```console
$ echo '1==b("nan")' > crash.py
$ pylint crash.py
crash.py:1:0: F0002: crash.py: Fatal error while checking 'crash.py'. (astroid-error)
astroid.exceptions.NameInferenceError: 'b' not found in <Module.crash l.0 at 0x106de8b00>.
```

Adding `astroid.InferenceError` to the handler makes an uninferable operand
answer "not a NaN", which is what the check already returns for every other
call it cannot resolve. `NameInferenceError` is a subclass of `InferenceError`,
so the sibling failures reported by the same fuzzing run are covered too.

The regression case goes into the existing `nan_comparison_check` functional
test. Reverting the one-line change makes it fail with the fatal error above.

Closes #11224

## Testing

- `pytest "tests/test_functional.py::test_functional[nan_comparison_check]"` — 1 passed, and 1 failed with the fix reverted
- `pytest tests/` — 2126 passed, 284 skipped, 5 xfailed (Python 3.13, astroid 4.2.0b5)
- `black --check` and `ruff check` on the changed checker
