### PR TITLE
Pin py-version in the unspecified-encoding doc example

### DIFF
--- a/doc/data/messages/u/unspecified-encoding/pylintrc
+++ b/doc/data/messages/u/unspecified-encoding/pylintrc
@@ -1,0 +1,4 @@
+[main]
+# PEP 686 makes UTF-8 the default encoding in Python 3.15, so the message
+# only applies to code that still supports an earlier version.
+py-version=3.14


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

(Split from #10982)

`unspecified-encoding` carries `maxversion=(3, 15)` because PEP 686 makes UTF-8
the default, and `may_be_emitted` compares that against the configured
`py-version`. The documentation example set none, so it inherited the running
interpreter and raised nothing at all on a 3.15 interpreter, failing
`doc/test_messages_documentation.py` there. CI never caught it because the
documentation examples only run on `DEFAULT_PYTHON`.

Pinning `py-version=3.14` in the example's own `pylintrc` keeps the example
running on every interpreter, and on 3.15 it now asserts what `maxversion` is
for: the message is selected by the py-version the code targets, not by the
interpreter pylint happens to run on. Gating the example on the interpreter
instead, the way functional tests use `min_pyver` and `max_pyver`, would have
dropped that assertion: `bad.py` parses fine on 3.15, it simply does not apply
there.

`boolean-datetime` and `deprecated-module` pin `py-version` the same way, and so
does the `unspecified_encoding_py38` functional test. The `pylintrc` is rendered
on the message page, so the comment explaining PEP 686 reaches the reader too.
