### PR TITLE
Link to a single option instead of the whole checker section

### DIFF
--- a/doc/data/messages/r/redefined-builtin/details.rst
+++ b/doc/data/messages/r/redefined-builtin/details.rst
@@ -1,4 +1,4 @@
-The :ref:`allowed-redefined-builtins <variables-options>` option lets you specify names that are permitted to shadow built-ins.
+The :ref:`--allowed-redefined-builtins <allowed-redefined-builtins-option>` option lets you specify names that are permitted to shadow built-ins.
 
 However, this option is not effective for redefinitions at the module level or for global variables. For example:
 

--- a/doc/data/messages/u/unused-import/related.rst
+++ b/doc/data/messages/u/unused-import/related.rst
@@ -1,1 +1,1 @@
-- :ref:`--init-import <variables-options>`
+- :ref:`--init-import <init-import-option>`

--- a/doc/data/messages/u/useless-import-alias/related.rst
+++ b/doc/data/messages/u/useless-import-alias/related.rst
@@ -1,4 +1,4 @@
-- :ref:`--allow-reexport-from-package<imports-options>`
+- :ref:`--allow-reexport-from-package <allow-reexport-from-package-option>`
 - `PEP 8, Import Guideline <https://peps.python.org/pep-0008/#imports>`_
 - :ref:`Pylint block-disable <block_disables>`
 - `mypy --no-implicit-reexport <https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport>`_

--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -107,6 +107,11 @@ def _create_checker_section(
     checker_table = tomlkit.table()
 
     for option in sorted(options, key=lambda x: x.name):
+        # Anchor so the documentation can link to a single option with
+        # ``:ref:`--option-name <option-name-option>``` instead of only to the
+        # checker's section. The '-option' suffix keeps those labels from ever
+        # clashing with the message labels, which are bare message symbols.
+        checker_string += f".. _{option.name}-option:\n\n"
         checker_string += get_rst_title(f"--{option.name}", '"')
         checker_string += f"*{option.optdict.get('help')}*\n\n"
         if option.optdict.get("default") == "":

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -13,12 +13,16 @@ Standard Checkers
 
 ``Main`` **Checker**
 --------------------
+.. _analyse-fallback-blocks-option:
+
 --analyse-fallback-blocks
 """""""""""""""""""""""""
 *Analyse import fallback blocks. This can be used to support both Python 2 and 3 compatible code, which means that the block might have code that exists only in one or another interpreter, leading to false positives when analysed.*
 
 **Default:**  ``False``
 
+
+.. _clear-cache-post-run-option:
 
 --clear-cache-post-run
 """"""""""""""""""""""
@@ -27,12 +31,16 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _confidence-option:
+
 --confidence
 """"""""""""
 *Only show warnings with the listed confidence levels. Leave empty to show all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE, UNDEFINED.*
 
 **Default:**  ``['HIGH', 'CONTROL_FLOW', 'INFERENCE', 'INFERENCE_FAILURE', 'UNDEFINED']``
 
+
+.. _disable-option:
 
 --disable
 """""""""
@@ -41,12 +49,16 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _enable-option:
+
 --enable
 """"""""
 *Enable the message, report, category or checker with the given id(s). You can either give multiple identifier separated by comma (,) or put this option multiple time (only on the command line, not in the configuration file where it should appear only once). See also the "--disable" option for examples.*
 
 **Default:**  ``()``
 
+
+.. _evaluation-option:
 
 --evaluation
 """"""""""""
@@ -55,12 +67,16 @@ Standard Checkers
 **Default:**  ``max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))``
 
 
+.. _exit-zero-option:
+
 --exit-zero
 """""""""""
 *Always return a 0 (non-error) status code, even if lint errors are found. This is primarily useful in continuous integration scripts.*
 
 **Default:**  ``False``
 
+
+.. _extension-pkg-allow-list-option:
 
 --extension-pkg-allow-list
 """"""""""""""""""""""""""
@@ -69,12 +85,16 @@ Standard Checkers
 **Default:**  ``[]``
 
 
+.. _extension-pkg-whitelist-option:
+
 --extension-pkg-whitelist
 """""""""""""""""""""""""
 *A comma-separated list of package or module names from where C extensions may be loaded. Extensions are loading into the active Python interpreter and may run arbitrary code. (This is an alternative name to extension-pkg-allow-list for backward compatibility.)*
 
 **Default:**  ``[]``
 
+
+.. _fail-on-option:
 
 --fail-on
 """""""""
@@ -83,12 +103,16 @@ Standard Checkers
 **Default:** ``""``
 
 
+.. _fail-under-option:
+
 --fail-under
 """"""""""""
 *Specify a score threshold under which the program will exit with error.*
 
 **Default:**  ``10``
 
+
+.. _files-option:
 
 --files
 """""""
@@ -97,12 +121,16 @@ Standard Checkers
 **Default:**  ``[]``
 
 
+.. _from-stdin-option:
+
 --from-stdin
 """"""""""""
 *Interpret the stdin as a python script, whose filename needs to be passed as the module_or_package argument.*
 
 **Default:**  ``False``
 
+
+.. _ignore-option:
 
 --ignore
 """"""""
@@ -111,12 +139,16 @@ Standard Checkers
 **Default:**  ``('CVS',)``
 
 
+.. _ignore-paths-option:
+
 --ignore-paths
 """"""""""""""
 *Add files or directories matching the regular expressions patterns to the ignore-list. The regex matches against paths and can be in Posix or Windows format. Because '\\' represents the directory delimiter on Windows systems, it can't be used as an escape character.*
 
 **Default:**  ``[]``
 
+
+.. _ignore-patterns-option:
 
 --ignore-patterns
 """""""""""""""""
@@ -125,12 +157,16 @@ Standard Checkers
 **Default:**  ``(re.compile('^\\.#'),)``
 
 
+.. _ignored-modules-option:
+
 --ignored-modules
 """""""""""""""""
 *List of module names for which member attributes should not be checked and will not be imported (useful for modules/projects where namespaces are manipulated during runtime and thus existing member attributes cannot be deduced by static analysis). It supports qualified module names, as well as Unix pattern matching.*
 
 **Default:**  ``()``
 
+
+.. _jobs-option:
 
 --jobs
 """"""
@@ -139,12 +175,16 @@ Standard Checkers
 **Default:**  ``1``
 
 
+.. _limit-inference-results-option:
+
 --limit-inference-results
 """""""""""""""""""""""""
 *Control the amount of potential inferred values when inferring a single object. This can help the performance when dealing with large functions or complex, nested conditions.*
 
 **Default:**  ``100``
 
+
+.. _load-plugins-option:
 
 --load-plugins
 """"""""""""""
@@ -153,12 +193,16 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _msg-template-option:
+
 --msg-template
 """"""""""""""
 *Template used to display messages. This is a python new-style format string used to format the message information. See doc for all details.*
 
 **Default:** ``""``
 
+
+.. _output-format-option:
 
 --output-format
 """""""""""""""
@@ -167,12 +211,16 @@ Standard Checkers
 **Default:**  ``text``
 
 
+.. _persistent-option:
+
 --persistent
 """"""""""""
 *Pickle collected data for later comparisons.*
 
 **Default:**  ``True``
 
+
+.. _prefer-stubs-option:
 
 --prefer-stubs
 """"""""""""""
@@ -181,12 +229,16 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _py-version-option:
+
 --py-version
 """"""""""""
 *Minimum Python version to use for version dependent checks. Will default to the version used to run pylint.*
 
 **Default:**  ``sys.version_info[:2]``
 
+
+.. _recursive-option:
 
 --recursive
 """""""""""
@@ -195,12 +247,16 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _reports-option:
+
 --reports
 """""""""
 *Tells whether to display a full report or only the messages.*
 
 **Default:**  ``False``
 
+
+.. _score-option:
 
 --score
 """""""
@@ -209,12 +265,16 @@ Standard Checkers
 **Default:**  ``True``
 
 
+.. _source-roots-option:
+
 --source-roots
 """"""""""""""
 *Add paths to the list of the source roots. Supports globbing patterns. The source root is an absolute path or a path relative to the current working directory used to determine a package namespace for modules located under the source root.*
 
 **Default:**  ``()``
 
+
+.. _unsafe-load-any-extension-option:
 
 --unsafe-load-any-extension
 """""""""""""""""""""""""""
@@ -305,12 +365,16 @@ Standard Checkers
 
 ``Basic`` **Checker**
 ---------------------
+.. _argument-naming-style-option:
+
 --argument-naming-style
 """""""""""""""""""""""
 *Naming style matching correct argument names.*
 
 **Default:**  ``snake_case``
 
+
+.. _argument-rgx-option:
 
 --argument-rgx
 """"""""""""""
@@ -319,12 +383,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _attr-naming-style-option:
+
 --attr-naming-style
 """""""""""""""""""
 *Naming style matching correct attribute names.*
 
 **Default:**  ``snake_case``
 
+
+.. _attr-rgx-option:
 
 --attr-rgx
 """"""""""
@@ -333,12 +401,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _bad-names-option:
+
 --bad-names
 """""""""""
 *Bad variable names which should always be refused, separated by a comma.*
 
 **Default:**  ``('foo', 'bar', 'baz', 'toto', 'tutu', 'tata')``
 
+
+.. _bad-names-rgxs-option:
 
 --bad-names-rgxs
 """"""""""""""""
@@ -347,12 +419,16 @@ Standard Checkers
 **Default:** ``""``
 
 
+.. _class-attribute-naming-style-option:
+
 --class-attribute-naming-style
 """"""""""""""""""""""""""""""
 *Naming style matching correct class attribute names.*
 
 **Default:**  ``any``
 
+
+.. _class-attribute-rgx-option:
 
 --class-attribute-rgx
 """""""""""""""""""""
@@ -361,12 +437,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _class-const-naming-style-option:
+
 --class-const-naming-style
 """"""""""""""""""""""""""
 *Naming style matching correct class constant names.*
 
 **Default:**  ``UPPER_CASE``
 
+
+.. _class-const-rgx-option:
 
 --class-const-rgx
 """""""""""""""""
@@ -375,12 +455,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _class-naming-style-option:
+
 --class-naming-style
 """"""""""""""""""""
 *Naming style matching correct class names.*
 
 **Default:**  ``PascalCase``
 
+
+.. _class-rgx-option:
 
 --class-rgx
 """""""""""
@@ -389,12 +473,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _const-naming-style-option:
+
 --const-naming-style
 """"""""""""""""""""
 *Naming style matching correct constant names.*
 
 **Default:**  ``UPPER_CASE``
 
+
+.. _const-rgx-option:
 
 --const-rgx
 """""""""""
@@ -403,12 +491,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _docstring-min-length-option:
+
 --docstring-min-length
 """"""""""""""""""""""
 *Minimum line length for functions/classes that require docstrings, shorter ones are exempt.*
 
 **Default:**  ``-1``
 
+
+.. _function-naming-style-option:
 
 --function-naming-style
 """""""""""""""""""""""
@@ -417,12 +509,16 @@ Standard Checkers
 **Default:**  ``snake_case``
 
 
+.. _function-rgx-option:
+
 --function-rgx
 """"""""""""""
 *Regular expression matching correct function names. Overrides function-naming-style. If left empty, function names will be checked with the set naming style.*
 
 **Default:**  ``None``
 
+
+.. _good-names-option:
 
 --good-names
 """"""""""""
@@ -431,12 +527,16 @@ Standard Checkers
 **Default:**  ``('i', 'j', 'k', 'ex', 'Run', '_')``
 
 
+.. _good-names-rgxs-option:
+
 --good-names-rgxs
 """""""""""""""""
 *Good variable names regexes, separated by a comma. If names match any regex, they will always be accepted*
 
 **Default:** ``""``
 
+
+.. _include-naming-hint-option:
 
 --include-naming-hint
 """""""""""""""""""""
@@ -445,12 +545,16 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _inlinevar-naming-style-option:
+
 --inlinevar-naming-style
 """"""""""""""""""""""""
 *Naming style matching correct inline iteration names.*
 
 **Default:**  ``any``
 
+
+.. _inlinevar-rgx-option:
 
 --inlinevar-rgx
 """""""""""""""
@@ -459,12 +563,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _method-naming-style-option:
+
 --method-naming-style
 """""""""""""""""""""
 *Naming style matching correct method names.*
 
 **Default:**  ``snake_case``
 
+
+.. _method-rgx-option:
 
 --method-rgx
 """"""""""""
@@ -473,12 +581,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _module-naming-style-option:
+
 --module-naming-style
 """""""""""""""""""""
 *Naming style matching correct module names.*
 
 **Default:**  ``snake_case``
 
+
+.. _module-rgx-option:
 
 --module-rgx
 """"""""""""
@@ -487,12 +599,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _name-group-option:
+
 --name-group
 """"""""""""
 *Colon-delimited sets of names that determine each other's naming style when the name regexes allow several styles.*
 
 **Default:**  ``()``
 
+
+.. _no-docstring-rgx-option:
 
 --no-docstring-rgx
 """"""""""""""""""
@@ -501,12 +617,16 @@ Standard Checkers
 **Default:**  ``re.compile('^_')``
 
 
+.. _paramspec-rgx-option:
+
 --paramspec-rgx
 """""""""""""""
 *Regular expression matching correct parameter specification variable names. If left empty, parameter specification variable names will be checked with the set naming style.*
 
 **Default:**  ``None``
 
+
+.. _property-classes-option:
 
 --property-classes
 """"""""""""""""""
@@ -515,12 +635,16 @@ Standard Checkers
 **Default:**  ``('abc.abstractproperty',)``
 
 
+.. _typealias-rgx-option:
+
 --typealias-rgx
 """""""""""""""
 *Regular expression matching correct type alias names. If left empty, type alias names will be checked with the set naming style.*
 
 **Default:**  ``None``
 
+
+.. _typevar-rgx-option:
 
 --typevar-rgx
 """""""""""""
@@ -529,6 +653,8 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _typevartuple-rgx-option:
+
 --typevartuple-rgx
 """"""""""""""""""
 *Regular expression matching correct type variable tuple names. If left empty, type variable tuple names will be checked with the set naming style.*
@@ -536,12 +662,16 @@ Standard Checkers
 **Default:**  ``None``
 
 
+.. _variable-naming-style-option:
+
 --variable-naming-style
 """""""""""""""""""""""
 *Naming style matching correct variable names.*
 
 **Default:**  ``snake_case``
 
+
+.. _variable-rgx-option:
 
 --variable-rgx
 """"""""""""""
@@ -653,12 +783,16 @@ Standard Checkers
 
 ``Classes`` **Checker**
 -----------------------
+.. _check-protected-access-in-special-methods-option:
+
 --check-protected-access-in-special-methods
 """""""""""""""""""""""""""""""""""""""""""
 *Warn about protected attribute access inside special methods*
 
 **Default:**  ``False``
 
+
+.. _defining-attr-methods-option:
 
 --defining-attr-methods
 """""""""""""""""""""""
@@ -667,6 +801,8 @@ Standard Checkers
 **Default:**  ``('__init__', '__new__', 'setUp', 'asyncSetUp', '__post_init__')``
 
 
+.. _exclude-protected-option:
+
 --exclude-protected
 """""""""""""""""""
 *List of member names, which should be excluded from the protected access warning.*
@@ -674,12 +810,16 @@ Standard Checkers
 **Default:**  ``('_asdict', '_fields', '_replace', '_source', '_make', 'os._exit')``
 
 
+.. _valid-classmethod-first-arg-option:
+
 --valid-classmethod-first-arg
 """""""""""""""""""""""""""""
 *List of valid names for the first argument in a class method.*
 
 **Default:**  ``('cls',)``
 
+
+.. _valid-metaclass-classmethod-first-arg-option:
 
 --valid-metaclass-classmethod-first-arg
 """""""""""""""""""""""""""""""""""""""
@@ -720,12 +860,16 @@ Standard Checkers
 
 ``Design`` **Checker**
 ----------------------
+.. _exclude-too-few-public-methods-option:
+
 --exclude-too-few-public-methods
 """"""""""""""""""""""""""""""""
 *List of regular expressions of class ancestor names to ignore when counting public methods (see R0903)*
 
 **Default:**  ``[]``
 
+
+.. _ignored-parents-option:
 
 --ignored-parents
 """""""""""""""""
@@ -734,12 +878,16 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _max-args-option:
+
 --max-args
 """"""""""
 *Maximum number of arguments for function / method.*
 
 **Default:**  ``5``
 
+
+.. _max-attributes-option:
 
 --max-attributes
 """"""""""""""""
@@ -748,12 +896,16 @@ Standard Checkers
 **Default:**  ``7``
 
 
+.. _max-bool-expr-option:
+
 --max-bool-expr
 """""""""""""""
 *Maximum number of boolean expressions in an if statement (see R0916).*
 
 **Default:**  ``5``
 
+
+.. _max-branches-option:
 
 --max-branches
 """"""""""""""
@@ -762,12 +914,16 @@ Standard Checkers
 **Default:**  ``12``
 
 
+.. _max-complexity-option:
+
 --max-complexity
 """"""""""""""""
 *McCabe complexity cyclomatic threshold*
 
 **Default:**  ``10``
 
+
+.. _max-locals-option:
 
 --max-locals
 """"""""""""
@@ -776,12 +932,16 @@ Standard Checkers
 **Default:**  ``15``
 
 
+.. _max-parents-option:
+
 --max-parents
 """""""""""""
 *Maximum number of parents for a class (see R0901).*
 
 **Default:**  ``7``
 
+
+.. _max-positional-arguments-option:
 
 --max-positional-arguments
 """"""""""""""""""""""""""
@@ -790,12 +950,16 @@ Standard Checkers
 **Default:**  ``5``
 
 
+.. _max-public-methods-option:
+
 --max-public-methods
 """"""""""""""""""""
 *Maximum number of public methods for a class (see R0904).*
 
 **Default:**  ``20``
 
+
+.. _max-returns-option:
 
 --max-returns
 """""""""""""
@@ -804,12 +968,16 @@ Standard Checkers
 **Default:**  ``6``
 
 
+.. _max-statements-option:
+
 --max-statements
 """"""""""""""""
 *Maximum number of statements in function / method body.*
 
 **Default:**  ``50``
 
+
+.. _min-public-methods-option:
 
 --min-public-methods
 """"""""""""""""""""
@@ -868,6 +1036,8 @@ Standard Checkers
 
 ``Exceptions`` **Checker**
 --------------------------
+.. _overgeneral-exceptions-option:
+
 --overgeneral-exceptions
 """"""""""""""""""""""""
 *Exceptions that will emit a warning when caught.*
@@ -899,12 +1069,16 @@ Standard Checkers
 
 ``Format`` **Checker**
 ----------------------
+.. _expected-line-ending-format-option:
+
 --expected-line-ending-format
 """""""""""""""""""""""""""""
 *Expected format of line ending, e.g. empty (any line ending), LF or CRLF.*
 
 **Default:** ``""``
 
+
+.. _ignore-long-lines-option:
 
 --ignore-long-lines
 """""""""""""""""""
@@ -913,12 +1087,16 @@ Standard Checkers
 **Default:**  ``^\s*(# )?<?https?://\S+>?$``
 
 
+.. _ignore-pattern-in-long-lines-option:
+
 --ignore-pattern-in-long-lines
 """"""""""""""""""""""""""""""
 *Regexp for a part of a line that will not be counted when calculating the line length.*
 
 **Default:**  ``None``
 
+
+.. _indent-after-paren-option:
 
 --indent-after-paren
 """"""""""""""""""""
@@ -927,12 +1105,16 @@ Standard Checkers
 **Default:**  ``4``
 
 
+.. _indent-string-option:
+
 --indent-string
 """""""""""""""
 *String used as indentation unit. This is usually "    " (4 spaces) or "\\t" (1 tab).*
 
 **Default:**  ``"    "``
 
+
+.. _max-line-length-option:
 
 --max-line-length
 """""""""""""""""
@@ -941,6 +1123,8 @@ Standard Checkers
 **Default:**  ``100``
 
 
+.. _max-module-lines-option:
+
 --max-module-lines
 """"""""""""""""""
 *Maximum number of lines in a module.*
@@ -948,12 +1132,16 @@ Standard Checkers
 **Default:**  ``1000``
 
 
+.. _single-line-class-stmt-option:
+
 --single-line-class-stmt
 """"""""""""""""""""""""
 *Allow the body of a class to be on the same line as the declaration if body contains single statement.*
 
 **Default:**  ``False``
 
+
+.. _single-line-if-stmt-option:
 
 --single-line-if-stmt
 """""""""""""""""""""
@@ -1003,12 +1191,16 @@ Standard Checkers
 
 ``Imports`` **Checker**
 -----------------------
+.. _allow-any-import-level-option:
+
 --allow-any-import-level
 """"""""""""""""""""""""
 *List of modules that can be imported at any level, not just the top level one.*
 
 **Default:**  ``()``
 
+
+.. _allow-reexport-from-package-option:
 
 --allow-reexport-from-package
 """""""""""""""""""""""""""""
@@ -1017,12 +1209,16 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _allow-wildcard-with-all-option:
+
 --allow-wildcard-with-all
 """""""""""""""""""""""""
 *Allow wildcard imports from modules that define __all__.*
 
 **Default:**  ``False``
 
+
+.. _deprecated-modules-option:
 
 --deprecated-modules
 """"""""""""""""""""
@@ -1031,12 +1227,16 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _ext-import-graph-option:
+
 --ext-import-graph
 """"""""""""""""""
 *Output a graph (.gv or any supported image format) of external dependencies to the given file (report RP0402 must not be disabled).*
 
 **Default:** ``""``
 
+
+.. _import-graph-option:
 
 --import-graph
 """"""""""""""
@@ -1045,12 +1245,16 @@ Standard Checkers
 **Default:** ``""``
 
 
+.. _int-import-graph-option:
+
 --int-import-graph
 """"""""""""""""""
 *Output a graph (.gv or any supported image format) of internal dependencies to the given file (report RP0402 must not be disabled).*
 
 **Default:** ``""``
 
+
+.. _known-first-party-option:
 
 --known-first-party
 """""""""""""""""""
@@ -1059,6 +1263,8 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _known-standard-library-option:
+
 --known-standard-library
 """"""""""""""""""""""""
 *Force import order to recognize a module as part of the standard compatibility libraries.*
@@ -1066,12 +1272,16 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _known-third-party-option:
+
 --known-third-party
 """""""""""""""""""
 *Force import order to recognize a module as part of a third party library.*
 
 **Default:**  ``('enchant',)``
 
+
+.. _preferred-modules-option:
 
 --preferred-modules
 """""""""""""""""""
@@ -1124,12 +1334,16 @@ Standard Checkers
 
 ``Logging`` **Checker**
 -----------------------
+.. _logging-format-style-option:
+
 --logging-format-style
 """"""""""""""""""""""
 *The type of string formatting that logging methods do. `old` means using % formatting, `new` is for `{}` formatting.*
 
 **Default:**  ``old``
 
+
+.. _logging-modules-option:
 
 --logging-modules
 """""""""""""""""
@@ -1165,6 +1379,8 @@ Standard Checkers
 
 ``Method_args`` **Checker**
 ---------------------------
+.. _timeout-methods-option:
+
 --timeout-methods
 """""""""""""""""
 *List of qualified names (i.e., library.method) which require a timeout parameter e.g. 'requests.api.get,requests.api.post'*
@@ -1196,6 +1412,8 @@ Standard Checkers
 
 ``Miscellaneous`` **Checker**
 -----------------------------
+.. _check-fixme-in-docstring-option:
+
 --check-fixme-in-docstring
 """"""""""""""""""""""""""
 *Whether or not to search for fixme's in docstrings.*
@@ -1203,12 +1421,16 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _notes-option:
+
 --notes
 """""""
 *List of note tags to take in consideration, separated by a comma.*
 
 **Default:**  ``('FIXME', 'XXX', 'TODO')``
 
+
+.. _notes-rgx-option:
 
 --notes-rgx
 """""""""""
@@ -1245,6 +1467,8 @@ Standard Checkers
 
 ``Refactoring`` **Checker**
 ---------------------------
+.. _max-nested-blocks-option:
+
 --max-nested-blocks
 """""""""""""""""""
 *Maximum number of nested blocks for function / method body*
@@ -1252,12 +1476,16 @@ Standard Checkers
 **Default:**  ``5``
 
 
+.. _never-returning-functions-option:
+
 --never-returning-functions
 """""""""""""""""""""""""""
 *Complete name of functions that never returns. When checking for inconsistent-return-statements if a never returning function is called then it will be considered as an explicit return statement and no message will be printed.*
 
 **Default:**  ``('sys.exit', 'argparse.parse_error')``
 
+
+.. _suggest-join-with-non-empty-separator-option:
 
 --suggest-join-with-non-empty-separator
 """""""""""""""""""""""""""""""""""""""
@@ -1295,12 +1523,16 @@ Standard Checkers
 
 ``Similarities`` **Checker**
 ----------------------------
+.. _ignore-comments-option:
+
 --ignore-comments
 """""""""""""""""
 *Comments are removed from the similarity computation*
 
 **Default:**  ``True``
 
+
+.. _ignore-docstrings-option:
 
 --ignore-docstrings
 """""""""""""""""""
@@ -1309,6 +1541,8 @@ Standard Checkers
 **Default:**  ``True``
 
 
+.. _ignore-imports-option:
+
 --ignore-imports
 """"""""""""""""
 *Imports are removed from the similarity computation*
@@ -1316,12 +1550,16 @@ Standard Checkers
 **Default:**  ``True``
 
 
+.. _ignore-signatures-option:
+
 --ignore-signatures
 """""""""""""""""""
 *Signatures are removed from the similarity computation*
 
 **Default:**  ``True``
 
+
+.. _min-similarity-lines-option:
 
 --min-similarity-lines
 """"""""""""""""""""""
@@ -1362,12 +1600,16 @@ Standard Checkers
 
 ``Spelling`` **Checker**
 ------------------------
+.. _max-spelling-suggestions-option:
+
 --max-spelling-suggestions
 """"""""""""""""""""""""""
 *Limits count of emitted suggestions for spelling mistakes.*
 
 **Default:**  ``4``
 
+
+.. _spelling-dict-option:
 
 --spelling-dict
 """""""""""""""
@@ -1376,12 +1618,16 @@ Standard Checkers
 **Default:** ``""``
 
 
+.. _spelling-ignore-comment-directives-option:
+
 --spelling-ignore-comment-directives
 """"""""""""""""""""""""""""""""""""
 *List of comma separated words that should be considered directives if they appear at the beginning of a comment and should not be checked.*
 
 **Default:**  ``fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:``
 
+
+.. _spelling-ignore-words-option:
 
 --spelling-ignore-words
 """""""""""""""""""""""
@@ -1390,12 +1636,16 @@ Standard Checkers
 **Default:** ``""``
 
 
+.. _spelling-private-dict-file-option:
+
 --spelling-private-dict-file
 """"""""""""""""""""""""""""
 *A path to a file that contains the private dictionary; one word per line.*
 
 **Default:** ``""``
 
+
+.. _spelling-store-unknown-words-option:
 
 --spelling-store-unknown-words
 """"""""""""""""""""""""""""""
@@ -1439,12 +1689,16 @@ Standard Checkers
 
 ``String`` **Checker**
 ----------------------
+.. _check-quote-consistency-option:
+
 --check-quote-consistency
 """""""""""""""""""""""""
 *This flag controls whether inconsistent-quotes generates a warning when the character used as a quote delimiter is used inconsistently within a module.*
 
 **Default:**  ``False``
 
+
+.. _check-str-concat-over-line-jumps-option:
 
 --check-str-concat-over-line-jumps
 """"""""""""""""""""""""""""""""""
@@ -1479,12 +1733,16 @@ Standard Checkers
 
 ``Typecheck`` **Checker**
 -------------------------
+.. _contextmanager-decorators-option:
+
 --contextmanager-decorators
 """""""""""""""""""""""""""
 *List of decorators that produce context managers, such as contextlib.contextmanager. Add to this list to register other decorators that produce valid context managers.*
 
 **Default:**  ``['contextlib.contextmanager']``
 
+
+.. _generated-members-option:
 
 --generated-members
 """""""""""""""""""
@@ -1493,12 +1751,16 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _ignore-mixin-members-option:
+
 --ignore-mixin-members
 """"""""""""""""""""""
 *Tells whether missing members accessed in mixin class should be ignored. A class is considered mixin if its name matches the mixin-class-rgx option.*
 
 **Default:**  ``True``
 
+
+.. _ignore-none-option:
 
 --ignore-none
 """""""""""""
@@ -1507,12 +1769,16 @@ Standard Checkers
 **Default:**  ``True``
 
 
+.. _ignore-on-opaque-inference-option:
+
 --ignore-on-opaque-inference
 """"""""""""""""""""""""""""
 *This flag controls whether pylint should warn about no-member and similar checks whenever an opaque object is returned when inferring. The inference can return multiple potential results while evaluating a Python object, but some branches might not be evaluated, which results in partial inference. In that case, it might be useful to still emit no-member and other checks for the rest of the inferred objects.*
 
 **Default:**  ``True``
 
+
+.. _ignored-checks-for-mixins-option:
 
 --ignored-checks-for-mixins
 """""""""""""""""""""""""""
@@ -1521,12 +1787,16 @@ Standard Checkers
 **Default:**  ``['no-member', 'not-async-context-manager', 'not-context-manager', 'attribute-defined-outside-init']``
 
 
+.. _ignored-classes-option:
+
 --ignored-classes
 """""""""""""""""
 *List of class names for which member attributes should not be checked (useful for classes with dynamically set attributes). This supports the use of qualified names.*
 
 **Default:**  ``('optparse.Values', 'thread._local', '_thread._local', 'argparse.Namespace')``
 
+
+.. _missing-member-hint-option:
 
 --missing-member-hint
 """""""""""""""""""""
@@ -1535,12 +1805,16 @@ Standard Checkers
 **Default:**  ``True``
 
 
+.. _missing-member-hint-distance-option:
+
 --missing-member-hint-distance
 """"""""""""""""""""""""""""""
 *The maximum edit distance a name should have in order to be considered a similar match for a missing member name.*
 
 **Default:**  ``1``
 
+
+.. _missing-member-max-choices-option:
 
 --missing-member-max-choices
 """"""""""""""""""""""""""""
@@ -1549,12 +1823,16 @@ Standard Checkers
 **Default:**  ``1``
 
 
+.. _mixin-class-rgx-option:
+
 --mixin-class-rgx
 """""""""""""""""
 *Regex pattern to define which classes are considered mixins.*
 
 **Default:**  ``.*[Mm]ixin``
 
+
+.. _signature-mutators-option:
 
 --signature-mutators
 """"""""""""""""""""
@@ -1609,12 +1887,16 @@ Standard Checkers
 
 ``Variables`` **Checker**
 -------------------------
+.. _additional-builtins-option:
+
 --additional-builtins
 """""""""""""""""""""
 *List of additional names supposed to be defined in builtins. Remember that you should avoid defining new builtins when possible.*
 
 **Default:**  ``()``
 
+
+.. _allow-global-unused-variables-option:
 
 --allow-global-unused-variables
 """""""""""""""""""""""""""""""
@@ -1623,12 +1905,16 @@ Standard Checkers
 **Default:**  ``True``
 
 
+.. _allowed-redefined-builtins-option:
+
 --allowed-redefined-builtins
 """"""""""""""""""""""""""""
 *List of names allowed to shadow builtins*
 
 **Default:**  ``()``
 
+
+.. _callbacks-option:
 
 --callbacks
 """""""""""
@@ -1637,12 +1923,16 @@ Standard Checkers
 **Default:**  ``('cb_', '_cb')``
 
 
+.. _dummy-variables-rgx-option:
+
 --dummy-variables-rgx
 """""""""""""""""""""
 *A regular expression matching the name of dummy variables (i.e. expected to not be used).*
 
 **Default:**  ``_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_``
 
+
+.. _ignored-argument-names-option:
 
 --ignored-argument-names
 """"""""""""""""""""""""
@@ -1651,12 +1941,16 @@ Standard Checkers
 **Default:**  ``re.compile('_.*|^ignored_|^unused_')``
 
 
+.. _init-import-option:
+
 --init-import
 """""""""""""
 *Tells whether we should check for unused import in __init__ files.*
 
 **Default:**  ``False``
 
+
+.. _redefining-builtins-modules-option:
 
 --redefining-builtins-modules
 """""""""""""""""""""""""""""
@@ -1707,6 +2001,8 @@ Extensions
 
 ``Broad_try_clause`` **Checker**
 --------------------------------
+.. _max-try-statements-option:
+
 --max-try-statements
 """"""""""""""""""""
 *Maximum number of statements allowed in a try clause*
@@ -1738,6 +2034,8 @@ Extensions
 
 ``Code_style`` **Checker**
 --------------------------
+.. _max-line-length-suggestions-option:
+
 --max-line-length-suggestions
 """""""""""""""""""""""""""""
 *Max line length for which to sill emit suggestions. Used to prevent optional suggestions which would get split by a code formatter (e.g., black). Will default to the setting for ``max-line-length``.*
@@ -1769,6 +2067,8 @@ Extensions
 
 ``Deprecated_builtins`` **Checker**
 -----------------------------------
+.. _bad-functions-option:
+
 --bad-functions
 """""""""""""""
 *List of builtins function names that should not be used, separated by a comma*
@@ -1800,6 +2100,8 @@ Extensions
 
 ``Dunder`` **Checker**
 ----------------------
+.. _good-dunder-names-option:
+
 --good-dunder-names
 """""""""""""""""""
 *Good dunder names which should always be accepted.*
@@ -1831,6 +2133,8 @@ Extensions
 
 ``Magic-value`` **Checker**
 ---------------------------
+.. _valid-magic-values-option:
+
 --valid-magic-values
 """"""""""""""""""""
 *List of valid magic values that `magic-value-compare` will not detect. Supports integers, floats, negative numbers, for empty string enter ``''``, for backslash values just use one backslash e.g \n.*
@@ -1862,12 +2166,16 @@ Extensions
 
 ``Parameter_documentation`` **Checker**
 ---------------------------------------
+.. _accept-no-param-doc-option:
+
 --accept-no-param-doc
 """""""""""""""""""""
 *Whether to accept totally missing parameter documentation in the docstring of a function that has parameters.*
 
 **Default:**  ``True``
 
+
+.. _accept-no-raise-doc-option:
 
 --accept-no-raise-doc
 """""""""""""""""""""
@@ -1876,6 +2184,8 @@ Extensions
 **Default:**  ``True``
 
 
+.. _accept-no-return-doc-option:
+
 --accept-no-return-doc
 """"""""""""""""""""""
 *Whether to accept totally missing return documentation in the docstring of a function that returns a statement.*
@@ -1883,12 +2193,16 @@ Extensions
 **Default:**  ``True``
 
 
+.. _accept-no-yields-doc-option:
+
 --accept-no-yields-doc
 """"""""""""""""""""""
 *Whether to accept totally missing yields documentation in the docstring of a generator.*
 
 **Default:**  ``True``
 
+
+.. _default-docstring-type-option:
 
 --default-docstring-type
 """"""""""""""""""""""""
@@ -1930,6 +2244,8 @@ Extensions
 
 ``Typing`` **Checker**
 ----------------------
+.. _runtime-typing-option:
+
 --runtime-typing
 """"""""""""""""
 *Set to ``no`` if the app / library does **NOT** need to support runtime introspection of type annotations. If you use type annotations **exclusively** for type checking of an application, you're probably fine. For libraries, evaluate if some users want to access the type hints at runtime first, e.g., through ``typing.get_type_hints``. Applies to Python versions 3.7 - 3.9*


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |
| ✓   | :scroll: Docs          |

## Description

The options page only had one anchor per checker, so a message page that wanted to point at a single option sent the reader to the top of a section holding a dozen of them.

Emit an '<option-name>-option' label before each option title, and use it in the three places that were linking to a checker section.
