### PR TITLE
Fix crash in docparams on raising a non-exception name

### DIFF
--- a/doc/whatsnew/fragments/11228.bugfix
+++ b/doc/whatsnew/fragments/11228.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the ``docparams`` extension when a raised name does not infer to an exception, such as ``raise sum`` or ``raise some_module``. Such objects have no ``ancestors()``, which aborted the whole file with an ``astroid-error`` fatal message.
+
+Closes #11228

--- a/pylint/extensions/_check_docs_utils.py
+++ b/pylint/extensions/_check_docs_utils.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Iterable
 
 import astroid
-from astroid import nodes
+from astroid import bases, nodes
 from astroid.util import UninferableBase
 
 from pylint.checkers import utils
@@ -150,7 +150,12 @@ def possible_exc_types(node: nodes.NodeNG) -> set[nodes.ClassDef]:
         return {
             exc
             for exc in exceptions
-            if not utils.node_ignores_exception(node, exc.name)
+            # Inference is not restricted to exception classes: ``raise sum``
+            # infers to a FunctionDef and ``raise os`` to a Module, neither of
+            # which implements ``ancestors()``. ``Instance`` is kept because it
+            # proxies ``name`` and ``ancestors`` to the class it wraps.
+            if isinstance(exc, (nodes.ClassDef, bases.Instance))
+            and not utils.node_ignores_exception(node, exc.name)
         }
     except astroid.InferenceError:
         return set()

--- a/tests/extensions/test_check_docs_utils.py
+++ b/tests/extensions/test_check_docs_utils.py
@@ -134,3 +134,52 @@ def test_possible_exc_types_raising_potential_none() -> None:
     raise a()  #@
     """)
     assert utils.possible_exc_types(raise_node) == set()
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        """
+    def my_func():
+        raise sum  #@
+    """,
+        """
+    import os
+    def my_func():
+        raise os  #@
+    """,
+        """
+    def my_func():
+        try:
+            fake_func()
+        except sum:
+            raise  #@
+    """,
+    ],
+)
+def test_possible_exc_types_non_exception(code: str) -> None:
+    """Inference is not restricted to exception classes.
+
+    A name can resolve to a function or a module, neither of which implements
+    ``ancestors()``; such objects must not be reported as raised exceptions.
+    """
+    raise_node = astroid.extract_node(code)
+    assert utils.possible_exc_types(raise_node) == set()
+
+
+def test_possible_exc_types_instance() -> None:
+    """An exception *instance* is kept.
+
+    It is not a ``ClassDef``, but it proxies ``name`` and ``ancestors`` to the
+    class it wraps, so it is still usable by the callers.
+    """
+    raise_node = astroid.extract_node("""
+    def my_func():
+        err = ValueError("hi")
+        raise err  #@
+    """)
+    found_nodes = utils.possible_exc_types(raise_node)
+    assert {node.name for node in found_nodes} == {"ValueError"}
+    assert {ancestor.name for node in found_nodes for ancestor in node.ancestors()} >= {
+        "Exception"
+    }

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Google.py
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Google.py
@@ -190,3 +190,12 @@ class Foo:
         if True:  # [using-constant-test]
             raise AttributeError()
         raise RuntimeError()
+
+
+def test_google_raises_non_exception(self):
+    """This is a Google docstring.
+
+    Raises:
+        TypeError: Never, ``sum`` is a builtin function and not an exception.
+    """
+    raise sum  # [raising-bad-type]

--- a/tests/functional/ext/docparams/raise/missing_raises_doc_Google.txt
+++ b/tests/functional/ext/docparams/raise/missing_raises_doc_Google.txt
@@ -12,3 +12,4 @@ unreachable:158:8:158:17:Foo.foo_method:Unreachable code:HIGH
 unreachable:180:8:180:17:Foo.foo_method:Unreachable code:HIGH
 missing-raises-doc:183:4:183:18:Foo.foo_method:"""AttributeError"" not documented as being raised":HIGH
 using-constant-test:190:11:190:15:Foo.foo_method:Using a conditional statement with a constant value:INFERENCE
+raising-bad-type:201:4:201:13:test_google_raises_non_exception:Raising sum while only classes or instances are allowed:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`possible_exc_types` is annotated to return exception classes, but its `nodes.Name` branch appends whatever `safe_infer` resolves to without checking what it got:

```python
if isinstance(node.exc, nodes.Name):
    inferred = utils.safe_infer(node.exc)
    if inferred:
        exceptions = [inferred]
```

The other two branches filter their results; this one does not. So `raise sum` puts a `FunctionDef` in the set, `docparams.visit_raise` calls `expected.ancestors()` on it, and since only `ClassDef` implements `ancestors()`, the whole file is aborted with an `astroid-error` fatal message.

The reported reproducer is not the only way in. While writing the test I found two more inputs that crash on the same line:

| input | inferred as | before |
| --- | --- | --- |
| `raise sum` | `FunctionDef` | 💥 `astroid-error` (the reported case) |
| `raise os` (a module) | `Module` | 💥 `astroid-error` |
| bare `raise` inside `except sum:` | `FunctionDef` | 💥 `astroid-error` |

The third one comes through the `node.exc is None` branch, so a fix confined to the `nodes.Name` branch would leave it crashing. I filter the returned set instead, which is where all three branches converge.

### Why `Instance` is kept

The obvious guard is `isinstance(exc, nodes.ClassDef)`, but that would be a regression. An exception raised via a name bound to an instance:

```python
err = ValueError("hi")
raise err
```

infers to an `ExceptionInstance`, which is **not** a `ClassDef` — it proxies `name` and `ancestors` to the class it wraps. Dropping it would silence legitimate `missing-raises-doc` reports, trading the crash for a false negative. `AGENTS.md` calls out this exact hazard, so the filter is `(nodes.ClassDef, bases.Instance)`.

After the fix all three inputs are reported as `raising-bad-type` (E0702), which is the message that already applies to them, instead of killing the run.

### Tests

- Three parametrized cases in `test_possible_exc_types_non_exception` — one per crashing input. All three fail on `main` with the traceback from the issue.
- `test_possible_exc_types_instance` guards the `Instance` case above against a future over-narrowed guard. It passes both with and without the fix, which is the point: it only fails if someone tightens the filter to `ClassDef` alone.
- A functional test in `missing_raises_doc_Google.py` reproducing the issue verbatim, so the end-to-end run is covered and not just the helper.

Closes #11228
