### PR TITLE
Add functional tests for messages affected by PEP 810 lazy imports

### DIFF
--- a/tests/functional/d/deprecated/deprecated_module_lazy_py315.py
+++ b/tests/functional/d/deprecated/deprecated_module_lazy_py315.py
@@ -1,0 +1,3 @@
+"""Tests for deprecated-module with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+lazy import json  # [deprecated-module]

--- a/tests/functional/d/deprecated/deprecated_module_lazy_py315.rc
+++ b/tests/functional/d/deprecated/deprecated_module_lazy_py315.rc
@@ -1,0 +1,5 @@
+[testoptions]
+min_pyver=3.15
+
+[IMPORTS]
+deprecated-modules=json

--- a/tests/functional/d/deprecated/deprecated_module_lazy_py315.txt
+++ b/tests/functional/d/deprecated/deprecated_module_lazy_py315.txt
@@ -1,0 +1,1 @@
+deprecated-module:3:0:3:16::Deprecated module 'json':UNDEFINED

--- a/tests/functional/i/import_aliasing_py315.py
+++ b/tests/functional/i/import_aliasing_py315.py
@@ -1,0 +1,6 @@
+"""Tests for import aliasing messages with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+lazy import collections.abc as abc  # [consider-using-from-import]
+lazy import json as json  # [useless-import-alias]
+lazy from os import path as path  # [useless-import-alias]
+lazy from os import getcwd as cwd

--- a/tests/functional/i/import_aliasing_py315.rc
+++ b/tests/functional/i/import_aliasing_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/i/import_aliasing_py315.txt
+++ b/tests/functional/i/import_aliasing_py315.txt
@@ -1,0 +1,3 @@
+consider-using-from-import:3:0:3:34::Use 'from collections import abc' instead:UNDEFINED
+useless-import-alias:4:0:4:24::Import alias does not rename original package:HIGH
+useless-import-alias:5:0:5:32::Import alias does not rename original package:HIGH

--- a/tests/functional/i/import_error_py315.py
+++ b/tests/functional/i/import_error_py315.py
@@ -1,0 +1,4 @@
+"""Tests for import-error with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+lazy import totally_missing_module_xyz  # [import-error]
+lazy from another_missing_module_xyz import something  # [import-error]

--- a/tests/functional/i/import_error_py315.rc
+++ b/tests/functional/i/import_error_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/i/import_error_py315.txt
+++ b/tests/functional/i/import_error_py315.txt
@@ -1,0 +1,2 @@
+import-error:3:0:3:38::Unable to import 'totally_missing_module_xyz':UNDEFINED
+import-error:4:0:4:53::Unable to import 'another_missing_module_xyz':UNDEFINED

--- a/tests/functional/i/import_itself_py315.py
+++ b/tests/functional/i/import_itself_py315.py
@@ -1,0 +1,4 @@
+"""Test module lazily importing itself (PEP 810)."""
+lazy from . import import_itself_py315  # [import-self]
+
+print(import_itself_py315)

--- a/tests/functional/i/import_itself_py315.rc
+++ b/tests/functional/i/import_itself_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/i/import_itself_py315.txt
+++ b/tests/functional/i/import_itself_py315.txt
@@ -1,0 +1,1 @@
+import-self:2:0:2:38::Module import itself:UNDEFINED

--- a/tests/functional/m/multiple_imports_py315.py
+++ b/tests/functional/m/multiple_imports_py315.py
@@ -1,0 +1,4 @@
+"""Tests for multiple-imports with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+lazy import os, sys  # [multiple-imports]
+lazy import collections

--- a/tests/functional/m/multiple_imports_py315.rc
+++ b/tests/functional/m/multiple_imports_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/m/multiple_imports_py315.txt
+++ b/tests/functional/m/multiple_imports_py315.txt
@@ -1,0 +1,1 @@
+multiple-imports:3:0:3:19::Multiple imports on one line (os, sys):UNDEFINED

--- a/tests/functional/n/no/no_name_in_module_py315.py
+++ b/tests/functional/n/no/no_name_in_module_py315.py
@@ -1,0 +1,3 @@
+"""Tests for no-name-in-module with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+lazy from collections import does_not_exist  # [no-name-in-module]

--- a/tests/functional/n/no/no_name_in_module_py315.rc
+++ b/tests/functional/n/no/no_name_in_module_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/n/no/no_name_in_module_py315.txt
+++ b/tests/functional/n/no/no_name_in_module_py315.txt
@@ -1,0 +1,1 @@
+no-name-in-module:3:0:3:43::No name 'does_not_exist' in module 'collections':UNDEFINED

--- a/tests/functional/p/preferred_module_py315.py
+++ b/tests/functional/p/preferred_module_py315.py
@@ -1,0 +1,3 @@
+"""Tests for preferred-module with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+lazy import json  # [preferred-module]

--- a/tests/functional/p/preferred_module_py315.rc
+++ b/tests/functional/p/preferred_module_py315.rc
@@ -1,0 +1,5 @@
+[testoptions]
+min_pyver=3.15
+
+[IMPORTS]
+preferred-modules=json:orjson

--- a/tests/functional/p/preferred_module_py315.txt
+++ b/tests/functional/p/preferred_module_py315.txt
@@ -1,0 +1,1 @@
+preferred-module:3:0:3:16::Prefer importing 'orjson' instead of 'json':UNDEFINED

--- a/tests/functional/r/reimported_py315.py
+++ b/tests/functional/r/reimported_py315.py
@@ -1,0 +1,6 @@
+"""Tests for reimported with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+import os
+lazy import os  # [reimported]
+lazy import sys
+lazy import sys  # [reimported]

--- a/tests/functional/r/reimported_py315.py
+++ b/tests/functional/r/reimported_py315.py
@@ -4,3 +4,5 @@ import os
 lazy import os  # [reimported]
 lazy import sys
 lazy import sys  # [reimported]
+lazy import collections
+import collections  # [reimported]

--- a/tests/functional/r/reimported_py315.rc
+++ b/tests/functional/r/reimported_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/r/reimported_py315.txt
+++ b/tests/functional/r/reimported_py315.txt
@@ -1,2 +1,3 @@
 reimported:4:0:4:14::Reimport 'os' (imported line 3):HIGH
 reimported:6:0:6:15::Reimport 'sys' (imported line 5):HIGH
+reimported:8:0:8:18::Reimport 'collections' (imported line 7):HIGH

--- a/tests/functional/r/reimported_py315.txt
+++ b/tests/functional/r/reimported_py315.txt
@@ -1,0 +1,2 @@
+reimported:4:0:4:14::Reimport 'os' (imported line 3):HIGH
+reimported:6:0:6:15::Reimport 'sys' (imported line 5):HIGH

--- a/tests/functional/s/shadowed_import_py315.py
+++ b/tests/functional/s/shadowed_import_py315.py
@@ -1,0 +1,4 @@
+"""Tests for shadowed-import with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+import json
+lazy from os import path as json  # [shadowed-import]

--- a/tests/functional/s/shadowed_import_py315.rc
+++ b/tests/functional/s/shadowed_import_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/s/shadowed_import_py315.txt
+++ b/tests/functional/s/shadowed_import_py315.txt
@@ -1,0 +1,1 @@
+shadowed-import:4:0:4:32::Shadowed 'json' (imported line 3):HIGH

--- a/tests/functional/u/ungrouped_imports_py315.py
+++ b/tests/functional/u/ungrouped_imports_py315.py
@@ -1,0 +1,5 @@
+"""Tests for ungrouped-imports with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+lazy from os import path
+lazy import sys
+lazy from os import walk  # [ungrouped-imports]

--- a/tests/functional/u/ungrouped_imports_py315.rc
+++ b/tests/functional/u/ungrouped_imports_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/u/ungrouped_imports_py315.txt
+++ b/tests/functional/u/ungrouped_imports_py315.txt
@@ -1,0 +1,1 @@
+ungrouped-imports:5:0:5:24::Imports from package os are not grouped:UNDEFINED

--- a/tests/functional/u/unused/unused_import_lazy_py315.py
+++ b/tests/functional/u/unused/unused_import_lazy_py315.py
@@ -1,0 +1,10 @@
+"""PEP 810 lazy imports (Python 3.15) interact normally with unused-import."""
+lazy import os
+lazy import sys  # [unused-import]
+lazy from pathlib import Path
+lazy from collections import OrderedDict  # [unused-import]
+
+
+def use():
+    """Use the lazily-imported names so they are not flagged as unused."""
+    return os.getcwd(), Path

--- a/tests/functional/u/unused/unused_import_lazy_py315.rc
+++ b/tests/functional/u/unused/unused_import_lazy_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/u/unused/unused_import_lazy_py315.txt
+++ b/tests/functional/u/unused/unused_import_lazy_py315.txt
@@ -1,0 +1,2 @@
+unused-import:3:0:3:15::Unused import sys:UNDEFINED
+unused-import:5:0:5:40::Unused OrderedDict imported from collections:UNDEFINED

--- a/tests/functional/w/wrong_import_order_py315.py
+++ b/tests/functional/w/wrong_import_order_py315.py
@@ -1,0 +1,4 @@
+"""Tests for wrong-import-order with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+import astroid
+lazy import os  # [wrong-import-order]

--- a/tests/functional/w/wrong_import_order_py315.rc
+++ b/tests/functional/w/wrong_import_order_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/w/wrong_import_order_py315.txt
+++ b/tests/functional/w/wrong_import_order_py315.txt
@@ -1,0 +1,1 @@
+wrong-import-order:4:0:4:14::"standard import ""os"" should be placed before third party import ""astroid""":UNDEFINED

--- a/tests/functional/w/wrong_import_position_py315.py
+++ b/tests/functional/w/wrong_import_position_py315.py
@@ -1,0 +1,5 @@
+"""Tests for wrong-import-position with PEP 810 lazy imports."""
+# pylint: disable=unused-import
+CONST = 1
+
+lazy import json  # [wrong-import-position]

--- a/tests/functional/w/wrong_import_position_py315.rc
+++ b/tests/functional/w/wrong_import_position_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/w/wrong_import_position_py315.txt
+++ b/tests/functional/w/wrong_import_position_py315.txt
@@ -1,0 +1,1 @@
+wrong-import-position:5:0:5:16::"Import ""lazy import json"" should be placed at the top of the module":UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

(Split from #10982)

Cover the lazy import syntax in the messages emitted by the imports and variables checkers: multiple-imports, wrong-import-order, ungrouped-imports, wrong-import-position, useless-import-alias, consider-using-from-import, import-error, no-name-in-module, reimported, shadowed-import, preferred-module, deprecated-module, import-self and unused-import.
