### PR TITLE
Fix crash in no-member for non-string inferred class names

### DIFF
--- a/doc/whatsnew/fragments/11229.bugfix
+++ b/doc/whatsnew/fragments/11229.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in ``no-member`` when astroid infers a non-string class name (e.g. ``Enum(1, "")``).
+
+Closes #11229

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -476,7 +476,12 @@ def _emit_no_member(
         return False
     if is_super(owner) or getattr(owner, "type", None) == "metaclass":
         return False
-    if owner_name and ignored_mixins and mixin_class_rgx.match(owner_name):
+    if (
+        isinstance(owner_name, str)
+        and owner_name
+        and ignored_mixins
+        and mixin_class_rgx.match(owner_name)
+    ):
         return False
     if isinstance(owner, nodes.FunctionDef) and (
         owner.decorators or owner.is_abstract()
@@ -513,7 +518,11 @@ def _emit_no_member(
             return False
         except astroid.NotFoundError:
             pass
-    if owner_name and node.attrname.startswith("_" + owner_name):
+    if (
+        isinstance(owner_name, str)
+        and owner_name
+        and node.attrname.startswith("_" + owner_name)
+    ):
         # Test if an attribute has been mangled ('private' attribute)
         unmangled_name = node.attrname.split("_" + owner_name)[-1]
         try:

--- a/tests/functional/r/regression_03/regression_11229_enum_int_name.py
+++ b/tests/functional/r/regression_03/regression_11229_enum_int_name.py
@@ -1,0 +1,11 @@
+"""Regression test from https://github.com/pylint-dev/pylint/issues/11229
+
+The following code should not crash pylint, even though astroid infers
+an integer as the Enum class name.
+"""
+# pylint: disable=too-few-public-methods
+
+from enum import Enum
+
+enum_instance = Enum(1, "")  # [invalid-name]
+enum_instance.b  # [no-member, pointless-statement]  # noqa: B018

--- a/tests/functional/r/regression_03/regression_11229_enum_int_name.txt
+++ b/tests/functional/r/regression_03/regression_11229_enum_int_name.txt
@@ -1,0 +1,3 @@
+invalid-name:10:0:10:13::Class name "enum_instance" doesn't conform to PascalCase naming style:HIGH
+no-member:11:0:11:15::Instance of 1 has no 'b' member:INFERENCE
+pointless-statement:11:0:11:15::Statement seems to have no effect:UNDEFINED


### PR DESCRIPTION
### What kind of change does this PR introduce?
- Bug fix

### What is the current behaviour?
Pylint crashes with `TypeError: expected string or bytes-like object, got 'int'` on code where astroid infers a non-string class name, e.g.:

```python
from enum import Enum

a = Enum(1, "")
a.b
```

The `no-member` checker passes the inferred (integer) owner name to `mixin_class_rgx.match()` and to name-mangling string concatenation in `_emit_no_member`, raising `TypeError` and aborting the run with a fatal `astroid-error`.

### What is the new behaviour?
The mixin-regex and mangled-name paths only run when the owner name is a string, so the check completes and emits the normal `no-member` diagnostic.

### Does this PR introduce a breaking change?
No.

### Other information
- Fixes #11229
- Regression test: `tests/functional/r/regression_03/regression_11229_enum_int_name.py`
- News fragment: `doc/whatsnew/fragments/11229.bugfix`
- Tested: `pytest tests/test_functional.py -k "regression_11229"`, `pytest tests/checkers/ -q` (406 passed), `ruff check`
