### PR TITLE
Record the Python 2 checks removed in pylint 2.2 as deleted messages

### DIFF
--- a/doc/exts/pylint_messages.py
+++ b/doc/exts/pylint_messages.py
@@ -259,6 +259,20 @@ DELETED_MESSAGE_METADATA: dict[str, tuple[str, str | None]] = {
         "2.14.0",
         "Name 'async' will become a keyword in Python 3.7",
     ),
+    # Issue #1896 — Python 2 only checks, first absent in pylint 2.2.0
+    "old-style-class": ("2.2.0", "Old-style class defined."),
+    "slots-on-old-class": ("2.2.0", "Use of __slots__ on an old style class"),
+    "super-on-old-class": ("2.2.0", "Use of super on an old style class"),
+    "deprecated-lambda": (
+        "2.2.0",
+        "map/filter on lambda could be replaced by comprehension",
+    ),
+    "lowercase-l-suffix": ("2.2.0", 'Use of "l" as long integer identifier'),
+    "nonstandard-exception": (
+        "2.2.0",
+        'Exception doesn\'t inherit from standard "Exception" class',
+    ),
+    "property-on-old-class": ("2.2.0", 'Use of "property" on an old style class'),
 }
 
 

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -206,6 +206,8 @@ All permanently deleted messages in the error category:
    error/old-raise-syntax
    error/parameter-unpacking
    error/print-statement
+   error/slots-on-old-class
+   error/super-on-old-class
    error/unpacking-in-except
 
 .. _warning-category:
@@ -422,6 +424,7 @@ All permanently deleted messages in the warning category:
    warning/comprehension-escape
    warning/delslice-method
    warning/deprecated-itertools-function
+   warning/deprecated-lambda
    warning/deprecated-operator-function
    warning/deprecated-str-translate-call
    warning/deprecated-string-function
@@ -448,6 +451,7 @@ All permanently deleted messages in the warning category:
    warning/intern-builtin
    warning/invalid-str-codec
    warning/long-builtin
+   warning/lowercase-l-suffix
    warning/map-builtin-not-iterating
    warning/metaclass-assignment
    warning/mixed-indentation
@@ -455,6 +459,7 @@ All permanently deleted messages in the warning category:
    warning/next-method-defined
    warning/no-absolute-import
    warning/no-init
+   warning/nonstandard-exception
    warning/nonzero-method
    warning/oct-method
    warning/old-backtick
@@ -463,6 +468,7 @@ All permanently deleted messages in the warning category:
    warning/old-old-raise-syntax
    warning/old-raising-string
    warning/old-unpacking-in-except
+   warning/property-on-old-class
    warning/raising-string
    warning/range-builtin-not-iterating
    warning/raw_input-builtin
@@ -575,6 +581,7 @@ All permanently deleted messages in the convention category:
    convention/no-space-after-comma
    convention/no-space-after-operator
    convention/no-space-before-operator
+   convention/old-style-class
 
 .. _refactor-category:
 

--- a/pylint/message/_deleted_message_ids.py
+++ b/pylint/message/_deleted_message_ids.py
@@ -124,6 +124,15 @@ DELETED_MESSAGES_IDS = {
     "https://github.com/pylint-dev/pylint/pull/6421": [
         DeletedMessage("W0111", "assign-to-new-keyword"),
     ],
+    "https://github.com/pylint-dev/pylint/issues/1896": [
+        DeletedMessage("C1001", "old-style-class"),
+        DeletedMessage("E1001", "slots-on-old-class"),
+        DeletedMessage("E1002", "super-on-old-class"),
+        DeletedMessage("W0110", "deprecated-lambda"),
+        DeletedMessage("W0332", "lowercase-l-suffix"),
+        DeletedMessage("W0710", "nonstandard-exception"),
+        DeletedMessage("W1001", "property-on-old-class"),
+    ],
 }
 MOVED_TO_EXTENSIONS = {
     "https://pylint.readthedocs.io/en/latest/whatsnew/2/2.14/summary.html#removed-checkers": [


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |
| ✓   | :scroll: Docs          |

## Description

Seven checks were removed in 2018 without being added to DELETED_MESSAGES_IDS, so pylint had no memory of them: disabling 'deprecated-lambda' answered that the name is unknown, and the documentation had no page to point a reader at.

Record them, with the message each one used to emit. Disabling one now explains that it was removed and links to the issue that removed it.

Refs #1896
