### PR TITLE
Add functional tests for messages affected by PEP 798 comprehension unpacking

### DIFF
--- a/tests/functional/c/consider/consider_using_generator_py315.py
+++ b/tests/functional/c/consider/consider_using_generator_py315.py
@@ -1,0 +1,4 @@
+"""Tests for consider-using-generator with PEP 798 starred comprehension elements."""
+NESTED = [[1, 2], [3, 4]]
+TOTAL = sum([*x for x in NESTED])  # [consider-using-generator]
+AS_TUPLE = tuple([*x for x in NESTED])  # [consider-using-generator]

--- a/tests/functional/c/consider/consider_using_generator_py315.rc
+++ b/tests/functional/c/consider/consider_using_generator_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/c/consider/consider_using_generator_py315.txt
+++ b/tests/functional/c/consider/consider_using_generator_py315.txt
@@ -1,0 +1,2 @@
+consider-using-generator:3:8:3:33::Consider using a generator instead 'sum(*x for x in NESTED)':UNDEFINED
+consider-using-generator:4:11:4:38::Consider using a generator instead 'tuple(*x for x in NESTED)':UNDEFINED

--- a/tests/functional/c/consider/consider_using_set_comprehension_py315.py
+++ b/tests/functional/c/consider/consider_using_set_comprehension_py315.py
@@ -1,0 +1,3 @@
+"""Tests for consider-using-set-comprehension with PEP 798 starred elements."""
+NESTED = [[1, 2], [3, 4]]
+FLAT = set([*x for x in NESTED])  # [consider-using-set-comprehension]

--- a/tests/functional/c/consider/consider_using_set_comprehension_py315.rc
+++ b/tests/functional/c/consider/consider_using_set_comprehension_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/c/consider/consider_using_set_comprehension_py315.txt
+++ b/tests/functional/c/consider/consider_using_set_comprehension_py315.txt
@@ -1,0 +1,1 @@
+consider-using-set-comprehension:3:7:3:32::Consider using a set comprehension:UNDEFINED

--- a/tests/functional/n/nested_min_max_py315.py
+++ b/tests/functional/n/nested_min_max_py315.py
@@ -1,0 +1,3 @@
+"""Tests for nested-min-max with PEP 798 starred comprehension elements."""
+NESTED = [[1, 2], [3, 4]]
+SMALLEST = min(1, min([*x for x in NESTED]))  # [nested-min-max, consider-using-generator]

--- a/tests/functional/n/nested_min_max_py315.rc
+++ b/tests/functional/n/nested_min_max_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/n/nested_min_max_py315.txt
+++ b/tests/functional/n/nested_min_max_py315.txt
@@ -1,0 +1,2 @@
+consider-using-generator:3:18:3:43::Consider using a generator instead 'min(*x for x in NESTED)':UNDEFINED
+nested-min-max:3:11:3:44::Do not use nested call of 'min'; it's possible to do 'min(1, *[*x for x in NESTED])' instead:INFERENCE

--- a/tests/functional/u/undefined/undefined_variable_py315.py
+++ b/tests/functional/u/undefined/undefined_variable_py315.py
@@ -1,0 +1,4 @@
+"""Tests for undefined-variable in PEP 798 starred comprehension elements."""
+NESTED = [[1, 2], [3, 4]]
+FLAT = [*x for x in NESTED]
+BAD = [*missing for x in NESTED]  # [undefined-variable]

--- a/tests/functional/u/undefined/undefined_variable_py315.rc
+++ b/tests/functional/u/undefined/undefined_variable_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/u/undefined/undefined_variable_py315.txt
+++ b/tests/functional/u/undefined/undefined_variable_py315.txt
@@ -1,0 +1,1 @@
+undefined-variable:4:8:4:15::Undefined variable 'missing':UNDEFINED

--- a/tests/functional/u/unnecessary/unnecessary_comprehension_py315.py
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension_py315.py
@@ -1,0 +1,6 @@
+"""PEP 798 comprehension unpacking is never an unnecessary-comprehension."""
+NESTED = [[1, 2], [3, 4]]
+DICTS = [{"a": 1}, {"b": 2}]
+FLAT = [*x for x in NESTED]
+MERGED = {**d for d in DICTS}
+COPIED = [x for x in NESTED]  # [unnecessary-comprehension]

--- a/tests/functional/u/unnecessary/unnecessary_comprehension_py315.rc
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/u/unnecessary/unnecessary_comprehension_py315.txt
+++ b/tests/functional/u/unnecessary/unnecessary_comprehension_py315.txt
@@ -1,0 +1,1 @@
+unnecessary-comprehension:6:9:6:28::Unnecessary use of a comprehension, use list(NESTED) instead.:UNDEFINED

--- a/tests/functional/u/use/use_a_generator_py315.py
+++ b/tests/functional/u/use/use_a_generator_py315.py
@@ -1,0 +1,4 @@
+"""Tests for use-a-generator with PEP 798 starred comprehension elements."""
+NESTED = [[True], [False]]
+ANY = any([*x for x in NESTED])  # [use-a-generator]
+ALL = all([*x for x in NESTED])  # [use-a-generator]

--- a/tests/functional/u/use/use_a_generator_py315.rc
+++ b/tests/functional/u/use/use_a_generator_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/u/use/use_a_generator_py315.txt
+++ b/tests/functional/u/use/use_a_generator_py315.txt
@@ -1,0 +1,2 @@
+use-a-generator:3:6:3:31::Use a generator instead 'any(*x for x in NESTED)':UNDEFINED
+use-a-generator:4:6:4:31::Use a generator instead 'all(*x for x in NESTED)':UNDEFINED

--- a/tests/functional/u/use/use_implicit_booleaness_not_len_py315.py
+++ b/tests/functional/u/use/use_implicit_booleaness_not_len_py315.py
@@ -1,0 +1,4 @@
+"""Tests for use-implicit-booleaness-not-len with PEP 798 starred elements."""
+NESTED = [[1, 2], [3, 4]]
+if len([*x for x in NESTED]):  # [use-implicit-booleaness-not-len]
+    pass

--- a/tests/functional/u/use/use_implicit_booleaness_not_len_py315.rc
+++ b/tests/functional/u/use/use_implicit_booleaness_not_len_py315.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.15

--- a/tests/functional/u/use/use_implicit_booleaness_not_len_py315.txt
+++ b/tests/functional/u/use/use_implicit_booleaness_not_len_py315.txt
@@ -1,0 +1,1 @@
+use-implicit-booleaness-not-len:3:3:3:28::Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                    |
| --- | ----------------------- |
| ✓   | :white_check_mark: Test |

## Description

(Split from #10983)

Depends on #11257, and stacked on top of it: without the checker fix the fixtures
raise `star-needs-assignment-target`. Only the last commit, "Add functional tests
for messages affected by PEP 798", belongs here; it will be rebased down to a
single commit once #11257 lands.

Cover comprehension unpacking in the messages whose checkers inspect
comprehension nodes: `use-a-generator`, `consider-using-generator`,
`consider-using-set-comprehension`, `unnecessary-comprehension`,
`nested-min-max`, `undefined-variable` and `use-implicit-booleaness-not-len`.

The fixtures are gated with `min_pyver=3.15`, so they run on the 3.15 interpreter
in the matrix.

Refs #10982 
