### PR TITLE
Link message symbols and message ids in the documentation

### DIFF
--- a/doc/data/messages/a/assert-on-string-literal/details.rst
+++ b/doc/data/messages/a/assert-on-string-literal/details.rst
@@ -1,4 +1,4 @@
 Directly asserting a string literal will always pass. The solution is to
 test something that could fail, or not assert at all.
 
-For ``unittest`` assertions there is the similar :ref:`redundant-unittest-assert` message.
+For ``unittest`` assertions there is the similar :ref:`redundant-unittest-assert <redundant-unittest-assert>` message.

--- a/doc/data/messages/a/assert-on-tuple/details.rst
+++ b/doc/data/messages/a/assert-on-tuple/details.rst
@@ -1,4 +1,4 @@
 Directly asserting a non-empty tuple will always pass. The solution is to
  test something that could fail, or not assert at all.
 
- For ``unittest`` assertions there is the similar :ref:`redundant-unittest-assert` message.
+ For ``unittest`` assertions there is the similar :ref:`redundant-unittest-assert <redundant-unittest-assert>` message.

--- a/doc/data/messages/n/no-member/details.rst
+++ b/doc/data/messages/n/no-member/details.rst
@@ -16,7 +16,7 @@ or for every extension with :ref:`unsafe-load-any-extension <main-options>`::
    $ pylint --unsafe-load-any-extension=y
 
 Attributes missing from a C extension are reported as
-:ref:`c-extension-no-member`, so you can also disable that message alone.
+:ref:`c-extension-no-member <c-extension-no-member>`, so you can also disable that message alone.
 
 For attributes created at runtime, list them with
 :ref:`generated-members <typecheck-options>`::

--- a/doc/data/messages/r/redundant-unittest-assert/details.rst
+++ b/doc/data/messages/r/redundant-unittest-assert/details.rst
@@ -1,4 +1,4 @@
 Directly asserting a string literal will always pass. The solution is to
 test something that could fail, or not assert at all.
 
-For assertions using ``assert`` there are similar messages: :ref:`assert-on-string-literal` and :ref:`assert-on-tuple`.
+For assertions using ``assert`` there are similar messages: :ref:`assert-on-string-literal <assert-on-string-literal>` and :ref:`assert-on-tuple <assert-on-tuple>`.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -98,17 +98,17 @@ of pylint is not easy; we also discourage the use of the ``-j`` option if this m
 Which messages should I disable to avoid duplicates if I use other popular linters ?
 ------------------------------------------------------------------------------------
 
-pycodestyle_: bad-indentation, bare-except, line-too-long, missing-final-newline, multiple-statements, singleton-comparison, trailing-newlines, trailing-whitespace, unnecessary-negation, unnecessary-semicolon, wrong-import-position
+pycodestyle_: :ref:`bad-indentation <bad-indentation>`, :ref:`bare-except <bare-except>`, :ref:`line-too-long <line-too-long>`, :ref:`missing-final-newline <missing-final-newline>`, :ref:`multiple-statements <multiple-statements>`, :ref:`singleton-comparison <singleton-comparison>`, :ref:`trailing-newlines <trailing-newlines>`, :ref:`trailing-whitespace <trailing-whitespace>`, :ref:`unnecessary-negation <unnecessary-negation>`, :ref:`unnecessary-semicolon <unnecessary-semicolon>`, :ref:`wrong-import-position <wrong-import-position>`
 
-pyflakes_: undefined-variable, unused-import, unused-variable
+pyflakes_: :ref:`undefined-variable <undefined-variable>`, :ref:`unused-import <unused-import>`, :ref:`unused-variable <unused-variable>`
 
-mccabe_: too-many-branches
+mccabe_: :ref:`too-many-branches <too-many-branches>`
 
-pydocstyle_: missing-module-docstring, missing-class-docstring, missing-function-docstring
+pydocstyle_: :ref:`missing-module-docstring <missing-module-docstring>`, :ref:`missing-class-docstring <missing-class-docstring>`, :ref:`missing-function-docstring <missing-function-docstring>`
 
-pep8-naming_: invalid-name, bad-classmethod-argument, bad-mcs-classmethod-argument, no-self-argument
+pep8-naming_: :ref:`invalid-name <invalid-name>`, :ref:`bad-classmethod-argument <bad-classmethod-argument>`, :ref:`bad-mcs-classmethod-argument <bad-mcs-classmethod-argument>`, :ref:`no-self-argument <no-self-argument>`
 
-isort_ and flake8-import-order_: ungrouped-imports, wrong-import-order
+isort_ and flake8-import-order_: :ref:`ungrouped-imports <ungrouped-imports>`, :ref:`wrong-import-order <wrong-import-order>`
 
 .. _`pycodestyle`: https://github.com/PyCQA/pycodestyle
 .. _`pyflakes`: https://github.com/PyCQA/pyflakes

--- a/doc/user_guide/usage/output.rst
+++ b/doc/user_guide/usage/output.rst
@@ -55,7 +55,7 @@ obj
 msg
     text of the message
 msg_id
-    the message code (eg. :ref:`I0011 <locally-disabled>`)
+    the message code (eg. I0011)
 symbol
     symbolic name of the message (eg. :ref:`locally-disabled <locally-disabled>`)
 C

--- a/doc/user_guide/usage/output.rst
+++ b/doc/user_guide/usage/output.rst
@@ -55,9 +55,9 @@ obj
 msg
     text of the message
 msg_id
-    the message code (eg. I0011)
+    the message code (eg. :ref:`I0011 <locally-disabled>`)
 symbol
-    symbolic name of the message (eg. locally-disabled)
+    symbolic name of the message (eg. :ref:`locally-disabled <locally-disabled>`)
 C
     one letter indication of the message category
 category

--- a/doc/whatsnew/0/0.x.rst
+++ b/doc/whatsnew/0/0.x.rst
@@ -4,13 +4,13 @@ Release date: 2013-04-25
 
 * bitbucket #1: fix "dictionary changed size during iteration" crash
 
-* #74013: new E1310[bad-str-strip-call] message warning when a call to a
+* #74013: new :ref:`bad-str-strip-call <bad-str-strip-call>` message warning when a call to a
   {l,r,}strip method contains duplicate characters (patch by Torsten Marek)
 
-* #123233: new E0108[duplicate-argument-name] message reporting duplicate
+* #123233: new :ref:`duplicate-argument-name <duplicate-argument-name>` message reporting duplicate
   argument names
 
-* #81378: emit W0120[useless-else-on-loop] for loops without break
+* #81378: emit :ref:`useless-else-on-loop <useless-else-on-loop>` for loops without break
 
 * #124660: internal dependencies should not appear in external dependencies
   report
@@ -21,7 +21,7 @@ Release date: 2013-04-25
 * #123285: apply pragmas for warnings attached to lines to physical source
   code lines
 
-* #123259: do not emit E0105 for yield expressions inside lambdas
+* #123259: do not emit :ref:`E0105 <yield-outside-function>` for yield expressions inside lambdas
 
 * #123892: don't crash when attempting to show source code line that can't
   be encoded with the current locale settings
@@ -42,10 +42,10 @@ Release date: 2013-02-26
   'disable-all' inline directive in favour of 'skip-file' (patch by
   A.Fayolle)
 
-* #110840: add messages I0020 and I0021 for reporting of suppressed
+* #110840: add messages :ref:`I0020 <suppressed-message>` and :ref:`I0021 <useless-suppression>` for reporting of suppressed
   messages and useless suppression pragmas. (patch by Torsten Marek)
 
-* #112728: add warning E0604 for non-string objects in __all__
+* #112728: add warning :ref:`E0604 <invalid-all-object>` for non-string objects in __all__
   (patch by Torsten Marek)
 
 * #120657: add warning W0110/deprecated-lambda when a map/filter
@@ -59,7 +59,7 @@ Release date: 2013-02-26
 
 * #110839: bind <F5> to Run button in pylint-gui
 
-* #115580: fix erroneous W0212 (access to protected member) on super call
+* #115580: fix erroneous :ref:`W0212 <protected-access>` (access to protected member) on super call
   (patch by Martin Pool)
 
 * #110853: fix a crash when an __init__ method in a base class has been
@@ -82,7 +82,7 @@ Release date: 2013-02-26
 
 * #120635: redefine cmp function used in pylint.reporters
 
-* Include full warning id for I0020 and I0021 and make sure to flush
+* Include full warning id for :ref:`I0020 <suppressed-message>` and :ref:`I0021 <useless-suppression>` and make sure to flush
   warnings after each module, not at the end of the pylint run.
   (patch by Torsten Marek)
 
@@ -104,26 +104,26 @@ Release date: 2012-10-05
   and 'symilar' command line tool (patch by Ry4an Brase)
 
 * #104571: check for anomalous backslash escape, introducing new
-  W1401 and W1402 messages (patch by Martin Pool)
+  :ref:`W1401 <anomalous-backslash-in-string>` and :ref:`W1402 <anomalous-unicode-escape-in-string>` messages (patch by Martin Pool)
 
 * #100707: check for boolop being used as exception class, introducing
-  new W0711 message (patch by Tim Hatch)
+  new :ref:`W0711 <binary-op-exception>` message (patch by Tim Hatch)
 
 * #4014: improve checking of metaclass methods first args, introducing
-  new C0204 message (patch by lothiraldan@gmail.com finalized by sthenault)
+  new :ref:`C0204 <bad-mcs-classmethod-argument>` message (patch by lothiraldan@gmail.com finalized by sthenault)
 
 * #4685: check for consistency of a module's __all__ variable,
-  introducing new E0603 message
+  introducing new :ref:`E0603 <undefined-all-variable>` message
 
 * #105337: allow custom reporter in output-format (patch by Kevin Jing Qiu)
 
-* #104420: check for protocol completeness and avoid false R0903
+* #104420: check for protocol completeness and avoid false :ref:`R0903 <too-few-public-methods>`
   (patch by Peter Hammond)
 
 * #100654: fix grammatical error for W0332 message (using 'l' as
   long int identifier)
 
-* #103656: fix W0231 false positive for missing call to object.__init__
+* #103656: fix :ref:`W0231 <super-init-not-called>` false positive for missing call to object.__init__
   (patch by lothiraldan@gmail.com)
 
 * #63424: fix similarity report disabling by properly renaming it to RP0801
@@ -145,19 +145,19 @@ Release date: 2012-07-17
   except handler contains a tuple of names instead of a single name.
   (patch by tmarek@google.com)
 
-* #7394: W0212 (access to protected member) not emitted on assignments
+* #7394: :ref:`W0212 <protected-access>` (access to protected member) not emitted on assignments
   (patch by lothiraldan@gmail.com)
 
 * #18772; no prototype consistency check for mangled methods (patch by
   lothiraldan@gmail.com)
 
-* #92911: emit W0102 when sets are used as default arguments in functions
+* #92911: emit :ref:`W0102 <dangerous-default-value>` when sets are used as default arguments in functions
   (patch by tmarek@google.com)
 
-* #77982: do not emit E0602 for loop variables of comprehensions
+* #77982: do not emit :ref:`E0602 <undefined-variable>` for loop variables of comprehensions
   used as argument values inside a decorator (patch by tmarek@google.com)
 
-* #89092: don't emit E0202 (attribute hiding a method) on @property methods
+* #89092: don't emit :ref:`E0202 <method-hidden>` (attribute hiding a method) on @property methods
 
 * #92584: fix pylint-gui crash due to internal API change
 
@@ -177,13 +177,13 @@ Release date: 2011-12-08
 * #81078: Warn if names in  exception handlers clobber overwrite
   existing names (patch by tmarek@google.com)
 
-* #81113: Fix W0702 messages appearing with the wrong line number.
+* #81113: Fix :ref:`W0702 <bare-except>` messages appearing with the wrong line number.
   (patch by tmarek@google.com)
 
 * #50461, #52020, #51222: Do not issue warnings when using 2.6's
   property.setter/deleter functionality (patch by dneil@google.com)
 
-* #9188, #4024: Do not trigger W0631 if a loop variable is assigned
+* #9188, #4024: Do not trigger :ref:`W0631 <undefined-loop-variable>` if a loop variable is assigned
   in the else branch of a for loop.
 
 
@@ -205,7 +205,7 @@ Release date: 2011-10-7
 
 * #76920: crash if on e.g. "pylint --rcfile" (patch by Torsten Marek)
 
-* #77237: warning for E0202 may be very misleading
+* #77237: warning for :ref:`E0202 <method-hidden>` may be very misleading
 
 * #73941: HTML report messages table is badly rendered
 
@@ -246,13 +246,13 @@ Release date: 2011-01-11
 
 * finalize python3 support
 
-* new W0106 warning 'Expression "%s" is assigned to nothing'
+* new :ref:`W0106 <expression-not-assigned>` warning 'Expression "%s" is assigned to nothing'
 
 * drop E0501 and E0502 messages about wrong source encoding: not anymore
   interesting since it's a syntax error for python >= 2.5 and we now only
   support this python version and above.
 
-* don't emit W0221 or W0222 when methods as variable arguments (e.g. \*arg
+* don't emit :ref:`W0221 <arguments-differ>` or :ref:`W0222 <signature-differs>` when methods as variable arguments (e.g. \*arg
   and/or \*\*args). Patch submitted by Charles Duffy.
 
 
@@ -323,7 +323,7 @@ Release date: 2010-05-11
 
 * fix #21591: html reporter produces no output if reports is set to 'no'
 
-* fix #4581: not Missing docstring (C0111) warning if a method is overridden
+* fix #4581: not Missing docstring (:ref:`C0111 <missing-docstring>`) warning if a method is overridden
 
 * fix #4683: Non-ASCII characters count double if utf8 encode
 
@@ -346,9 +346,9 @@ Release date: 2010-03-01
 * fix #19339: pylint.el : non existing py-mod-map
   (closes Debian Bug report logs - #475939)
 
-* implement #18860, new W0199 message on assert (a, b)
+* implement #18860, new :ref:`W0199 <assert-on-tuple>` message on assert (a, b)
 
-* implement #9776, 'W0150' break or return statement in finally block may
+* implement #9776, ':ref:`W0150 <lost-exception>`' break or return statement in finally block may
   swallow exception.
 
 * fix #9263, __init__ and __new__ are checked for unused arguments
@@ -357,13 +357,13 @@ Release date: 2010-03-01
 
 * fix #5975, Abstract intermediate class not recognized as such
 
-* fix #5977, yield and return statement have their own counters, no more R0911
+* fix #5977, yield and return statement have their own counters, no more :ref:`R0911 <too-many-return-statements>`
   (Too many return statements) when a function have many yield stamtements
 
 * implement #5564, function / method arguments with leading "_" are ignored in
   arguments / local variables count.
 
-* implement #9982, E0711 specific error message when raising NotImplemented
+* implement #9982, :ref:`E0711 <notimplemented-raised>` specific error message when raising NotImplemented
 
 * remove --cache-size option
 
@@ -388,7 +388,7 @@ Release date: 2009-12-18
 
 * refactor and fix the imports checker
 
-* fix #18862: E0601 false positive with lambda functions
+* fix #18862: :ref:`E0601 <used-before-assignment>` false positive with lambda functions
 
 * fix #8764: More than one statement on a single line false positive with
   try/except/finally
@@ -408,20 +408,20 @@ Release date: 2009-03-25
 
 * tests ok with python 2.4, 2.5, 2.6. 2.3 not tested
 
-* fix #8687, W0613 false positive on inner function
+* fix #8687, :ref:`W0613 <unused-argument>` false positive on inner function
 
-* fix #8350, C0322 false positive on multi-line string
+* fix #8350, :ref:`C0322 <no-space-before-operator>` false positive on multi-line string
 
 * fix #8332: set E0501 line no to the first line where non ascii character
   has been found
 
-* avoid some E0203 / E0602 false negatives by detecting respectively
+* avoid some :ref:`E0203 <access-member-before-definition>` / :ref:`E0602 <undefined-variable>` false negatives by detecting respectively
   AttributeError / NameError
 
-* implements #4037: don't issue W0142 (* or ** magic) when they are barely
+* implements #4037: don't issue :ref:`W0142 <star-args>` (* or ** magic) when they are barely
   passed from */** arguments
 
-* complete #5573: more complete list of special methods, also skip W0613
+* complete #5573: more complete list of special methods, also skip :ref:`W0613 <unused-argument>`
   for python internal method
 
 * don't show information messages by default
@@ -433,7 +433,7 @@ What's New in Pylint 0.17.0?
 ============================
 Release date: 2009-03-19
 
-* semicolon check : move W0601 to W0301
+* semicolon check : move :ref:`W0601 <global-variable-undefined>` to :ref:`W0301 <unnecessary-semicolon>`
 
 * remove rpython : remove all rpython checker, modules and tests
 
@@ -452,18 +452,18 @@ Release date: 2009-01-28
 
 * setuptools/easy_install support
 
-* include a modified version of Maarten ter Huurne patch to avoid W0613
+* include a modified version of Maarten ter Huurne patch to avoid :ref:`W0613 <unused-argument>`
   warning on arguments from overridden method
 
 * implement #5575  drop dumb W0704 message) by adding W0704 to ignored
   messages by default
 
-* new W0108 message, checking for suspicious lambda (provided by  Nathaniel
+* new :ref:`W0108 <unnecessary-lambda>` message, checking for suspicious lambda (provided by  Nathaniel
   Manista)
 
-* fix W0631, false positive reported by Paul Hachmann
+* fix :ref:`W0631 <undefined-loop-variable>`, false positive reported by Paul Hachmann
 
-* fix #6951: false positive with W0104
+* fix #6951: false positive with :ref:`W0104 <pointless-statement>`
 
 * fix #6949
 
@@ -481,7 +481,7 @@ What's New in Pylint 0.15.2?
 ============================
 Release date: 2008-10-13
 
-* fix #5672: W0706 weirdness ( W0706 removed )
+* fix #5672: :ref:`W0706 <try-except-raise>` weirdness (removed)
 
 * fix #5998: documentation points to wrong url for mailing list
 
@@ -532,10 +532,10 @@ Release date: 2008-01-14
 
 * fix a bug in colorized reporter, spotted by Dave Borowitz
 
-* applied patch from Stefan Rank to avoid W0410 false positive when
+* applied patch from Stefan Rank to avoid :ref:`W0410 <misplaced-future>` false positive when
   multiple "from __future__" import statements
 
-* implement #4012: flag back tick as deprecated (new W0333 message)
+* implement #4012: flag back tick as deprecated (new :ref:`W0333 <old-backtick>` message)
 
 * new ignored-class option on typecheck checker allowing to skip members
   checking based on class name (patch provided by Thomas W Barr)
@@ -568,18 +568,18 @@ Release date: 2007-02-28
   translator of the PyPy project. For more information about PyPy or
   RPython, visit https://www.pypy.org, previously codespeak.net/pypy/
 
-* new E0104 and E0105 messages introduced to respectively warn about
+* new :ref:`E0104 <return-outside-function>` and :ref:`E0105 <yield-outside-function>` messages introduced to respectively warn about
   "return" and "yield" outside function or method
 
-* new E0106 message when "yield" and "return something" are mixed in a
+* new :ref:`E0106 <return-arg-in-generator>` message when "yield" and "return something" are mixed in a
   function or method
 
-* new W0107 message for unnecessary pass statement
+* new :ref:`W0107 <unnecessary-pass>` message for unnecessary pass statement
 
-* new W0614 message to differentiate between unused ``import X`` and
+* new :ref:`W0614 <unused-wildcard-import>` message to differentiate between unused ``import X`` and
   unused `from X import *` (#3209, patch submitted by Daniel Drake)
 
-* included Daniel Drake's patch to have a different message E1003 instead of
+* included Daniel Drake's patch to have a different message :ref:`E1003 <bad-super-call>` instead of
   E1001 when a missing member is found but an inference failure has been
   detected
 
@@ -597,9 +597,9 @@ Release date: 2007-02-28
 
 * fix #3205: W0704 false positive
 
-* fix #3123: W0212 false positive on static method
+* fix #3123: :ref:`W0212 <protected-access>` false positive on static method
 
-* fix #2485: W0222 false positive
+* fix #2485: :ref:`W0222 <signature-differs>` false positive
 
 * fix #3259: when a message is explicitly enabled, check the checker
   emitting it is enabled
@@ -609,19 +609,19 @@ What's New in Pylint 0.12.2?
 ============================
 Release date: 2006-11-23
 
-* fix #3143: W0233 bug w/ YES objects
+* fix #3143: :ref:`W0233 <non-parent-init-called>` bug w/ YES objects
 
 * fix #3119: Off-by-one error counting lines in a file
 
 * fix #3117: ease sys.stdout overriding for reporters
 
-* fix #2508: E0601 false positive with lambda
+* fix #2508: :ref:`E0601 <used-before-assignment>` false positive with lambda
 
-* fix #3125: E1101 false positive and a message duplication. Only the last part
+* fix #3125: :ref:`E1101 <no-member>` false positive and a message duplication. Only the last part
   is actually fixed since the initial false positive is due to dynamic setting of
   attributes on the decimal.Context class.
 
-* fix #3149: E0101 false positives and introduced E0100 for generator __init__
+* fix #3149: :ref:`E0101 <return-in-init>` false positives and introduced :ref:`E0100 <init-is-generator>` for generator __init__
   methods
 
 * fixed some format checker false positives
@@ -657,15 +657,15 @@ Release date: 2006-08-10
 
 * started a reference user manual
 
-* new W0212 message for access to protected member from client code
+* new :ref:`W0212 <protected-access>` message for access to protected member from client code
   (Closes #14081)
 
-* new W0105 and W0106 messages extracted from W0104 (statement seems
+* new :ref:`W0105 <pointless-string-statement>` and :ref:`W0106 <expression-not-assigned>` messages extracted from :ref:`W0104 <pointless-statement>` (statement seems
   to have no effect) respectively when the statement is actually string
   (that's sometimes used instead of comments for documentation) or an
   empty  statement generated by a useless semicolon
 
-* reclassified W0302 to C0302
+* reclassified W0302 to :ref:`C0302 <too-many-lines>`
 
 * fix so that global messages are not anymore connected to the last
   analyzed module (Closes #10106)
@@ -681,7 +681,7 @@ Release date: 2006-04-19
 
 * fix crash caused by the exceptions checker in some case
 
-* fix some E1101 false positive with abstract method or classes defining
+* fix some :ref:`E1101 <no-member>` false positive with abstract method or classes defining
   __getattr__
 
 * dirty fix to avoid "_socketobject" has not "connect" member. The actual
@@ -706,24 +706,24 @@ Release date: 2006-03-06
 * this release require the 0.15 version of astng or superior (it will save
   you a lot of pylint crashes...)
 
-* W0705 has been reclassified to E0701, and is now detecting more
+* :ref:`W0705 <duplicate-except>` has been reclassified to :ref:`E0701 <bad-except-order>`, and is now detecting more
   inheriting problem, and a false positive when empty except clause is
   following an Exception catch has been fixed (Closes #10422)
 
 * E0212 and E0214 (metaclass/class method should have mcs/cls as first
-  argument have been reclassified to C0202 and C0203 since this not as
-  well established as "self" for instance method (E0213)
+  argument have been reclassified to :ref:`C0202 <bad-classmethod-argument>` and :ref:`C0203 <bad-mcs-method-argument>` since this not as
+  well established as "self" for instance method (:ref:`E0213 <no-self-argument>`)
 
 * W0224 has been reclassified into F0220 (failed to resolve interfaces
   implemented by a class)
 
 * a new typecheck checker, introducing the following checks:
 
-    - E1101, access to nonexistent member (implements #10430), remove
+    - :ref:`E1101 <no-member>`, access to nonexistent member (implements #10430), remove
       the need of E0201 and so some options has been moved from the
       classes checker to this one
-    - E1102, calling a non callable object
-    - E1111 and W1111 when an assignment is done on a function call but the
+    - :ref:`E1102 <not-callable>`, calling a non callable object
+    - :ref:`E1111 <assignment-from-no-return>` and :ref:`W1111 <old-assignment-from-none>` when an assignment is done on a function call but the
       inferred function returns None (implements #10431)
 
 * change in the base checker:
@@ -736,22 +736,22 @@ Release date: 2006-03-06
       #9146)
     - the C0101 check with its min-name-length option has
       been removed (this can be specified in the regxp after all...)
-    - W0103 and W0121 are now handled by the variables checker
-      (W0103 is now W0603 and W0604 has been split into different messages)
-    - W0131 and W0132 messages  have been reclassified to C0111 and
-      C0112 respectively
-    - new W0104 message on statement without effect
+    - W0103 and :ref:`W0121 <old-old-raise-syntax>` are now handled by the variables checker
+      (W0103 is now :ref:`W0603 <global-statement>` and :ref:`W0604 <global-at-module-level>` has been split into different messages)
+    - :ref:`W0131 <named-expr-without-context>` and :ref:`W0132 <old-empty-docstring>` messages  have been reclassified to :ref:`C0111 <missing-docstring>` and
+      :ref:`C0112 <empty-docstring>` respectively
+    - new :ref:`W0104 <pointless-statement>` message on statement without effect
 
 * regexp support for dummy-variables (dummy-variables-rgx option
   replace dummy-variables) (implements #10027)
 
-* better global statement handling, see W0602, W0603, W0604 messages
+* better global statement handling, see :ref:`W0602 <global-variable-not-assigned>`, :ref:`W0603 <global-statement>`, :ref:`W0604 <global-at-module-level>` messages
   (implements #10344 and #10236)
 
 * --debug-mode option, disabling all checkers without error message
   and filtering others to only display error
 
-* fixed some R0201 (method could be a function) false positive
+* fixed some :ref:`R0201 <old-no-self-use>` (method could be a function) false positive
 
 
 What's New in Pylint 0.9.0?
@@ -773,13 +773,13 @@ Release date: 2006-01-10
   before using the one specified in the PYLINTRC environment variable
   or the default ~/.pylintrc or /etc/pylintrc
 
-* fixed W0706 (Identifier used to raise an exception is assigned...)
+* fixed :ref:`W0706 <try-except-raise>` (Identifier used to raise an exception is assigned...)
   false positive and reraising a caught exception instance
 
-* fixed E0611 (No name get in module blabla) false positive when accessing
+* fixed :ref:`E0611 <no-name-in-module>` (No name get in module blabla) false positive when accessing
   to a class'__dict__
 
-* fixed some E0203 ("access to member before its definition") false
+* fixed some :ref:`E0203 <access-member-before-definition>` ("access to member before its definition") false
   positive
 
 * fixed E0214 ("metaclass method first argument should be mcs) false
@@ -787,11 +787,11 @@ Release date: 2006-01-10
 
 * fixed packaging which was missing the test/regrtest_data directory
 
-* W0212 (method could be a function) has been reclassified in the
-  REFACTOR category as R0201, and is no more considerer when a method
+* :ref:`W0212 <protected-access>` (method could be a function) has been reclassified in the
+  REFACTOR category as :ref:`R0201 <old-no-self-use>`, and is no more considerer when a method
   overrides an abstract method from an ancestor class
 
-* include module name in W0401 (wildcard import), as suggested by
+* include module name in :ref:`W0401 <wildcard-import>` (wildcard import), as suggested by
   Amaury
 
 * when using the '--parseable', path are written relative to the
@@ -825,10 +825,10 @@ What's New in Pylint 0.8.0?
 ============================
 Release date: 2005-10-21
 
-* check names imported from a module exists in the module (E0611),
+* check names imported from a module exists in the module (:ref:`E0611 <no-name-in-module>`),
   patch contributed by Amaury Forgeot d'Arc
 
-* print a warning (W0212) for methods that could be a function
+* print a warning (:ref:`W0212 <protected-access>`) for methods that could be a function
   (implements #9100)
 
 * new --defining-attr-methods option on classes checker
@@ -837,7 +837,7 @@ Release date: 2005-10-21
   --zope=yes to avoid false positive on acquired attributes (listed
   using this new option) (Closes #8616)
 
-* generate one E0602 for each use of an undefined variable
+* generate one :ref:`E0602 <undefined-variable>` for each use of an undefined variable
   (previously, only one for the first use but not for the following)
   (implements #1000)
 
@@ -845,7 +845,7 @@ Release date: 2005-10-21
 
 * fix Windows .bat file,  patch contributed by Amaury Forgeot d'Arc
 
-* fix one more false positive for E0601 (access before definition)
+* fix one more false positive for :ref:`E0601 <used-before-assignment>` (access before definition)
   with for loop such as "for i in range(10): print i" (test
   func_noerror_defined_and_used_on_same_line)
 
@@ -883,7 +883,7 @@ Release date: 2005-05-27
 
 * fix bug with --list-messages and python -OO
 
-* fix possible false positive for W0201
+* fix possible false positive for :ref:`W0201 <attribute-defined-outside-init>`
 
 
 What's New in Pylint 0.6.4?
@@ -896,7 +896,7 @@ Release date: 2005-04-14
 * don't fail if we are unable to read an inline option  (e.g. inside a
   module), just produce an information message (test func_i0010)
 
-* new message E0103 for break or continue outside loop (Closes #8883,
+* new message :ref:`E0103 <not-in-loop>` for break or continue outside loop (Closes #8883,
   test func_continue_not_in_loop)
 
 * fix bug in the variables checker, causing non detection of some
@@ -921,7 +921,7 @@ What's New in Pylint 0.6.3?
 Release date: 2005-02-24
 
 * fix scope problem which may cause false positive and true negative
-  on E0602
+  on :ref:`E0602 <undefined-variable>`
 
 * fix problem with some options such as disable-msg causing error when
   they are coming from the configuration file
@@ -934,10 +934,10 @@ Release date: 2005-02-16
 * fix false positive on E0201 ("access to undefined member") with
   metaclasses
 
-* fix false positive on E0203 ("access to member before its
+* fix false positive on :ref:`E0203 <access-member-before-definition>` ("access to member before its
   definition") when attributes are defined in a parent class
 
-* fix false positive on W0706 ("identifier used to raise an exception
+* fix false positive on :ref:`W0706 <try-except-raise>` ("identifier used to raise an exception
   assigned to...")
 
 * fix interpretation of ``\t`` as value for the indent-string
@@ -974,7 +974,7 @@ Release date: 2005-01-20
 * fix a bug which may cause crashes on resolving parent classes
 
 * fix problems with the format checker: don't chock on files
-  containing multiple CR, avoid C0322, C0323, C0324 false positives
+  containing multiple CR, avoid :ref:`C0322 <no-space-before-operator>`, :ref:`C0323 <no-space-after-operator>`, :ref:`C0324 <no-space-after-comma>` false positives
   with triple quoted string with quote inside
 
 * correctly detect access to member defined latter in __init__ method
@@ -1158,7 +1158,7 @@ Release date: 2003-11-20
 
 * read disable-msg and enable-msg options in source files (should be
   in comments on the top of the file, in the form
-  "# pylint: disable-msg=W0402"
+  "# pylint: disable-msg=:ref:`W0402 <old-deprecated-module>`"
 
 * new message for modules importing themselves instead of the "cyclic
   import" message

--- a/doc/whatsnew/0/0.x.rst
+++ b/doc/whatsnew/0/0.x.rst
@@ -48,7 +48,7 @@ Release date: 2013-02-26
 * #112728: add warning :ref:`E0604 <invalid-all-object>` for non-string objects in __all__
   (patch by Torsten Marek)
 
-* #120657: add warning W0110/deprecated-lambda when a map/filter
+* #120657: add warning :ref:`W0110/deprecated-lambda <deprecated-lambda>` when a map/filter
   of a lambda could be a comprehension (patch by Martin Pool)
 
 * #113231: logging checker now looks at instances of Logger classes
@@ -120,7 +120,7 @@ Release date: 2012-10-05
 * #104420: check for protocol completeness and avoid false :ref:`R0903 <too-few-public-methods>`
   (patch by Peter Hammond)
 
-* #100654: fix grammatical error for W0332 message (using 'l' as
+* #100654: fix grammatical error for :ref:`W0332 <lowercase-l-suffix>` message (using 'l' as
   long int identifier)
 
 * #103656: fix :ref:`W0231 <super-init-not-called>` false positive for missing call to object.__init__
@@ -580,7 +580,7 @@ Release date: 2007-02-28
   unused `from X import *` (#3209, patch submitted by Daniel Drake)
 
 * included Daniel Drake's patch to have a different message :ref:`E1003 <bad-super-call>` instead of
-  E1001 when a missing member is found but an inference failure has been
+  :ref:`E1001 <slots-on-old-class>` when a missing member is found but an inference failure has been
   detected
 
 * msvs reporter for Visual Studio line number reporting (#3285)

--- a/doc/whatsnew/0/0.x.rst
+++ b/doc/whatsnew/0/0.x.rst
@@ -21,7 +21,7 @@ Release date: 2013-04-25
 * #123285: apply pragmas for warnings attached to lines to physical source
   code lines
 
-* #123259: do not emit :ref:`E0105 <yield-outside-function>` for yield expressions inside lambdas
+* #123259: do not emit :ref:`yield-outside-function <yield-outside-function>` for yield expressions inside lambdas
 
 * #123892: don't crash when attempting to show source code line that can't
   be encoded with the current locale settings
@@ -42,13 +42,13 @@ Release date: 2013-02-26
   'disable-all' inline directive in favour of 'skip-file' (patch by
   A.Fayolle)
 
-* #110840: add messages :ref:`I0020 <suppressed-message>` and :ref:`I0021 <useless-suppression>` for reporting of suppressed
+* #110840: add messages :ref:`suppressed-message <suppressed-message>` and :ref:`useless-suppression <useless-suppression>` for reporting of suppressed
   messages and useless suppression pragmas. (patch by Torsten Marek)
 
-* #112728: add warning :ref:`E0604 <invalid-all-object>` for non-string objects in __all__
+* #112728: add warning :ref:`invalid-all-object <invalid-all-object>` for non-string objects in __all__
   (patch by Torsten Marek)
 
-* #120657: add warning :ref:`W0110/deprecated-lambda <deprecated-lambda>` when a map/filter
+* #120657: add warning :ref:`deprecated-lambda <deprecated-lambda>` when a map/filter
   of a lambda could be a comprehension (patch by Martin Pool)
 
 * #113231: logging checker now looks at instances of Logger classes
@@ -59,7 +59,7 @@ Release date: 2013-02-26
 
 * #110839: bind <F5> to Run button in pylint-gui
 
-* #115580: fix erroneous :ref:`W0212 <protected-access>` (access to protected member) on super call
+* #115580: fix erroneous :ref:`protected-access <protected-access>` (access to protected member) on super call
   (patch by Martin Pool)
 
 * #110853: fix a crash when an __init__ method in a base class has been
@@ -82,7 +82,7 @@ Release date: 2013-02-26
 
 * #120635: redefine cmp function used in pylint.reporters
 
-* Include full warning id for :ref:`I0020 <suppressed-message>` and :ref:`I0021 <useless-suppression>` and make sure to flush
+* Include full warning id for :ref:`suppressed-message <suppressed-message>` and :ref:`useless-suppression <useless-suppression>` and make sure to flush
   warnings after each module, not at the end of the pylint run.
   (patch by Torsten Marek)
 
@@ -104,26 +104,26 @@ Release date: 2012-10-05
   and 'symilar' command line tool (patch by Ry4an Brase)
 
 * #104571: check for anomalous backslash escape, introducing new
-  :ref:`W1401 <anomalous-backslash-in-string>` and :ref:`W1402 <anomalous-unicode-escape-in-string>` messages (patch by Martin Pool)
+  :ref:`anomalous-backslash-in-string <anomalous-backslash-in-string>` and :ref:`anomalous-unicode-escape-in-string <anomalous-unicode-escape-in-string>` messages (patch by Martin Pool)
 
 * #100707: check for boolop being used as exception class, introducing
-  new :ref:`W0711 <binary-op-exception>` message (patch by Tim Hatch)
+  new :ref:`binary-op-exception <binary-op-exception>` message (patch by Tim Hatch)
 
 * #4014: improve checking of metaclass methods first args, introducing
-  new :ref:`C0204 <bad-mcs-classmethod-argument>` message (patch by lothiraldan@gmail.com finalized by sthenault)
+  new :ref:`bad-mcs-classmethod-argument <bad-mcs-classmethod-argument>` message (patch by lothiraldan@gmail.com finalized by sthenault)
 
 * #4685: check for consistency of a module's __all__ variable,
-  introducing new :ref:`E0603 <undefined-all-variable>` message
+  introducing new :ref:`undefined-all-variable <undefined-all-variable>` message
 
 * #105337: allow custom reporter in output-format (patch by Kevin Jing Qiu)
 
-* #104420: check for protocol completeness and avoid false :ref:`R0903 <too-few-public-methods>`
+* #104420: check for protocol completeness and avoid false :ref:`too-few-public-methods <too-few-public-methods>`
   (patch by Peter Hammond)
 
-* #100654: fix grammatical error for :ref:`W0332 <lowercase-l-suffix>` message (using 'l' as
+* #100654: fix grammatical error for :ref:`lowercase-l-suffix <lowercase-l-suffix>` message (using 'l' as
   long int identifier)
 
-* #103656: fix :ref:`W0231 <super-init-not-called>` false positive for missing call to object.__init__
+* #103656: fix :ref:`super-init-not-called <super-init-not-called>` false positive for missing call to object.__init__
   (patch by lothiraldan@gmail.com)
 
 * #63424: fix similarity report disabling by properly renaming it to RP0801
@@ -145,19 +145,19 @@ Release date: 2012-07-17
   except handler contains a tuple of names instead of a single name.
   (patch by tmarek@google.com)
 
-* #7394: :ref:`W0212 <protected-access>` (access to protected member) not emitted on assignments
+* #7394: :ref:`protected-access <protected-access>` (access to protected member) not emitted on assignments
   (patch by lothiraldan@gmail.com)
 
 * #18772; no prototype consistency check for mangled methods (patch by
   lothiraldan@gmail.com)
 
-* #92911: emit :ref:`W0102 <dangerous-default-value>` when sets are used as default arguments in functions
+* #92911: emit :ref:`dangerous-default-value <dangerous-default-value>` when sets are used as default arguments in functions
   (patch by tmarek@google.com)
 
-* #77982: do not emit :ref:`E0602 <undefined-variable>` for loop variables of comprehensions
+* #77982: do not emit :ref:`undefined-variable <undefined-variable>` for loop variables of comprehensions
   used as argument values inside a decorator (patch by tmarek@google.com)
 
-* #89092: don't emit :ref:`E0202 <method-hidden>` (attribute hiding a method) on @property methods
+* #89092: don't emit :ref:`method-hidden <method-hidden>` (attribute hiding a method) on @property methods
 
 * #92584: fix pylint-gui crash due to internal API change
 
@@ -177,13 +177,13 @@ Release date: 2011-12-08
 * #81078: Warn if names in  exception handlers clobber overwrite
   existing names (patch by tmarek@google.com)
 
-* #81113: Fix :ref:`W0702 <bare-except>` messages appearing with the wrong line number.
+* #81113: Fix :ref:`bare-except <bare-except>` messages appearing with the wrong line number.
   (patch by tmarek@google.com)
 
 * #50461, #52020, #51222: Do not issue warnings when using 2.6's
   property.setter/deleter functionality (patch by dneil@google.com)
 
-* #9188, #4024: Do not trigger :ref:`W0631 <undefined-loop-variable>` if a loop variable is assigned
+* #9188, #4024: Do not trigger :ref:`undefined-loop-variable <undefined-loop-variable>` if a loop variable is assigned
   in the else branch of a for loop.
 
 
@@ -205,7 +205,7 @@ Release date: 2011-10-7
 
 * #76920: crash if on e.g. "pylint --rcfile" (patch by Torsten Marek)
 
-* #77237: warning for :ref:`E0202 <method-hidden>` may be very misleading
+* #77237: warning for :ref:`method-hidden <method-hidden>` may be very misleading
 
 * #73941: HTML report messages table is badly rendered
 
@@ -246,13 +246,13 @@ Release date: 2011-01-11
 
 * finalize python3 support
 
-* new :ref:`W0106 <expression-not-assigned>` warning 'Expression "%s" is assigned to nothing'
+* new :ref:`expression-not-assigned <expression-not-assigned>` warning 'Expression "%s" is assigned to nothing'
 
 * drop E0501 and E0502 messages about wrong source encoding: not anymore
   interesting since it's a syntax error for python >= 2.5 and we now only
   support this python version and above.
 
-* don't emit :ref:`W0221 <arguments-differ>` or :ref:`W0222 <signature-differs>` when methods as variable arguments (e.g. \*arg
+* don't emit :ref:`arguments-differ <arguments-differ>` or :ref:`signature-differs <signature-differs>` when methods as variable arguments (e.g. \*arg
   and/or \*\*args). Patch submitted by Charles Duffy.
 
 
@@ -323,7 +323,7 @@ Release date: 2010-05-11
 
 * fix #21591: html reporter produces no output if reports is set to 'no'
 
-* fix #4581: not Missing docstring (:ref:`C0111 <missing-docstring>`) warning if a method is overridden
+* fix #4581: no :ref:`missing-docstring <missing-docstring>` warning if a method is overridden
 
 * fix #4683: Non-ASCII characters count double if utf8 encode
 
@@ -346,9 +346,9 @@ Release date: 2010-03-01
 * fix #19339: pylint.el : non existing py-mod-map
   (closes Debian Bug report logs - #475939)
 
-* implement #18860, new :ref:`W0199 <assert-on-tuple>` message on assert (a, b)
+* implement #18860, new :ref:`assert-on-tuple <assert-on-tuple>` message on assert (a, b)
 
-* implement #9776, ':ref:`W0150 <lost-exception>`' break or return statement in finally block may
+* implement #9776, :ref:`lost-exception <lost-exception>`: break or return statement in finally block may
   swallow exception.
 
 * fix #9263, __init__ and __new__ are checked for unused arguments
@@ -357,13 +357,13 @@ Release date: 2010-03-01
 
 * fix #5975, Abstract intermediate class not recognized as such
 
-* fix #5977, yield and return statement have their own counters, no more :ref:`R0911 <too-many-return-statements>`
+* fix #5977, yield and return statement have their own counters, no more :ref:`too-many-return-statements <too-many-return-statements>`
   (Too many return statements) when a function have many yield stamtements
 
 * implement #5564, function / method arguments with leading "_" are ignored in
   arguments / local variables count.
 
-* implement #9982, :ref:`E0711 <notimplemented-raised>` specific error message when raising NotImplemented
+* implement #9982, :ref:`notimplemented-raised <notimplemented-raised>` specific error message when raising NotImplemented
 
 * remove --cache-size option
 
@@ -388,7 +388,7 @@ Release date: 2009-12-18
 
 * refactor and fix the imports checker
 
-* fix #18862: :ref:`E0601 <used-before-assignment>` false positive with lambda functions
+* fix #18862: :ref:`used-before-assignment <used-before-assignment>` false positive with lambda functions
 
 * fix #8764: More than one statement on a single line false positive with
   try/except/finally
@@ -408,20 +408,20 @@ Release date: 2009-03-25
 
 * tests ok with python 2.4, 2.5, 2.6. 2.3 not tested
 
-* fix #8687, :ref:`W0613 <unused-argument>` false positive on inner function
+* fix #8687, :ref:`unused-argument <unused-argument>` false positive on inner function
 
-* fix #8350, :ref:`C0322 <no-space-before-operator>` false positive on multi-line string
+* fix #8350, :ref:`no-space-before-operator <no-space-before-operator>` false positive on multi-line string
 
 * fix #8332: set E0501 line no to the first line where non ascii character
   has been found
 
-* avoid some :ref:`E0203 <access-member-before-definition>` / :ref:`E0602 <undefined-variable>` false negatives by detecting respectively
+* avoid some :ref:`access-member-before-definition <access-member-before-definition>` / :ref:`undefined-variable <undefined-variable>` false negatives by detecting respectively
   AttributeError / NameError
 
-* implements #4037: don't issue :ref:`W0142 <star-args>` (* or ** magic) when they are barely
+* implements #4037: don't issue :ref:`star-args <star-args>` (* or ** magic) when they are barely
   passed from */** arguments
 
-* complete #5573: more complete list of special methods, also skip :ref:`W0613 <unused-argument>`
+* complete #5573: more complete list of special methods, also skip :ref:`unused-argument <unused-argument>`
   for python internal method
 
 * don't show information messages by default
@@ -433,7 +433,7 @@ What's New in Pylint 0.17.0?
 ============================
 Release date: 2009-03-19
 
-* semicolon check : move :ref:`W0601 <global-variable-undefined>` to :ref:`W0301 <unnecessary-semicolon>`
+* semicolon check : move W0601 to W0301
 
 * remove rpython : remove all rpython checker, modules and tests
 
@@ -452,18 +452,18 @@ Release date: 2009-01-28
 
 * setuptools/easy_install support
 
-* include a modified version of Maarten ter Huurne patch to avoid :ref:`W0613 <unused-argument>`
+* include a modified version of Maarten ter Huurne patch to avoid :ref:`unused-argument <unused-argument>`
   warning on arguments from overridden method
 
 * implement #5575  drop dumb W0704 message) by adding W0704 to ignored
   messages by default
 
-* new :ref:`W0108 <unnecessary-lambda>` message, checking for suspicious lambda (provided by  Nathaniel
+* new :ref:`unnecessary-lambda <unnecessary-lambda>` message, checking for suspicious lambda (provided by  Nathaniel
   Manista)
 
-* fix :ref:`W0631 <undefined-loop-variable>`, false positive reported by Paul Hachmann
+* fix :ref:`undefined-loop-variable <undefined-loop-variable>`, false positive reported by Paul Hachmann
 
-* fix #6951: false positive with :ref:`W0104 <pointless-statement>`
+* fix #6951: false positive with :ref:`pointless-statement <pointless-statement>`
 
 * fix #6949
 
@@ -481,7 +481,7 @@ What's New in Pylint 0.15.2?
 ============================
 Release date: 2008-10-13
 
-* fix #5672: :ref:`W0706 <try-except-raise>` weirdness (removed)
+* fix #5672: :ref:`try-except-raise <try-except-raise>` weirdness (the message was removed)
 
 * fix #5998: documentation points to wrong url for mailing list
 
@@ -532,10 +532,10 @@ Release date: 2008-01-14
 
 * fix a bug in colorized reporter, spotted by Dave Borowitz
 
-* applied patch from Stefan Rank to avoid :ref:`W0410 <misplaced-future>` false positive when
+* applied patch from Stefan Rank to avoid :ref:`misplaced-future <misplaced-future>` false positive when
   multiple "from __future__" import statements
 
-* implement #4012: flag back tick as deprecated (new :ref:`W0333 <old-backtick>` message)
+* implement #4012: flag back tick as deprecated (new :ref:`old-backtick <old-backtick>` message)
 
 * new ignored-class option on typecheck checker allowing to skip members
   checking based on class name (patch provided by Thomas W Barr)
@@ -568,19 +568,19 @@ Release date: 2007-02-28
   translator of the PyPy project. For more information about PyPy or
   RPython, visit https://www.pypy.org, previously codespeak.net/pypy/
 
-* new :ref:`E0104 <return-outside-function>` and :ref:`E0105 <yield-outside-function>` messages introduced to respectively warn about
+* new :ref:`return-outside-function <return-outside-function>` and :ref:`yield-outside-function <yield-outside-function>` messages introduced to respectively warn about
   "return" and "yield" outside function or method
 
-* new :ref:`E0106 <return-arg-in-generator>` message when "yield" and "return something" are mixed in a
+* new :ref:`return-arg-in-generator <return-arg-in-generator>` message when "yield" and "return something" are mixed in a
   function or method
 
-* new :ref:`W0107 <unnecessary-pass>` message for unnecessary pass statement
+* new :ref:`unnecessary-pass <unnecessary-pass>` message for unnecessary pass statement
 
-* new :ref:`W0614 <unused-wildcard-import>` message to differentiate between unused ``import X`` and
+* new :ref:`unused-wildcard-import <unused-wildcard-import>` message to differentiate between unused ``import X`` and
   unused `from X import *` (#3209, patch submitted by Daniel Drake)
 
-* included Daniel Drake's patch to have a different message :ref:`E1003 <bad-super-call>` instead of
-  :ref:`E1001 <slots-on-old-class>` when a missing member is found but an inference failure has been
+* included Daniel Drake's patch to have a different message :ref:`bad-super-call <bad-super-call>` instead of
+  :ref:`slots-on-old-class <slots-on-old-class>` when a missing member is found but an inference failure has been
   detected
 
 * msvs reporter for Visual Studio line number reporting (#3285)
@@ -597,9 +597,9 @@ Release date: 2007-02-28
 
 * fix #3205: W0704 false positive
 
-* fix #3123: :ref:`W0212 <protected-access>` false positive on static method
+* fix #3123: :ref:`protected-access <protected-access>` false positive on static method
 
-* fix #2485: :ref:`W0222 <signature-differs>` false positive
+* fix #2485: :ref:`signature-differs <signature-differs>` false positive
 
 * fix #3259: when a message is explicitly enabled, check the checker
   emitting it is enabled
@@ -609,19 +609,19 @@ What's New in Pylint 0.12.2?
 ============================
 Release date: 2006-11-23
 
-* fix #3143: :ref:`W0233 <non-parent-init-called>` bug w/ YES objects
+* fix #3143: :ref:`non-parent-init-called <non-parent-init-called>` bug w/ YES objects
 
 * fix #3119: Off-by-one error counting lines in a file
 
 * fix #3117: ease sys.stdout overriding for reporters
 
-* fix #2508: :ref:`E0601 <used-before-assignment>` false positive with lambda
+* fix #2508: :ref:`used-before-assignment <used-before-assignment>` false positive with lambda
 
-* fix #3125: :ref:`E1101 <no-member>` false positive and a message duplication. Only the last part
+* fix #3125: :ref:`no-member <no-member>` false positive and a message duplication. Only the last part
   is actually fixed since the initial false positive is due to dynamic setting of
   attributes on the decimal.Context class.
 
-* fix #3149: :ref:`E0101 <return-in-init>` false positives and introduced :ref:`E0100 <init-is-generator>` for generator __init__
+* fix #3149: :ref:`return-in-init <return-in-init>` false positives and introduced :ref:`init-is-generator <init-is-generator>` for generator __init__
   methods
 
 * fixed some format checker false positives
@@ -657,15 +657,15 @@ Release date: 2006-08-10
 
 * started a reference user manual
 
-* new :ref:`W0212 <protected-access>` message for access to protected member from client code
+* new :ref:`protected-access <protected-access>` message for access to protected member from client code
   (Closes #14081)
 
-* new :ref:`W0105 <pointless-string-statement>` and :ref:`W0106 <expression-not-assigned>` messages extracted from :ref:`W0104 <pointless-statement>` (statement seems
+* new :ref:`pointless-string-statement <pointless-string-statement>` and :ref:`expression-not-assigned <expression-not-assigned>` messages extracted from :ref:`pointless-statement <pointless-statement>` (statement seems
   to have no effect) respectively when the statement is actually string
   (that's sometimes used instead of comments for documentation) or an
   empty  statement generated by a useless semicolon
 
-* reclassified W0302 to :ref:`C0302 <too-many-lines>`
+* reclassified W0302 to C0302
 
 * fix so that global messages are not anymore connected to the last
   analyzed module (Closes #10106)
@@ -681,7 +681,7 @@ Release date: 2006-04-19
 
 * fix crash caused by the exceptions checker in some case
 
-* fix some :ref:`E1101 <no-member>` false positive with abstract method or classes defining
+* fix some :ref:`no-member <no-member>` false positive with abstract method or classes defining
   __getattr__
 
 * dirty fix to avoid "_socketobject" has not "connect" member. The actual
@@ -706,24 +706,24 @@ Release date: 2006-03-06
 * this release require the 0.15 version of astng or superior (it will save
   you a lot of pylint crashes...)
 
-* :ref:`W0705 <duplicate-except>` has been reclassified to :ref:`E0701 <bad-except-order>`, and is now detecting more
+* W0705 has been reclassified to E0701, and is now detecting more
   inheriting problem, and a false positive when empty except clause is
   following an Exception catch has been fixed (Closes #10422)
 
 * E0212 and E0214 (metaclass/class method should have mcs/cls as first
-  argument have been reclassified to :ref:`C0202 <bad-classmethod-argument>` and :ref:`C0203 <bad-mcs-method-argument>` since this not as
-  well established as "self" for instance method (:ref:`E0213 <no-self-argument>`)
+  argument have been reclassified to C0202 and C0203 since this not as
+  well established as "self" for instance method (E0213)
 
 * W0224 has been reclassified into F0220 (failed to resolve interfaces
   implemented by a class)
 
 * a new typecheck checker, introducing the following checks:
 
-    - :ref:`E1101 <no-member>`, access to nonexistent member (implements #10430), remove
+    - :ref:`no-member <no-member>`, access to nonexistent member (implements #10430), remove
       the need of E0201 and so some options has been moved from the
       classes checker to this one
-    - :ref:`E1102 <not-callable>`, calling a non callable object
-    - :ref:`E1111 <assignment-from-no-return>` and :ref:`W1111 <old-assignment-from-none>` when an assignment is done on a function call but the
+    - :ref:`not-callable <not-callable>`, calling a non callable object
+    - :ref:`assignment-from-no-return <assignment-from-no-return>` and :ref:`old-assignment-from-none <old-assignment-from-none>` when an assignment is done on a function call but the
       inferred function returns None (implements #10431)
 
 * change in the base checker:
@@ -736,22 +736,22 @@ Release date: 2006-03-06
       #9146)
     - the C0101 check with its min-name-length option has
       been removed (this can be specified in the regxp after all...)
-    - W0103 and :ref:`W0121 <old-old-raise-syntax>` are now handled by the variables checker
-      (W0103 is now :ref:`W0603 <global-statement>` and :ref:`W0604 <global-at-module-level>` has been split into different messages)
-    - :ref:`W0131 <named-expr-without-context>` and :ref:`W0132 <old-empty-docstring>` messages  have been reclassified to :ref:`C0111 <missing-docstring>` and
-      :ref:`C0112 <empty-docstring>` respectively
-    - new :ref:`W0104 <pointless-statement>` message on statement without effect
+    - W0103 and W0121 are now handled by the variables checker
+      (W0103 is now W0603 and W0604 has been split into different messages)
+    - W0131 and W0132 messages  have been reclassified to C0111 and
+      C0112 respectively
+    - new :ref:`pointless-statement <pointless-statement>` message on statement without effect
 
 * regexp support for dummy-variables (dummy-variables-rgx option
   replace dummy-variables) (implements #10027)
 
-* better global statement handling, see :ref:`W0602 <global-variable-not-assigned>`, :ref:`W0603 <global-statement>`, :ref:`W0604 <global-at-module-level>` messages
+* better global statement handling, see :ref:`global-variable-not-assigned <global-variable-not-assigned>`, :ref:`global-statement <global-statement>`, :ref:`global-at-module-level <global-at-module-level>` messages
   (implements #10344 and #10236)
 
 * --debug-mode option, disabling all checkers without error message
   and filtering others to only display error
 
-* fixed some :ref:`R0201 <old-no-self-use>` (method could be a function) false positive
+* fixed some :ref:`old-no-self-use <old-no-self-use>` (method could be a function) false positive
 
 
 What's New in Pylint 0.9.0?
@@ -773,13 +773,13 @@ Release date: 2006-01-10
   before using the one specified in the PYLINTRC environment variable
   or the default ~/.pylintrc or /etc/pylintrc
 
-* fixed :ref:`W0706 <try-except-raise>` (Identifier used to raise an exception is assigned...)
+* fixed :ref:`try-except-raise <try-except-raise>` (Identifier used to raise an exception is assigned...)
   false positive and reraising a caught exception instance
 
-* fixed :ref:`E0611 <no-name-in-module>` (No name get in module blabla) false positive when accessing
+* fixed :ref:`no-name-in-module <no-name-in-module>` (No name get in module blabla) false positive when accessing
   to a class'__dict__
 
-* fixed some :ref:`E0203 <access-member-before-definition>` ("access to member before its definition") false
+* fixed some :ref:`access-member-before-definition <access-member-before-definition>` ("access to member before its definition") false
   positive
 
 * fixed E0214 ("metaclass method first argument should be mcs) false
@@ -787,11 +787,11 @@ Release date: 2006-01-10
 
 * fixed packaging which was missing the test/regrtest_data directory
 
-* :ref:`W0212 <protected-access>` (method could be a function) has been reclassified in the
-  REFACTOR category as :ref:`R0201 <old-no-self-use>`, and is no more considerer when a method
+* W0212 (method could be a function) has been reclassified in the
+  REFACTOR category as R0201, and is no more considerer when a method
   overrides an abstract method from an ancestor class
 
-* include module name in :ref:`W0401 <wildcard-import>` (wildcard import), as suggested by
+* include module name in :ref:`wildcard-import <wildcard-import>` (wildcard import), as suggested by
   Amaury
 
 * when using the '--parseable', path are written relative to the
@@ -825,10 +825,10 @@ What's New in Pylint 0.8.0?
 ============================
 Release date: 2005-10-21
 
-* check names imported from a module exists in the module (:ref:`E0611 <no-name-in-module>`),
+* check names imported from a module exists in the module (:ref:`no-name-in-module <no-name-in-module>`),
   patch contributed by Amaury Forgeot d'Arc
 
-* print a warning (:ref:`W0212 <protected-access>`) for methods that could be a function
+* print a warning (W0212) for methods that could be a function
   (implements #9100)
 
 * new --defining-attr-methods option on classes checker
@@ -837,7 +837,7 @@ Release date: 2005-10-21
   --zope=yes to avoid false positive on acquired attributes (listed
   using this new option) (Closes #8616)
 
-* generate one :ref:`E0602 <undefined-variable>` for each use of an undefined variable
+* generate one :ref:`undefined-variable <undefined-variable>` for each use of an undefined variable
   (previously, only one for the first use but not for the following)
   (implements #1000)
 
@@ -845,7 +845,7 @@ Release date: 2005-10-21
 
 * fix Windows .bat file,  patch contributed by Amaury Forgeot d'Arc
 
-* fix one more false positive for :ref:`E0601 <used-before-assignment>` (access before definition)
+* fix one more false positive for :ref:`used-before-assignment <used-before-assignment>` (access before definition)
   with for loop such as "for i in range(10): print i" (test
   func_noerror_defined_and_used_on_same_line)
 
@@ -883,7 +883,7 @@ Release date: 2005-05-27
 
 * fix bug with --list-messages and python -OO
 
-* fix possible false positive for :ref:`W0201 <attribute-defined-outside-init>`
+* fix possible false positive for :ref:`attribute-defined-outside-init <attribute-defined-outside-init>`
 
 
 What's New in Pylint 0.6.4?
@@ -896,7 +896,7 @@ Release date: 2005-04-14
 * don't fail if we are unable to read an inline option  (e.g. inside a
   module), just produce an information message (test func_i0010)
 
-* new message :ref:`E0103 <not-in-loop>` for break or continue outside loop (Closes #8883,
+* new message :ref:`not-in-loop <not-in-loop>` for break or continue outside loop (Closes #8883,
   test func_continue_not_in_loop)
 
 * fix bug in the variables checker, causing non detection of some
@@ -921,7 +921,7 @@ What's New in Pylint 0.6.3?
 Release date: 2005-02-24
 
 * fix scope problem which may cause false positive and true negative
-  on :ref:`E0602 <undefined-variable>`
+  on :ref:`undefined-variable <undefined-variable>`
 
 * fix problem with some options such as disable-msg causing error when
   they are coming from the configuration file
@@ -934,10 +934,10 @@ Release date: 2005-02-16
 * fix false positive on E0201 ("access to undefined member") with
   metaclasses
 
-* fix false positive on :ref:`E0203 <access-member-before-definition>` ("access to member before its
+* fix false positive on :ref:`access-member-before-definition <access-member-before-definition>` ("access to member before its
   definition") when attributes are defined in a parent class
 
-* fix false positive on :ref:`W0706 <try-except-raise>` ("identifier used to raise an exception
+* fix false positive on :ref:`try-except-raise <try-except-raise>` ("identifier used to raise an exception
   assigned to...")
 
 * fix interpretation of ``\t`` as value for the indent-string
@@ -974,7 +974,7 @@ Release date: 2005-01-20
 * fix a bug which may cause crashes on resolving parent classes
 
 * fix problems with the format checker: don't chock on files
-  containing multiple CR, avoid :ref:`C0322 <no-space-before-operator>`, :ref:`C0323 <no-space-after-operator>`, :ref:`C0324 <no-space-after-comma>` false positives
+  containing multiple CR, avoid :ref:`no-space-before-operator <no-space-before-operator>`, :ref:`no-space-after-operator <no-space-after-operator>`, :ref:`no-space-after-comma <no-space-after-comma>` false positives
   with triple quoted string with quote inside
 
 * correctly detect access to member defined latter in __init__ method
@@ -1158,7 +1158,7 @@ Release date: 2003-11-20
 
 * read disable-msg and enable-msg options in source files (should be
   in comments on the top of the file, in the form
-  "# pylint: disable-msg=:ref:`W0402 <old-deprecated-module>`"
+  "# pylint: disable-msg=W0402"
 
 * new message for modules importing themselves instead of the "cyclic
   import" message

--- a/doc/whatsnew/0/0.x.rst
+++ b/doc/whatsnew/0/0.x.rst
@@ -29,7 +29,7 @@ Release date: 2013-04-25
 * Simplify checks for dangerous default values by unifying tests for all
   different mutable compound literals.
 
-* Improve the description for :ref:`redundant-keyword-arg`
+* Improve the description for :ref:`redundant-keyword-arg <redundant-keyword-arg>`
 
 
 What's New in Pylint 0.27.0?

--- a/doc/whatsnew/1/1.0.rst
+++ b/doc/whatsnew/1/1.0.rst
@@ -52,7 +52,7 @@ Release date: 2013-08-06
 * New warning :ref:`trailing-whitespace` that warns about
   trailing whitespace.
 
-* Added a new warning :ref:`unpacking-in-except <unpacking-in-except>` (:ref:`W0712 <old-unpacking-in-except>`) about unpacking
+* Added a new warning :ref:`unpacking-in-except <unpacking-in-except>` about unpacking
   exceptions in handlers, which is unsupported in Python 3.
 
 * Add a configuration option for :ref:`missing-docstring` to
@@ -78,7 +78,7 @@ Release date: 2013-08-06
 
 * Do not flag names in nested with statements as undefined.
 
-* Added a new warning ':ref:`old-raise-syntax <old-raise-syntax>`' for the deprecated syntax
+* Added a new warning :ref:`old-raise-syntax <old-raise-syntax>` for the deprecated syntax
   raise Exception, args
 
 * Support for PEP 3102 and new :ref:`missing-kwoa` message for missing
@@ -102,7 +102,7 @@ Release date: 2013-08-06
 
   Closes BitBucket #25
 
-* Fix False positive :ref:`E1003 <bad-super-call>` on Python 3 for argument-less super()
+* Fix False positive :ref:`bad-super-call <bad-super-call>` on Python 3 for argument-less super()
 
   Closes BitBucket #16
 

--- a/doc/whatsnew/1/1.0.rst
+++ b/doc/whatsnew/1/1.0.rst
@@ -19,7 +19,7 @@ Release date: 2013-08-06
 * Do not double-check parameter names with the regex for parameters and
   inline variables.
 
-* Added a new warning :ref:`missing-final-newline` for files missing
+* Added a new warning :ref:`missing-final-newline <missing-final-newline>` for files missing
   the final newline.
 
 * Methods that are decorated as properties are now treated as attributes
@@ -34,13 +34,13 @@ Release date: 2013-08-06
   pylint can detect that value on the right-hand side is a class
   (like collections.namedtuple()).
 
-* Simplified :ref:`invalid-name` message
+* Simplified :ref:`invalid-name <invalid-name>` message
 
 * Added a new warning invalid-encoded-data (W0512) for files that
   contain data that cannot be decoded with the specified or
   default encoding.
 
-* New warning :ref:`bad-open-mode` for calls to open (or file) that
+* New warning :ref:`bad-open-mode <bad-open-mode>` for calls to open (or file) that
   specify invalid open modes (Original implementation by Sasha Issayev).
 
 * New warning :ref:`old-style-class <old-style-class>` for classes that do not have any
@@ -49,18 +49,18 @@ Release date: 2013-08-06
 * Add new name type 'class_attribute' for attributes defined
   in class scope. By default, allow both const and variable names.
 
-* New warning :ref:`trailing-whitespace` that warns about
+* New warning :ref:`trailing-whitespace <trailing-whitespace>` that warns about
   trailing whitespace.
 
 * Added a new warning :ref:`unpacking-in-except <unpacking-in-except>` about unpacking
   exceptions in handlers, which is unsupported in Python 3.
 
-* Add a configuration option for :ref:`missing-docstring` to
+* Add a configuration option for :ref:`missing-docstring <missing-docstring>` to
   optionally exempt short functions/methods/classes from
   the check.
 
-* Add the type of the offending node to :ref:`missing-docstring`
-  and :ref:`empty-docstring`.
+* Add the type of the offending node to :ref:`missing-docstring <missing-docstring>`
+  and :ref:`empty-docstring <empty-docstring>`.
 
 * New utility classes for per-checker unittests in testutils.py
 
@@ -70,7 +70,7 @@ Release date: 2013-08-06
 * Do not treat all variables starting with _ as dummy variables,
   only _ itself.
 
-* Make the :ref:`line-too-long` warning configurable by adding a regex for lines
+* Make the :ref:`line-too-long <line-too-long>` warning configurable by adding a regex for lines
   for with the length limit should not be enforced
 
 * Do not warn about a long line if a pylint disable
@@ -81,7 +81,7 @@ Release date: 2013-08-06
 * Added a new warning :ref:`old-raise-syntax <old-raise-syntax>` for the deprecated syntax
   raise Exception, args
 
-* Support for PEP 3102 and new :ref:`missing-kwoa` message for missing
+* Support for PEP 3102 and new :ref:`missing-kwoa <missing-kwoa>` message for missing
   mandatory keyword argument
 
   Closes Logilab #107788

--- a/doc/whatsnew/1/1.0.rst
+++ b/doc/whatsnew/1/1.0.rst
@@ -43,7 +43,7 @@ Release date: 2013-08-06
 * New warning :ref:`bad-open-mode` for calls to open (or file) that
   specify invalid open modes (Original implementation by Sasha Issayev).
 
-* New warning old-style-class (C1001) for classes that do not have any
+* New warning :ref:`old-style-class <old-style-class>` for classes that do not have any
   base class.
 
 * Add new name type 'class_attribute' for attributes defined

--- a/doc/whatsnew/1/1.0.rst
+++ b/doc/whatsnew/1/1.0.rst
@@ -52,7 +52,7 @@ Release date: 2013-08-06
 * New warning :ref:`trailing-whitespace` that warns about
   trailing whitespace.
 
-* Added a new warning unpacking-in-except (W0712) about unpacking
+* Added a new warning :ref:`unpacking-in-except <unpacking-in-except>` (:ref:`W0712 <old-unpacking-in-except>`) about unpacking
   exceptions in handlers, which is unsupported in Python 3.
 
 * Add a configuration option for :ref:`missing-docstring` to
@@ -78,7 +78,7 @@ Release date: 2013-08-06
 
 * Do not flag names in nested with statements as undefined.
 
-* Added a new warning 'old-raise-syntax' for the deprecated syntax
+* Added a new warning ':ref:`old-raise-syntax <old-raise-syntax>`' for the deprecated syntax
   raise Exception, args
 
 * Support for PEP 3102 and new :ref:`missing-kwoa` message for missing
@@ -102,7 +102,7 @@ Release date: 2013-08-06
 
   Closes BitBucket #25
 
-* Fix False positive E1003 on Python 3 for argument-less super()
+* Fix False positive :ref:`E1003 <bad-super-call>` on Python 3 for argument-less super()
 
   Closes BitBucket #16
 

--- a/doc/whatsnew/1/1.1.rst
+++ b/doc/whatsnew/1/1.1.rst
@@ -12,8 +12,8 @@ Release date: 2013-12-22
 
   Closes #111
 
-* Combine ':ref:`no-space-after-operator <no-space-after-operator>`', ':ref:`no-space-after-comma <no-space-after-comma>`' and
-  ':ref:`no-space-before-operator <no-space-before-operator>`' into a new warning ':ref:`bad-whitespace <bad-whitespace>`'.
+* Combine :ref:`no-space-after-operator <no-space-after-operator>`, :ref:`no-space-after-comma <no-space-after-comma>` and
+  :ref:`no-space-before-operator <no-space-before-operator>` into a new warning :ref:`bad-whitespace <bad-whitespace>`.
 
 * Add a new warning :ref:`superfluous-parens` for unnecessary
   parentheses after certain keywords.

--- a/doc/whatsnew/1/1.1.rst
+++ b/doc/whatsnew/1/1.1.rst
@@ -4,10 +4,10 @@
 
 Release date: 2013-12-22
 
-* Add new check for use of :ref:`deprecated-pragma` directives "pylint:disable-msg"
+* Add new check for use of :ref:`deprecated-pragma <deprecated-pragma>` directives "pylint:disable-msg"
   or "pylint:enable-msg" which was previously emitted as a regular warn().
 
-* Avoid false :ref:`used-before-assignment` for except handler defined
+* Avoid false :ref:`used-before-assignment <used-before-assignment>` for except handler defined
   identifier used on the same line.
 
   Closes #111
@@ -15,7 +15,7 @@ Release date: 2013-12-22
 * Combine :ref:`no-space-after-operator <no-space-after-operator>`, :ref:`no-space-after-comma <no-space-after-comma>` and
   :ref:`no-space-before-operator <no-space-before-operator>` into a new warning :ref:`bad-whitespace <bad-whitespace>`.
 
-* Add a new warning :ref:`superfluous-parens` for unnecessary
+* Add a new warning :ref:`superfluous-parens <superfluous-parens>` for unnecessary
   parentheses after certain keywords.
 
 * Fix a potential crash in the redefine-in-handler warning
@@ -24,7 +24,7 @@ Release date: 2013-12-22
 * Add a new option for the multi-statement warning to
   allow single-line if statements.
 
-* Add :ref:`bad-context-manager` error, checking that '__exit__'
+* Add :ref:`bad-context-manager <bad-context-manager>` error, checking that '__exit__'
   special method accepts the right number of arguments.
 
 * Run pylint as a python module 'python -m pylint' (Anatoly Techtonik).
@@ -38,14 +38,14 @@ Release date: 2013-12-22
   Closes BitBucket #53
   Closes BitBucket #54
 
-* Added a new warning, :ref:`non-iterator-returned`, for non-iterators
+* Added a new warning, :ref:`non-iterator-returned <non-iterator-returned>`, for non-iterators
   returned by '__iter__'.
 
 * Add new checks for unpacking non-sequences in assignments
-  (:ref:`unpacking-non-sequence`) as well as unbalanced tuple unpacking
-  (:ref:`unbalanced-tuple-unpacking`).
+  (:ref:`unpacking-non-sequence <unpacking-non-sequence>`) as well as unbalanced tuple unpacking
+  (:ref:`unbalanced-tuple-unpacking <unbalanced-tuple-unpacking>`).
 
-* :ref:`useless-else-on-loop` not emitted if there is a break in the
+* :ref:`useless-else-on-loop <useless-else-on-loop>` not emitted if there is a break in the
   else clause of inner loop.
 
   Closes #117
@@ -69,6 +69,6 @@ Release date: 2013-12-22
 
 * Various documentation fixes and enhancements
 
-* Fix a false-positive :ref:`trailing-whitespace` on Windows
+* Fix a false-positive :ref:`trailing-whitespace <trailing-whitespace>` on Windows
 
   Closes #55

--- a/doc/whatsnew/1/1.1.rst
+++ b/doc/whatsnew/1/1.1.rst
@@ -12,8 +12,8 @@ Release date: 2013-12-22
 
   Closes #111
 
-* Combine 'no-space-after-operator', 'no-space-after-comma' and
-  'no-space-before-operator' into a new warning 'bad-whitespace'.
+* Combine ':ref:`no-space-after-operator <no-space-after-operator>`', ':ref:`no-space-after-comma <no-space-after-comma>`' and
+  ':ref:`no-space-before-operator <no-space-before-operator>`' into a new warning ':ref:`bad-whitespace <bad-whitespace>`'.
 
 * Add a new warning :ref:`superfluous-parens` for unnecessary
   parentheses after certain keywords.

--- a/doc/whatsnew/1/1.2.rst
+++ b/doc/whatsnew/1/1.2.rst
@@ -10,7 +10,7 @@ Release date: 2014-04-30
 * Add a new warning :ref:`bad-continuation <bad-continuation>` for badly indented continued
   lines.
 
-* Emit :ref:`assignment-from-none` when the function contains bare returns.
+* Emit :ref:`assignment-from-none <assignment-from-none>` when the function contains bare returns.
 
   Closes BitBucket #191
 
@@ -24,8 +24,8 @@ Release date: 2014-04-30
 
   Closes BitBucket #151
 
-* Extend the checking for :ref:`unbalanced-tuple-unpacking` and
-  :ref:`unpacking-non-sequence` to instance attribute unpacking as well.
+* Extend the checking for :ref:`unbalanced-tuple-unpacking <unbalanced-tuple-unpacking>` and
+  :ref:`unpacking-non-sequence <unpacking-non-sequence>` to instance attribute unpacking as well.
 
 * Fix explicit checking of python script (1.2 regression)
 
@@ -66,7 +66,7 @@ Release date: 2014-04-18
 
   Closes BitBucket #170
 
-* Add new warning :ref:`eval-used`, checking that the builtin function ``eval`` was used.
+* Add new warning :ref:`eval-used <eval-used>`, checking that the builtin function ``eval`` was used.
 
 * Make it possible to show a naming hint for invalid name by setting
   include-naming-hint. Also make the naming hints configurable.
@@ -84,7 +84,7 @@ Release date: 2014-04-18
   warnings; contributed by sebastianu@google.com.
 
 * Added a new configuration option logging-modules to make the list
-  of module names that can be checked for :ref:`logging-not-lazy` et. al.
+  of module names that can be checked for :ref:`logging-not-lazy <logging-not-lazy>` et. al.
   configurable; contributed by morbo@google.com.
 
 * ensure init-hooks is evaluated before other options, notably load-plugins
@@ -97,11 +97,11 @@ Release date: 2014-04-18
   Closes BitBucket #50
   Closes BitBucket #62
 
-* pylint doesn't crash when looking for :ref:`used-before-assignment` in context manager assignments.
+* pylint doesn't crash when looking for :ref:`used-before-assignment <used-before-assignment>` in context manager assignments.
 
   Closes BitBucket #128
 
-* Add new warning, :ref:`bad-reversed-sequence`, for checking that the
+* Add new warning, :ref:`bad-reversed-sequence <bad-reversed-sequence>`, for checking that the
   reversed() builtin receive a sequence (implements ``__getitem__`` and ``__len__``,
   without being a dict or a dict subclass) or an instance which implements
   ``__reversed__``.
@@ -110,25 +110,25 @@ Release date: 2014-04-18
 
   Closes #8
 
-* Add new warning :ref:`bad-exception-context`, checking
+* Add new warning :ref:`bad-exception-context <bad-exception-context>`, checking
   that ``raise ... from ...`` uses a proper exception context
   (None or an exception).
 
-* Enhance the check for :ref:`used-before-assignment` to look
+* Enhance the check for :ref:`used-before-assignment <used-before-assignment>` to look
   for 'nonlocal' uses.
 
-* Emit :ref:`undefined-all-variable` if a package's __all__
+* Emit :ref:`undefined-all-variable <undefined-all-variable>` if a package's __all__
   variable contains a missing submodule.
 
   Closes #126
 
-* Add a new warning :ref:`abstract-class-instantiated` for checking
+* Add a new warning :ref:`abstract-class-instantiated <abstract-class-instantiated>` for checking
   that abstract classes created with ``abc`` module and
   with abstract methods are instantiated.
 
-* Do not warn about :ref:`return-arg-in-generator` in Python 3.3+.
+* Do not warn about :ref:`return-arg-in-generator <return-arg-in-generator>` in Python 3.3+.
 
-* Do not warn about :ref:`abstract-method` when the abstract method
+* Do not warn about :ref:`abstract-method <abstract-method>` when the abstract method
   is implemented through assignment
 
   Closes #155
@@ -145,11 +145,11 @@ Release date: 2014-04-18
 
 * Don't register the new style checker w/ python >= 3
 
-* Fix :ref:`unused-import` false positive w/ augment assignment
+* Fix :ref:`unused-import <unused-import>` false positive w/ augment assignment
 
   Closes #78
 
-* Fix :ref:`access-member-before-definition` false negative wrt aug assign
+* Fix :ref:`access-member-before-definition <access-member-before-definition>` false negative wrt aug assign
 
   Closes #164
 

--- a/doc/whatsnew/1/1.2.rst
+++ b/doc/whatsnew/1/1.2.rst
@@ -7,7 +7,7 @@ Release date: 2014-04-30
 * Restore the ability to specify the init-hook option via the
   configuration file, which was accidentally broken in 1.2.0.
 
-* Add a new warning [bad-continuation] for badly indented continued
+* Add a new warning [:ref:`bad-continuation <bad-continuation>`] for badly indented continued
   lines.
 
 * Emit :ref:`assignment-from-none` when the function contains bare returns.
@@ -35,7 +35,7 @@ Release date: 2014-04-30
 
   Closes #211
 
-* Add 'indexing-exception' warning, which detects that indexing
+* Add ':ref:`indexing-exception <indexing-exception>`' warning, which detects that indexing
   an exception occurs in Python 2 (behaviour removed in Python 3).
 
 

--- a/doc/whatsnew/1/1.2.rst
+++ b/doc/whatsnew/1/1.2.rst
@@ -7,7 +7,7 @@ Release date: 2014-04-30
 * Restore the ability to specify the init-hook option via the
   configuration file, which was accidentally broken in 1.2.0.
 
-* Add a new warning [:ref:`bad-continuation <bad-continuation>`] for badly indented continued
+* Add a new warning :ref:`bad-continuation <bad-continuation>` for badly indented continued
   lines.
 
 * Emit :ref:`assignment-from-none` when the function contains bare returns.
@@ -35,7 +35,7 @@ Release date: 2014-04-30
 
   Closes #211
 
-* Add ':ref:`indexing-exception <indexing-exception>`' warning, which detects that indexing
+* Add :ref:`indexing-exception <indexing-exception>` warning, which detects that indexing
   an exception occurs in Python 2 (behaviour removed in Python 3).
 
 

--- a/doc/whatsnew/1/1.3.rst
+++ b/doc/whatsnew/1/1.3.rst
@@ -28,7 +28,7 @@ Release date: 2014-07-26
 
   Closes #229
 
-* Fix a false positive regarding :ref:`W0511 <fixme>`.
+* Fix a false positive regarding :ref:`fixme <fixme>`.
 
   Closes #149.
 

--- a/doc/whatsnew/1/1.3.rst
+++ b/doc/whatsnew/1/1.3.rst
@@ -21,7 +21,7 @@ Release date: 2014-07-26
 
   Closes #205.
 
-* Emit :ref:`undefined-variable` for undefined names when using the
+* Emit :ref:`undefined-variable <undefined-variable>` for undefined names when using the
   Python 3 ``metaclass=`` argument.
 
 * Checkers respect priority now.
@@ -32,29 +32,29 @@ Release date: 2014-07-26
 
   Closes #149.
 
-* Fix :ref:`unused-import` false positive with Python 3 metaclasses
+* Fix :ref:`unused-import <unused-import>` false positive with Python 3 metaclasses
 
   Closes #143
 
-* Don't warn with :ref:`bad-format-character` when encountering
+* Don't warn with :ref:`bad-format-character <bad-format-character>` when encountering
   the 'a' format on Python 3.
 
 * Add multiple checks for PEP 3101 advanced string formatting:
-  :ref:`bad-format-string`, :ref:`missing-format-argument-key`,
-  :ref:`unused-format-string-argument`, :ref:`format-combined-specification`,
-  :ref:`missing-format-attribute` and :ref:`invalid-format-index`.
+  :ref:`bad-format-string <bad-format-string>`, :ref:`missing-format-argument-key <missing-format-argument-key>`,
+  :ref:`unused-format-string-argument <unused-format-string-argument>`, :ref:`format-combined-specification <format-combined-specification>`,
+  :ref:`missing-format-attribute <missing-format-attribute>` and :ref:`invalid-format-index <invalid-format-index>`.
 
-* Issue :ref:`broad-except` and :ref:`bare-except` even if the number
+* Issue :ref:`broad-except <broad-except>` and :ref:`bare-except <bare-except>` even if the number
   of except handlers is different than 1.
 
   Closes #113
 
-* Issue :ref:`attribute-defined-outside-init` for all cases, not just
+* Issue :ref:`attribute-defined-outside-init <attribute-defined-outside-init>` for all cases, not just
   for the last assignment.
 
   Closes #262
 
-* Emit :ref:`not-callable` when calling properties.
+* Emit :ref:`not-callable <not-callable>` when calling properties.
 
   Closes #268.
 
@@ -63,17 +63,17 @@ Release date: 2014-07-26
 
   Closes #273.
 
-* Add new checks, :ref:`invalid-slice-index` and :ref:`invalid-sequence-index`
+* Add new checks, :ref:`invalid-slice-index <invalid-slice-index>` and :ref:`invalid-sequence-index <invalid-sequence-index>`
   for invalid sequence and slice indices.
 
-* Add :ref:`assigning-non-slot` warning, which detects assignments to
+* Add :ref:`assigning-non-slot <assigning-non-slot>` warning, which detects assignments to
   attributes not defined in slots.
 
-* Don't emit :ref:`no-name-in-module` for ignored modules.
+* Don't emit :ref:`no-name-in-module <no-name-in-module>` for ignored modules.
 
   Closes #223.
 
-* Fix an :ref:`unused-variable` false positive, where the variable is
+* Fix an :ref:`unused-variable <unused-variable>` false positive, where the variable is
   assigned through an import.
 
   Closes #196.
@@ -83,7 +83,7 @@ Release date: 2014-07-26
 
   Closes #257.
 
-* Don't emit :ref:`unused-variable` when assigning to a nonlocal.
+* Don't emit :ref:`unused-variable <unused-variable>` when assigning to a nonlocal.
 
   Closes #275.
 
@@ -92,7 +92,7 @@ Release date: 2014-07-26
 
   Closes #203.
 
-* Don't emit :ref:`pointless-string-statement` for attribute docstrings.
+* Don't emit :ref:`pointless-string-statement <pointless-string-statement>` for attribute docstrings.
 
   Closes #193.
 
@@ -103,14 +103,14 @@ Release date: 2014-07-26
 * Don't emit hidden-method message when the attribute has been
   monkey-patched, you're on your own when you do that.
 
-* Only emit :ref:`attribute-defined-outside-init` for definition within the same
+* Only emit :ref:`attribute-defined-outside-init <attribute-defined-outside-init>` for definition within the same
   module as the offended class, avoiding to mangle the output in some cases.
 
-* Don't emit :ref:`unnecessary-lambda` if the body of the lambda call contains
+* Don't emit :ref:`unnecessary-lambda <unnecessary-lambda>` if the body of the lambda call contains
   call chaining.
 
   Closes #243.
 
-* Don't emit :ref:`missing-docstring` when the actual docstring uses ``.format``.
+* Don't emit :ref:`missing-docstring <missing-docstring>` when the actual docstring uses ``.format``.
 
   Closes #281.

--- a/doc/whatsnew/1/1.3.rst
+++ b/doc/whatsnew/1/1.3.rst
@@ -28,7 +28,7 @@ Release date: 2014-07-26
 
   Closes #229
 
-* Fix a false positive regarding W0511.
+* Fix a false positive regarding :ref:`W0511 <fixme>`.
 
   Closes #149.
 

--- a/doc/whatsnew/1/1.4.rst
+++ b/doc/whatsnew/1/1.4.rst
@@ -38,16 +38,16 @@ Release date: 2015-03-11
   Closes #463
 
 * Take in account all the methods from the ancestors
-  when checking for :ref:`too-few-public-methods`.
+  when checking for :ref:`too-few-public-methods <too-few-public-methods>`.
 
   Closes #471
 
-* Catch enchant errors and emit :ref:`invalid-characters-in-docstring`
+* Catch enchant errors and emit :ref:`invalid-characters-in-docstring <invalid-characters-in-docstring>`
   when checking for spelling errors.
 
   Closes #469
 
-* Use all the inferred statements for the :ref:`super-init-not-called`
+* Use all the inferred statements for the :ref:`super-init-not-called <super-init-not-called>`
   check.
 
   Closes #389
@@ -73,7 +73,7 @@ Release date: 2015-03-11
   appropriate built-in is not used in an iterating context (semantics
   taken from 2to3).
 
-* Add a new warning, :ref:`unidiomatic-typecheck`, emitted when an explicit
+* Add a new warning, :ref:`unidiomatic-typecheck <unidiomatic-typecheck>`, emitted when an explicit
   typecheck uses type() instead of isinstance(). For example,
   `type(x) == Y` instead of `isinstance(x, Y)`. Patch by Chris Rebert.
 
@@ -99,11 +99,11 @@ What's New in Pylint 1.4.1?
 ===========================
 Release date: 2015-01-16
 
-* Look only in the current function's scope for :ref:`bad-super-call`.
+* Look only in the current function's scope for :ref:`bad-super-call <bad-super-call>`.
 
   Closes #403
 
-* Check the return of properties when checking for :ref:`not-callable`.
+* Check the return of properties when checking for :ref:`not-callable <not-callable>`.
 
   Closes #406
 
@@ -111,7 +111,7 @@ Release date: 2015-01-16
 
   Closes #411
 
-* Proper abstract method lookup while checking for :ref:`abstract-class-instantiated`.
+* Proper abstract method lookup while checking for :ref:`abstract-class-instantiated <abstract-class-instantiated>`.
 
   Closes #401
 
@@ -119,12 +119,12 @@ Release date: 2015-01-16
 
   Closes #415
 
-* Fix a false positive with :ref:`catching-non-exception` and tuples of exceptions.
+* Fix a false positive with :ref:`catching-non-exception <catching-non-exception>` and tuples of exceptions.
 
-* Fix a false negative with :ref:`raising-non-exception`, when the raise used
+* Fix a false negative with :ref:`raising-non-exception <raising-non-exception>`, when the raise used
   an uninferrable exception context.
 
-* Fix a false positive on Python 2 for :ref:`raising-bad-type`, when
+* Fix a false positive on Python 2 for :ref:`raising-bad-type <raising-bad-type>`, when
   raising tuples in the form 'raise (ZeroDivisionError, None)'.
 
 * Fix a false positive with invalid-slots-objects, where the slot entry
@@ -132,13 +132,13 @@ Release date: 2015-01-16
 
   Closes #421
 
-* Add a new warning, :ref:`redundant-unittest-assert`, emitted when using
+* Add a new warning, :ref:`redundant-unittest-assert <redundant-unittest-assert>`, emitted when using
   unittest's methods assertTrue and assertFalse with constant value
   as argument. Patch by Vlad Temian.
 
 * Add a new JSON reporter, usable through -f flag.
 
-* Add the method names for the :ref:`signature-differs` and 'argument-differs'
+* Add the method names for the :ref:`signature-differs <signature-differs>` and 'argument-differs'
   warnings.
 
   Closes #433
@@ -177,21 +177,21 @@ Release date: 2014-11-23
   all messages that were emitted even though an inference failure
   happened during checking.
 
-* Improved presenting :ref:`unused-import` message.
+* Improved presenting :ref:`unused-import <unused-import>` message.
 
   Closes #293
 
 * Add new checker for finding spelling errors. New messages:
-  :ref:`wrong-spelling-in-comment`, :ref:`wrong-spelling-in-docstring`.
+  :ref:`wrong-spelling-in-comment <wrong-spelling-in-comment>`, :ref:`wrong-spelling-in-docstring <wrong-spelling-in-docstring>`.
   New options: spelling-dict, spelling-ignore-words.
 
 * Add new '-j' option for running checks in sub-processes.
 
 * Added new checks for line endings if they are mixed (LF vs CRLF)
-  or if they are not as expected. New messages: :ref:`mixed-line-endings`,
-  :ref:`unexpected-line-ending-format`. New option: expected-line-ending-format.
+  or if they are not as expected. New messages: :ref:`mixed-line-endings <mixed-line-endings>`,
+  :ref:`unexpected-line-ending-format <unexpected-line-ending-format>`. New option: expected-line-ending-format.
 
-* :ref:`dangerous-default-value` no longer evaluates the value of the arguments,
+* :ref:`dangerous-default-value <dangerous-default-value>` no longer evaluates the value of the arguments,
   which could result in long error messages or sensitive data being leaked.
 
   Closes #282
@@ -208,7 +208,7 @@ Release date: 2014-11-23
 
 * Proper handle class level scope for lambdas.
 
-* Handle :ref:`too-few-format-args` or :ref:`too-many-format-args` for format
+* Handle :ref:`too-few-format-args <too-few-format-args>` or :ref:`too-many-format-args <too-many-format-args>` for format
   strings with both named and positional fields.
 
   Closes #286
@@ -221,7 +221,7 @@ Release date: 2014-11-23
 
   Closes #294
 
-* Don't emit :ref:`attribute-defined-outside-init` if the attribute
+* Don't emit :ref:`attribute-defined-outside-init <attribute-defined-outside-init>` if the attribute
   was set by a function call in a defining method.
 
   Closes #192
@@ -230,22 +230,22 @@ Release date: 2014-11-23
 
   Closes #296
 
-* Don't emit :ref:`import-error` if an import was protected by a try-except,
+* Don't emit :ref:`import-error <import-error>` if an import was protected by a try-except,
   which excepted ImportError.
 
-* Fix an :ref:`unused-import` false positive, when the error was emitted
+* Fix an :ref:`unused-import <unused-import>` false positive, when the error was emitted
   for all the members imported with 'from import' form.
 
   Closes #304
 
-* Don't emit :ref:`invalid-name` when assigning a name in an
+* Don't emit :ref:`invalid-name <invalid-name>` when assigning a name in an
   ImportError handler.
 
   Closes #302
 
 * Don't count branches from nested functions.
 
-* Fix a false positive with :ref:`too-few-format-args`, when the format
+* Fix a false positive with :ref:`too-few-format-args <too-few-format-args>`, when the format
   strings contains duplicate manual position arguments.
 
   Closes #310
@@ -254,7 +254,7 @@ Release date: 2014-11-23
 
   Closes #311
 
-* Don't emit :ref:`unused-import` when a special object is imported
+* Don't emit :ref:`unused-import <unused-import>` when a special object is imported
   (__all__, __doc__ etc.).
 
   Closes #309
@@ -264,7 +264,7 @@ Release date: 2014-11-23
 
   Closes #306
 
-* Don't emit :ref:`protected-access` if the attribute is accessed using
+* Don't emit :ref:`protected-access <protected-access>` if the attribute is accessed using
   a property defined at the class level.
 
 * Detect calls of the parent's __init__, through a binded super() call.
@@ -272,31 +272,31 @@ Release date: 2014-11-23
 * Check that a class has an explicitly defined metaclass before
   emitting :ref:`old-style-class <old-style-class>` for Python 2.
 
-* Emit :ref:`catching-non-exception` for non-class nodes.
+* Emit :ref:`catching-non-exception <catching-non-exception>` for non-class nodes.
 
   Closes #303
 
 * Order of reporting is consistent.
 
-* Add a new warning, :ref:`boolean-datetime`, emitted when an instance
+* Add a new warning, :ref:`boolean-datetime <boolean-datetime>`, emitted when an instance
   of 'datetime.time' is used in a boolean context.
 
   Closes #239
 
-* Fix a crash which occurred while checking for :ref:`method-hidden`,
+* Fix a crash which occurred while checking for :ref:`method-hidden <method-hidden>`,
   when the parent frame was something different than a function.
 
 * Generate html output for missing files.
 
   Closes #320
 
-* Fix a false positive with :ref:`too-many-format-args`, when the format
+* Fix a false positive with :ref:`too-many-format-args <too-many-format-args>`, when the format
   string contains mixed attribute access arguments and manual
   fields.
 
   Closes #322
 
-* Extend the cases where :ref:`undefined-variable` and :ref:`used-before-assignment`
+* Extend the cases where :ref:`undefined-variable <undefined-variable>` and :ref:`used-before-assignment <used-before-assignment>`
   can be detected.
 
   Closes #291
@@ -306,20 +306,20 @@ Release date: 2014-11-23
 
   Closes #326
 
-* Add a new warning, :ref:`logging-format-interpolation`, emitted when .format()
+* Add a new warning, :ref:`logging-format-interpolation <logging-format-interpolation>`, emitted when .format()
   string interpolation is used within logging function calls.
 
-* Don't emit :ref:`unbalanced-tuple-unpacking` when the rhs of the assignment
+* Don't emit :ref:`unbalanced-tuple-unpacking <unbalanced-tuple-unpacking>` when the rhs of the assignment
   is a variable length argument.
 
   Closes #329
 
-* Add a new warning, :ref:`inherit-non-class`, emitted when a class inherits
+* Add a new warning, :ref:`inherit-non-class <inherit-non-class>`, emitted when a class inherits
   from something which is not a class.
 
   Closes #331
 
-* Fix another false positives with :ref:`undefined-variable`, where the variable
+* Fix another false positives with :ref:`undefined-variable <undefined-variable>`, where the variable
   can be found as a class assignment and used in a function annotation.
 
   Closes #342
@@ -340,7 +340,7 @@ Release date: 2014-11-23
   __coerce__, __delslice__, __getslice__, __setslice__, __cmp__,
   __oct__, __nonzero__ and __hex__.
 
-* Don't emit :ref:`assigning-non-slot` when the assignment is for a property.
+* Don't emit :ref:`assigning-non-slot <assigning-non-slot>` when the assignment is for a property.
 
   Closes #359
 
@@ -350,12 +350,12 @@ Release date: 2014-11-23
 
   Closes #319
 
-* :ref:`too-many-public-methods` is reported only for methods defined in a class,
+* :ref:`too-many-public-methods <too-many-public-methods>` is reported only for methods defined in a class,
   not in its ancestors.
 
   Closes #248
 
-* :ref:`too-many-lines` disable pragma can be located on any line, not only the
+* :ref:`too-many-lines <too-many-lines>` disable pragma can be located on any line, not only the
   first.
 
   Closes #321
@@ -367,7 +367,7 @@ Release date: 2014-11-23
   a corresponding ``from __future__ import division``.
 
 * Add a new option, 'exclude-protected', for excluding members
-  from the :ref:`protected-access` warning.
+  from the :ref:`protected-access <protected-access>` warning.
 
   Closes #48
 
@@ -383,7 +383,7 @@ Release date: 2014-11-23
 * Warn when performing parameter tuple unpacking; it is not supported in
   Python 3.
 
-* :ref:`abstract-class-instantiated` is also emitted for Python 2.
+* :ref:`abstract-class-instantiated <abstract-class-instantiated>` is also emitted for Python 2.
   It was previously disabled.
 
 * Add 'long-suffix' error, emitted when encountering the long suffix

--- a/doc/whatsnew/1/1.4.rst
+++ b/doc/whatsnew/1/1.4.rst
@@ -6,8 +6,8 @@ What's New in Pylint 1.4.3?
 ===========================
 Release date: 2015-03-14
 
-* Remove three warnings: star-args, abstract-class-little-used,
-  abstract-class-not-used. These warnings don't add any real value
+* Remove three warnings: :ref:`star-args <star-args>`, :ref:`abstract-class-little-used <abstract-class-little-used>`,
+  :ref:`abstract-class-not-used <abstract-class-not-used>`. These warnings don't add any real value
   and they don't imply errors or problems in the code.
 
 * Added a new option for controlling the peephole optimizer in astroid.
@@ -52,12 +52,12 @@ Release date: 2015-03-11
 
   Closes #389
 
-* Add a new warning, 'unichr-builtin', emitted by the Python 3
+* Add a new warning, ':ref:`unichr-builtin <unichr-builtin>`', emitted by the Python 3
   porting checker, when the unichr builtin is found.
 
   Closes #472
 
-* Add a new warning, 'intern-builtin', emitted by the Python 3
+* Add a new warning, ':ref:`intern-builtin <intern-builtin>`', emitted by the Python 3
   porting checker, when the intern builtin is found.
 
   Closes #473
@@ -67,9 +67,9 @@ Release date: 2015-03-11
 * The HTML output accepts the ``--msg-template`` option. Patch by
   Dan Goldsmith.
 
-* Add 'map-builtin-not-iterating' (replacing 'implicit-map-evaluation'),
-  'zip-builtin-not-iterating', 'range-builtin-not-iterating', and
-  'filter-builtin-not-iterating' which are emitted by ``--py3k`` when the
+* Add ':ref:`map-builtin-not-iterating <map-builtin-not-iterating>`' (replacing ':ref:`implicit-map-evaluation <implicit-map-evaluation>`'),
+  ':ref:`zip-builtin-not-iterating <zip-builtin-not-iterating>`', ':ref:`range-builtin-not-iterating <range-builtin-not-iterating>`', and
+  ':ref:`filter-builtin-not-iterating <filter-builtin-not-iterating>`' which are emitted by ``--py3k`` when the
   appropriate built-in is not used in an iterating context (semantics
   taken from 2to3).
 
@@ -84,7 +84,7 @@ Release date: 2015-03-11
 
   Closes #467
 
-* Add a new warning for the Python 3 porting checker, 'using-cmp-argument',
+* Add a new warning for the Python 3 porting checker, ':ref:`using-cmp-argument <using-cmp-argument>`',
   emitted when the ``cmp`` argument for the ``list.sort`` or ``sorted builtin``
   is encountered.
 
@@ -399,5 +399,5 @@ Release date: 2014-11-23
 * Add 'old-octal-literal' to Python 3 porting checker, emitted when
   encountering octals with the old syntax.
 
-* Add 'implicit-map-evaluation' to Python 3 porting checker, emitted
+* Add ':ref:`implicit-map-evaluation <implicit-map-evaluation>`' to Python 3 porting checker, emitted
   when encountering the use of map builtin, without explicit evaluation.

--- a/doc/whatsnew/1/1.4.rst
+++ b/doc/whatsnew/1/1.4.rst
@@ -52,12 +52,12 @@ Release date: 2015-03-11
 
   Closes #389
 
-* Add a new warning, ':ref:`unichr-builtin <unichr-builtin>`', emitted by the Python 3
+* Add a new warning, :ref:`unichr-builtin <unichr-builtin>`, emitted by the Python 3
   porting checker, when the unichr builtin is found.
 
   Closes #472
 
-* Add a new warning, ':ref:`intern-builtin <intern-builtin>`', emitted by the Python 3
+* Add a new warning, :ref:`intern-builtin <intern-builtin>`, emitted by the Python 3
   porting checker, when the intern builtin is found.
 
   Closes #473
@@ -67,9 +67,9 @@ Release date: 2015-03-11
 * The HTML output accepts the ``--msg-template`` option. Patch by
   Dan Goldsmith.
 
-* Add ':ref:`map-builtin-not-iterating <map-builtin-not-iterating>`' (replacing ':ref:`implicit-map-evaluation <implicit-map-evaluation>`'),
-  ':ref:`zip-builtin-not-iterating <zip-builtin-not-iterating>`', ':ref:`range-builtin-not-iterating <range-builtin-not-iterating>`', and
-  ':ref:`filter-builtin-not-iterating <filter-builtin-not-iterating>`' which are emitted by ``--py3k`` when the
+* Add :ref:`map-builtin-not-iterating <map-builtin-not-iterating>` (replacing :ref:`implicit-map-evaluation <implicit-map-evaluation>`),
+  :ref:`zip-builtin-not-iterating <zip-builtin-not-iterating>`, :ref:`range-builtin-not-iterating <range-builtin-not-iterating>`, and
+  :ref:`filter-builtin-not-iterating <filter-builtin-not-iterating>` which are emitted by ``--py3k`` when the
   appropriate built-in is not used in an iterating context (semantics
   taken from 2to3).
 
@@ -84,7 +84,7 @@ Release date: 2015-03-11
 
   Closes #467
 
-* Add a new warning for the Python 3 porting checker, ':ref:`using-cmp-argument <using-cmp-argument>`',
+* Add a new warning for the Python 3 porting checker, :ref:`using-cmp-argument <using-cmp-argument>`,
   emitted when the ``cmp`` argument for the ``list.sort`` or ``sorted builtin``
   is encountered.
 
@@ -270,7 +270,7 @@ Release date: 2014-11-23
 * Detect calls of the parent's __init__, through a binded super() call.
 
 * Check that a class has an explicitly defined metaclass before
-  emitting ':ref:`old-style-class <old-style-class>`' for Python 2.
+  emitting :ref:`old-style-class <old-style-class>` for Python 2.
 
 * Emit :ref:`catching-non-exception` for non-class nodes.
 
@@ -399,5 +399,5 @@ Release date: 2014-11-23
 * Add 'old-octal-literal' to Python 3 porting checker, emitted when
   encountering octals with the old syntax.
 
-* Add ':ref:`implicit-map-evaluation <implicit-map-evaluation>`' to Python 3 porting checker, emitted
+* Add :ref:`implicit-map-evaluation <implicit-map-evaluation>` to Python 3 porting checker, emitted
   when encountering the use of map builtin, without explicit evaluation.

--- a/doc/whatsnew/1/1.4.rst
+++ b/doc/whatsnew/1/1.4.rst
@@ -270,7 +270,7 @@ Release date: 2014-11-23
 * Detect calls of the parent's __init__, through a binded super() call.
 
 * Check that a class has an explicitly defined metaclass before
-  emitting 'old-style-class' for Python 2.
+  emitting ':ref:`old-style-class <old-style-class>`' for Python 2.
 
 * Emit :ref:`catching-non-exception` for non-class nodes.
 

--- a/doc/whatsnew/1/1.5.rst
+++ b/doc/whatsnew/1/1.5.rst
@@ -46,14 +46,14 @@ Release date: 2016-01-15
   messages from the StringFormatChecker would have resulted in no
   messages at all.
 
-* Don't apply :ref:`unneeded-not` over sets.
+* Don't apply :ref:`unneeded-not <unneeded-not>` over sets.
 
 
 What's New in Pylint 1.5.3?
 ===========================
 Release date: 2016-01-11
 
-* Handle the import fallback idiom with regard to :ref:`wrong-import-order`.
+* Handle the import fallback idiom with regard to :ref:`wrong-import-order <wrong-import-order>`.
 
   Closes #750
 
@@ -75,7 +75,7 @@ Release date: 2016-01-11
 
   Inferring variadic positional arguments and keyword arguments
   will result into empty Tuples and Dicts, which can lead in
-  some cases to false positives with regard to :ref:`no-value-for-parameter`.
+  some cases to false positives with regard to :ref:`no-value-for-parameter <no-value-for-parameter>`.
   In order to avoid this, until we'll have support for call context
   propagation, we're ignoring such cases if detected.
 
@@ -92,7 +92,7 @@ Release date: 2016-01-11
 
   Closes #745
 
-* Suppress reporting :ref:`unneeded-not` inside ``__ne__`` methods
+* Suppress reporting :ref:`unneeded-not <unneeded-not>` inside ``__ne__`` methods
 
   Closes #749
 
@@ -130,21 +130,21 @@ Release date: 2015-12-02
 
   Closes #711
 
-* Add :ref:`wrong-import-position` to check_messages's decorator arguments
+* Add :ref:`wrong-import-position <wrong-import-position>` to check_messages's decorator arguments
   for ImportChecker.leave_module
-  This fixes an esoteric bug which occurs when :ref:`ungrouped-imports` and
-  :ref:`wrong-import-order` are disabled and pylint is executed on multiple files.
-  What happens is that without :ref:`wrong-import-position` in check_messages,
+  This fixes an esoteric bug which occurs when :ref:`ungrouped-imports <ungrouped-imports>` and
+  :ref:`wrong-import-order <wrong-import-order>` are disabled and pylint is executed on multiple files.
+  What happens is that without :ref:`wrong-import-position <wrong-import-position>` in check_messages,
   leave_module will never be called, which means that the first non-import node
   from other files might leak into the current file,
-  leading to :ref:`wrong-import-position` being emitted by pylint.
+  leading to :ref:`wrong-import-position <wrong-import-position>` being emitted by pylint.
 
 * Fix a crash which occurred when old visit methods are encountered
   in plugin modules.
 
   Closes #711
 
-* Don't emit :ref:`import-self` and :ref:`cyclic-import` for relative imports
+* Don't emit :ref:`import-self <import-self>` and :ref:`cyclic-import <cyclic-import>` for relative imports
   of modules with the same name as the package itself.
 
   Closes #708
@@ -155,30 +155,30 @@ What's New in Pylint 1.5.0?
 ===========================
 Release date: 2015-11-29
 
-* Added multiple warnings related to imports. :ref:`wrong-import-order`
+* Added multiple warnings related to imports. :ref:`wrong-import-order <wrong-import-order>`
   is emitted when PEP 8 recommendations regarding imports are not
   respected (that is, standard imports should be followed by third-party
-  imports and then by local imports). :ref:`ungrouped-imports` is emitted
+  imports and then by local imports). :ref:`ungrouped-imports <ungrouped-imports>` is emitted
   when imports from the same package or module are not placed
-  together, but scattered around in the code. :ref:`wrong-import-position`
+  together, but scattered around in the code. :ref:`wrong-import-position <wrong-import-position>`
   is emitted when code is mixed with imports, being recommended for the
   latter to be at the top of the file, in order to figure out easier by
   a human reader what dependencies a module has.
 
   Closes #692
 
-* Added a new refactoring warning, :ref:`unneeded-not`, emitted
+* Added a new refactoring warning, :ref:`unneeded-not <unneeded-not>`, emitted
   when an expression with the not operator could be simplified.
 
   Closes #670
 
-* Added a new refactoring warning, :ref:`simplifiable-if-statement`,
+* Added a new refactoring warning, :ref:`simplifiable-if-statement <simplifiable-if-statement>`,
   used when an if statement could be reduced to a boolean evaluation
   of its test.
 
   Closes #698
 
-* Added a new refactoring warning, :ref:`too-many-boolean-expressions`,
+* Added a new refactoring warning, :ref:`too-many-boolean-expressions <too-many-boolean-expressions>`,
   used when an if statement contains too many boolean expressions,
   which makes the code less maintainable and harder to understand.
 
@@ -189,13 +189,13 @@ Release date: 2015-11-29
 
   Closes #284
 
-* Add a new refactoring error, :ref:`too-many-nested-blocks`, which is emitted
+* Add a new refactoring error, :ref:`too-many-nested-blocks <too-many-nested-blocks>`, which is emitted
   when a function or a method has too many nested blocks, which makes the
   code less readable and harder to understand.
 
   Closes #668
 
-* Add a new error, :ref:`unsubscriptable-object`, that is emitted when
+* Add a new error, :ref:`unsubscriptable-object <unsubscriptable-object>`, that is emitted when
   value used in subscription expression doesn't support subscription
   (i.e. doesn't define __getitem__ method).
 
@@ -208,17 +208,17 @@ Release date: 2015-11-29
 
   Closes #632
 
-* :ref:`non-iterator-returned` can detect classes with iterator-metaclasses.
+* :ref:`non-iterator-returned <non-iterator-returned>` can detect classes with iterator-metaclasses.
 
   Closes #679
 
-* Add a new error, :ref:`unsupported-membership-test`, emitted when value
+* Add a new error, :ref:`unsupported-membership-test <unsupported-membership-test>`, emitted when value
   to the right of the 'in' operator doesn't support membership test
   protocol (i.e. doesn't define __contains__/__iter__/__getitem__)
 
-* Add new errors, :ref:`not-an-iterable`, emitted when non-iterable value
+* Add new errors, :ref:`not-an-iterable <not-an-iterable>`, emitted when non-iterable value
   is used in an iterating context (starargs, for-statement,
-  comprehensions, etc), and :ref:`not-a-mapping`, emitted when non-mapping
+  comprehensions, etc), and :ref:`not-a-mapping <not-a-mapping>`, emitted when non-mapping
   value is used in a mapping context.
 
   Closes #563
@@ -232,39 +232,39 @@ Release date: 2015-11-29
 
   Closes #598
 
-* Fix :ref:`unused-argument` false positive when the "+=" operator is used.
+* Fix :ref:`unused-argument <unused-argument>` false positive when the "+=" operator is used.
 
   Closes #518
 
-* Don't emit :ref:`import-error` for ignored modules. PyLint will not emit import
+* Don't emit :ref:`import-error <import-error>` for ignored modules. PyLint will not emit import
   errors for any import which is, or is a subpackage of, a module in
   the ignored-modules list.
 
   Closes #223
 
-* Fix :ref:`unused-import` false positive when the import is used in a
+* Fix :ref:`unused-import <unused-import>` false positive when the import is used in a
   class assignment.
 
   Closes #475
 
-* Add a new error, :ref:`not-context-manager`, emitted when something
+* Add a new error, :ref:`not-context-manager <not-context-manager>`, emitted when something
   that doesn't implement __enter__ and __exit__ is used in a with
   statement.
 
-* Add a new warning, :ref:`confusing-with-statement`, emitted by the
+* Add a new warning, :ref:`confusing-with-statement <confusing-with-statement>`, emitted by the
   base checker, when an ambiguous looking with statement is used.
   For example `with open() as first, second` which looks like a
   tuple assignment but is actually 2 context managers.
 
-* Add a new warning, :ref:`duplicate-except`, emitted when there is an
+* Add a new warning, :ref:`duplicate-except <duplicate-except>`, emitted when there is an
   exception handler which handles an exception type that was handled
   before.
 
   Closes #485
 
 * A couple of warnings got promoted to errors, since they could uncover
-  potential bugs in the code. These warnings are: :ref:`assignment-from-none`,
-  :ref:`unbalanced-tuple-unpacking`, :ref:`unpacking-non-sequence`, :ref:`non-iterator-returned`.
+  potential bugs in the code. These warnings are: :ref:`assignment-from-none <assignment-from-none>`,
+  :ref:`unbalanced-tuple-unpacking <unbalanced-tuple-unpacking>`, :ref:`unpacking-non-sequence <unpacking-non-sequence>`, :ref:`non-iterator-returned <non-iterator-returned>`.
 
   Closes #388
 
@@ -282,7 +282,7 @@ Release date: 2015-11-29
 
   Closes #479
 
-* Don't emit an :ref:`unused-wildcard-import` when the imported name comes
+* Don't emit an :ref:`unused-wildcard-import <unused-wildcard-import>` when the imported name comes
   from another module and it is in fact a __future__ name.
 
 * The colorized reporter now works on Windows.
@@ -298,19 +298,19 @@ Release date: 2015-11-29
   crashed when it encountered a bytes string with a .format
   method called.
 
-* Don't warn about :ref:`no-self-use` for builtin properties.
+* Don't warn about :ref:`no-self-use <no-self-use>` for builtin properties.
 
-* Fix a false positive for :ref:`bad-reversed-sequence`, when a subclass
+* Fix a false positive for :ref:`bad-reversed-sequence <bad-reversed-sequence>`, when a subclass
   of a ``dict`` provides a __reversed__ method.
 
-* Change the default no-docstring-rgx so :ref:`missing-docstring` isn't
+* Change the default no-docstring-rgx so :ref:`missing-docstring <missing-docstring>` isn't
   emitted for private functions.
 
-* Don't emit :ref:`redefined-outer-name` for __future__ directives.
+* Don't emit :ref:`redefined-outer-name <redefined-outer-name>` for __future__ directives.
 
   Closes #520.
 
-* Provide some hints for the :ref:`bad-builtin` message.
+* Provide some hints for the :ref:`bad-builtin <bad-builtin>` message.
 
   Closes #522.
 
@@ -324,21 +324,21 @@ Release date: 2015-11-29
 
   Closes #429.
 
-* Don't emit :ref:`no-member` for classes with unknown bases.
+* Don't emit :ref:`no-member <no-member>` for classes with unknown bases.
 
   Since we don't know what those bases might add, we simply ignore
   the error in this case.
 
-* Lookup in the implicit metaclass when checking for :ref:`no-member`,
+* Lookup in the implicit metaclass when checking for :ref:`no-member <no-member>`,
   if the class in question has an implicit metaclass, which is
   True for new style classes.
 
   Closes #438.
 
-* Add two new warnings, :ref:`duplicate-bases` and :ref:`inconsistent-mro`.
+* Add two new warnings, :ref:`duplicate-bases <duplicate-bases>` and :ref:`inconsistent-mro <inconsistent-mro>`.
 
-  :ref:`duplicate-bases` is emitted when a class has the same bases
-  listed more than once in its bases definition, while :ref:`inconsistent-mro`
+  :ref:`duplicate-bases <duplicate-bases>` is emitted when a class has the same bases
+  listed more than once in its bases definition, while :ref:`inconsistent-mro <inconsistent-mro>`
   is emitted when no sane mro hierarchy can be determined.
 
   Closes #526.
@@ -365,12 +365,12 @@ Release date: 2015-11-29
   documentation in Sphinx, Google, and Numpy style.
 
 * Detect undefined variable cases, where the "definition" of an undefined
-  variable was in del statement. Instead of emitting :ref:`used-before-assignment`,
-  which is totally misleading, it now emits :ref:`undefined-variable`.
+  variable was in del statement. Instead of emitting :ref:`used-before-assignment <used-before-assignment>`,
+  which is totally misleading, it now emits :ref:`undefined-variable <undefined-variable>`.
 
   Closes #528.
 
-* Don't emit :ref:`attribute-defined-outside-init` and :ref:`access-member-before-definition`
+* Don't emit :ref:`attribute-defined-outside-init <attribute-defined-outside-init>` and :ref:`access-member-before-definition <access-member-before-definition>`
   for mixin classes. Actual errors can occur in mixin classes, but this is
   controlled by the ignore-mixin-members option.
 
@@ -382,34 +382,34 @@ Release date: 2015-11-29
 
   Closes #342 and issue #404.
 
-* Add a new warning, :ref:`unexpected-special-method-signature`, which is emitted
+* Add a new warning, :ref:`unexpected-special-method-signature <unexpected-special-method-signature>`, which is emitted
   when a special method (dunder method) doesn't have the expected signature,
   which can lead to actual errors in the application code.
 
   Closes #253.
 
-* Remove :ref:`bad-context-manager` due to the inclusion of :ref:`unexpected-special-method-signature`.
+* Remove :ref:`bad-context-manager <bad-context-manager>` due to the inclusion of :ref:`unexpected-special-method-signature <unexpected-special-method-signature>`.
 
-* Don't emit :ref:`no-name-in-module` if the import is guarded by an ImportError, Exception or
+* Don't emit :ref:`no-name-in-module <no-name-in-module>` if the import is guarded by an ImportError, Exception or
   a bare except clause.
 
-* Don't emit :ref:`no-member` if the attribute access node is protected by an
+* Don't emit :ref:`no-member <no-member>` if the attribute access node is protected by an
   except handler, which handles AttributeError, Exception or it is a
   bare except.
 
-* Don't emit :ref:`import-error` if the import is guarded by an ImportError, Exception or a
+* Don't emit :ref:`import-error <import-error>` if the import is guarded by an ImportError, Exception or a
   bare except clause.
 
-* Don't emit :ref:`undefined-variable` if the node is guarded by a NameError, Exception
+* Don't emit :ref:`undefined-variable <undefined-variable>` if the node is guarded by a NameError, Exception
   or bare except clause.
 
-* Add a new warning, :ref:`using-constant-test`, which is emitted when a conditional
+* Add a new warning, :ref:`using-constant-test <using-constant-test>`, which is emitted when a conditional
   statement (If, IfExp) uses a test which is always constant, such as numbers,
   classes, functions etc. This is most likely an error from the user's part.
 
   Closes #524.
 
-* Don't emit :ref:`raising-non-exception` when the exception has unknown
+* Don't emit :ref:`raising-non-exception <raising-non-exception>` when the exception has unknown
   bases. We don't know what those bases actually are and it's better
   to assume that the user knows what he is doing rather than emitting
   a message which can be considered a false positive.
@@ -442,11 +442,11 @@ Release date: 2015-11-29
 
 * yield-outside-func is also emitted for ``yield from``.
 
-* Add a new error, :ref:`too-many-star-expressions`, emitted when
+* Add a new error, :ref:`too-many-star-expressions <too-many-star-expressions>`, emitted when
   there are more than one starred expression (`*x`) in an assignment.
   The warning is emitted only on Python 3.
 
-* Add a new error, :ref:`invalid-star-assignment-target`, emitted when
+* Add a new error, :ref:`invalid-star-assignment-target <invalid-star-assignment-target>`, emitted when
   a starred expression (`*x`) is used as the lhs side of an assignment,
   as in `*x = [1, 2]`. This is not a SyntaxError on Python 3 though.
 
@@ -458,11 +458,11 @@ Release date: 2015-11-29
   module level, which is an error on Python 3. Using this will emit a
   SyntaxWarning on Python 2.
 
-* Add a new error, :ref:`star-needs-assignment-target`, emitted on Python 3 when
+* Add a new error, :ref:`star-needs-assignment-target <star-needs-assignment-target>`, emitted on Python 3 when
   a Starred expression (`*x`) is not used in an assignment target. This is not
   caught when parsing the AST on Python 3, so it needs to be a separate check.
 
-* Add a new error, :ref:`unsupported-binary-operation`, emitted when
+* Add a new error, :ref:`unsupported-binary-operation <unsupported-binary-operation>`, emitted when
   two a binary arithmetic operation is executed between two objects
   which don't support it (a number plus a string for instance).
   This is currently disabled, since the it exhibits way too many false
@@ -473,11 +473,11 @@ Release date: 2015-11-29
 
   These were moved since they didn't belong in astroid.
 
-* Enable :ref:`misplaced-future` for Python 3.
+* Enable :ref:`misplaced-future <misplaced-future>` for Python 3.
 
   Closes #580.
 
-* Add a new error, :ref:`nonlocal-and-global`, which is emitted when a
+* Add a new error, :ref:`nonlocal-and-global <nonlocal-and-global>`, which is emitted when a
   name is found to be both nonlocal and global in the same scope.
 
   Closes #581.
@@ -509,7 +509,7 @@ Release date: 2015-11-29
 
 * Improved the :ref:`not-in-loop <not-in-loop>` check to properly detect more cases.
 
-* Add a new error, :ref:`continue-in-finally`, which is emitted when
+* Add a new error, :ref:`continue-in-finally <continue-in-finally>`, which is emitted when
   the ``continue`` keyword is found inside a ``finally`` clause, which
   is a SyntaxError.
 
@@ -542,7 +542,7 @@ Release date: 2015-11-29
 
 * --profile flag is obsolete and it will be removed in Pylint 1.6.
 
-* Add a new error, :ref:`misplaced-bare-raise`.
+* Add a new error, :ref:`misplaced-bare-raise <misplaced-bare-raise>`.
 
   The error is used when a bare raise is not used inside an except clause.
   This can generate a RuntimeError in Python, if there are no active exceptions
@@ -576,14 +576,14 @@ Release date: 2015-11-29
 
   Closes #424.
 
-* Add a new error, :ref:`nonlocal-without-binding`
+* Add a new error, :ref:`nonlocal-without-binding <nonlocal-without-binding>`
 
   The error is emitted on Python 3 when a nonlocal name is not bound
   to any variable in the parents scopes.
 
   Closes #582.
 
-* :ref:`deprecated-module` can be shown for modules which aren't
+* :ref:`deprecated-module <deprecated-module>` can be shown for modules which aren't
    available.
 
   Closes #362.
@@ -591,51 +591,51 @@ Release date: 2015-11-29
 * Don't consider a class abstract if its members can't
   be properly inferred.
 
-  This fixes a false positive related to :ref:`abstract-class-instantiated`.
+  This fixes a false positive related to :ref:`abstract-class-instantiated <abstract-class-instantiated>`.
 
   Closes #648.
 
 * Add a new checker for the async features added by PEP 492.
 
-* Add a new error, :ref:`yield-inside-async-function`, emitted on
+* Add a new error, :ref:`yield-inside-async-function <yield-inside-async-function>`, emitted on
   Python 3.5 and upwards when the ``yield`` statement is found inside
   a new coroutine function (PEP 492).
 
-* Add a new error, :ref:`not-async-context-manager`, emitted when
+* Add a new error, :ref:`not-async-context-manager <not-async-context-manager>`, emitted when
   an async context manager block is used with an object which doesn't
   support this protocol (PEP 492).
 
-* Add a new convention warning, :ref:`singleton-comparison`, emitted when
+* Add a new convention warning, :ref:`singleton-comparison <singleton-comparison>`, emitted when
   comparison to True, False or None is found.
 
-* Don't emit :ref:`assigning-non-slot` for descriptors.
+* Don't emit :ref:`assigning-non-slot <assigning-non-slot>` for descriptors.
 
   Closes #652.
 
-* Add a new error, :ref:`repeated-keyword`, when a keyword argument is passed
+* Add a new error, :ref:`repeated-keyword <repeated-keyword>`, when a keyword argument is passed
   multiple times into a function call.
 
-  This is similar with :ref:`redundant-keyword-arg`, but it's mildly different
+  This is similar with :ref:`redundant-keyword-arg <redundant-keyword-arg>`, but it's mildly different
   that it needs to be a separate error.
 
 * --enable=all can now be used.
 
   Closes #142.
 
-* Add a new convention message, :ref:`misplaced-comparison-constant`,
+* Add a new convention message, :ref:`misplaced-comparison-constant <misplaced-comparison-constant>`,
   emitted when a constant is placed in the left hand side of a comparison,
   as in '5 == func()'. This is also called Yoda condition, since the
   flow of code reminds of the Star Wars green character, conditions usually
   encountered in languages with variabile assignments in conditional
   statements.
 
-* Add a new convention message, :ref:`consider-using-enumerate`, which is
+* Add a new convention message, :ref:`consider-using-enumerate <consider-using-enumerate>`, which is
   emitted when code that uses ``range`` and ``len`` for iterating is encountered.
 
   Closes #684.
 
-* Added two new refactoring messages, :ref:`no-classmethod-decorator` and
-  :ref:`no-staticmethod-decorator`, which are emitted when a static method or a class
+* Added two new refactoring messages, :ref:`no-classmethod-decorator <no-classmethod-decorator>` and
+  :ref:`no-staticmethod-decorator <no-staticmethod-decorator>`, which are emitted when a static method or a class
   method is declared without using decorators syntax.
 
   Closes #675.

--- a/doc/whatsnew/1/1.5.rst
+++ b/doc/whatsnew/1/1.5.rst
@@ -494,7 +494,7 @@ Release date: 2015-11-29
 * Improve detection of relative imports in non-packages, as well as importing
   missing modules with a relative import from a package.
 
-* Don't emit no-init if not all the bases from a class are known.
+* Don't emit :ref:`no-init <no-init>` if not all the bases from a class are known.
 
   Closes #604.
 

--- a/doc/whatsnew/1/1.5.rst
+++ b/doc/whatsnew/1/1.5.rst
@@ -106,7 +106,7 @@ Release date: 2015-12-21
 
   Closes #168
 
-* Accept only functions and methods for the :ref:`deprecated-method` checker.
+* Accept only functions and methods for the :ref:`deprecated-method <deprecated-method>` check.
 
   This prevents a crash which can occur when an object doesn't have
   .qname() method after the inference.
@@ -223,7 +223,7 @@ Release date: 2015-11-29
 
   Closes #563
 
-* Make :ref:`no-self-use` checker not emit a warning if there is a 'super()'
+* Make the :ref:`no-self-use <no-self-use>` check not emit a warning if there is a 'super()'
   call inside the method.
 
   Closes #667
@@ -507,7 +507,7 @@ Release date: 2015-11-29
 
   Closes #608.
 
-* Improved the :ref:`not-in-loop` checker to properly detect more cases.
+* Improved the :ref:`not-in-loop <not-in-loop>` check to properly detect more cases.
 
 * Add a new error, :ref:`continue-in-finally`, which is emitted when
   the ``continue`` keyword is found inside a ``finally`` clause, which

--- a/doc/whatsnew/1/1.5.rst
+++ b/doc/whatsnew/1/1.5.rst
@@ -111,7 +111,7 @@ Release date: 2015-12-21
   This prevents a crash which can occur when an object doesn't have
   .qname() method after the inference.
 
-* Don't emit super-on-old-class on classes with unknown bases.
+* Don't emit :ref:`super-on-old-class <super-on-old-class>` on classes with unknown bases.
 
   Closes #721
 

--- a/doc/whatsnew/1/1.6/full.rst
+++ b/doc/whatsnew/1/1.6/full.rst
@@ -59,12 +59,12 @@ Release date: 2016-07-03
 
   Closes #923
 
-* :ref:`bad-builtin` is now an extension check.
+* :ref:`bad-builtin <bad-builtin>` is now an extension check.
 
 * generated-members support qualified name through regular expressions.
 
   For instance, one can specify a regular expression as --generated-members=astroid.node_classes.*
-  for ignoring every :ref:`no-member` error that is accessed as in ``astroid.node_classes.missing.object``.
+  for ignoring every :ref:`no-member <no-member>` error that is accessed as in ``astroid.node_classes.missing.object``.
 
 * Add the ability to ignore files based on regex matching, with the new ``--ignore-patterns``
   option. Allow for multiple ignore patterns to be specified. Rather than clobber the existing
@@ -72,7 +72,7 @@ Release date: 2016-07-03
 
   Closes #156
 
-* Added a new error, :ref:`trailing-newlines`, which is emitted when a file
+* Added a new error, :ref:`trailing-newlines <trailing-newlines>`, which is emitted when a file
   has trailing new lines.
 
   Closes #682
@@ -86,7 +86,7 @@ Release date: 2016-07-03
 
   Closes #162
 
-* Add a new recommendation checker, :ref:`consider-iterating-dictionary`, which is emitted
+* Add a new recommendation checker, :ref:`consider-iterating-dictionary <consider-iterating-dictionary>`, which is emitted
   which is emitted when a dictionary is iterated through .keys().
 
   Closes #699
@@ -98,12 +98,12 @@ Release date: 2016-07-03
 
   Closes #828
 
-* A new error was added, :ref:`invalid-length-returned`, when the ``__len__``
+* A new error was added, :ref:`invalid-length-returned <invalid-length-returned>`, when the ``__len__``
   special method returned something else than a non-negative number.
 
   Closes #557
 
-* Switch to using isort internally for :ref:`wrong-import-order`.
+* Switch to using isort internally for :ref:`wrong-import-order <wrong-import-order>`.
 
   Closes #879
 
@@ -111,14 +111,14 @@ Release date: 2016-07-03
 
   Closes #887
 
-* Don't warn about :ref:`invalid-sequence-index` if the indexed object has unknown base
+* Don't warn about :ref:`invalid-sequence-index <invalid-sequence-index>` if the indexed object has unknown base
   classes.
 
   Closes #867
 
-* Don't crash when checking, for :ref:`super-init-not-called`, a method defined in an if block.
+* Don't crash when checking, for :ref:`super-init-not-called <super-init-not-called>`, a method defined in an if block.
 
-* Do not emit :ref:`import-error` or :ref:`no-name-in-module` for fallback import blocks by default.
+* Do not emit :ref:`import-error <import-error>` or :ref:`no-name-in-module <no-name-in-module>` for fallback import blocks by default.
 
   Until now, we warned with these errors when a fallback import block (a TryExcept block
   that contained imports for Python 2 and 3) was found, but this gets cumbersome when

--- a/doc/whatsnew/1/1.7/full.rst
+++ b/doc/whatsnew/1/1.7/full.rst
@@ -22,17 +22,17 @@ What's New in Pylint 1.7?
 
 Release date: 2017-04-13
 
-* Don't emit :ref:`missing-final-newline` or :ref:`trailing-whitespace` for formfeeds (page breaks).
+* Don't emit :ref:`missing-final-newline <missing-final-newline>` or :ref:`trailing-whitespace <trailing-whitespace>` for formfeeds (page breaks).
 
   Closes #1218 and #1219
 
-* Don't emit by default :ref:`no-member` if we have opaque inference objects in the inference results
+* Don't emit by default :ref:`no-member <no-member>` if we have opaque inference objects in the inference results
 
   This is controlled through the new flag ignore-on-opaque-inference, which is by
   default True. The inference can return  multiple potential results while
   evaluating a Python object, but some branches might not be evaluated, which
   results in partial inference. In that case, it might be useful to still emit
-  :ref:`no-member` and other checks for the rest of the inferred objects.
+  :ref:`no-member <no-member>` and other checks for the rest of the inferred objects.
 
 * Added new message ``assign-to-new-keyword`` to warn about assigning to names which
   will become a keyword in future Python releases.
@@ -40,12 +40,12 @@ Release date: 2017-04-13
   Closes #1351
 
 * Split the 'missing or differing' in parameter documentation in different error.
-  :ref:`differing-param-doc` covers the differing part of the old :ref:`missing-param-doc`',
-  and :ref:`differing-type-doc`' covers the differing part of the old :ref:`missing-type-doc`'
+  :ref:`differing-param-doc <differing-param-doc>` covers the differing part of the old :ref:`missing-param-doc <missing-param-doc>`',
+  and :ref:`differing-type-doc <differing-type-doc>`' covers the differing part of the old :ref:`missing-type-doc <missing-type-doc>`'
 
   Closes #1342
 
-* Added a new error, :ref:`used-prior-global-declaration`', which is emitted when a name
+* Added a new error, :ref:`used-prior-global-declaration <used-prior-global-declaration>`', which is emitted when a name
   is used prior a global declaration in a function. This causes a SyntaxError in
   Python 3.6
 
@@ -62,18 +62,18 @@ Release date: 2017-04-13
 
 * Require one space for annotations with type hints, as per PEP 8.
 
-* :ref:`trailing-comma-tuple`' check was added
+* :ref:`trailing-comma-tuple <trailing-comma-tuple>`' check was added
 
   This message is emitted when pylint finds an one-element tuple,
   created by a stray comma. This can suggest a potential problem in the
   code and it is recommended to use parentheses in order to emphasise the
   creation of a tuple, rather than relying on the comma itself.
 
-* Don't emit :ref:`not-callable` for instances with unknown bases.
+* Don't emit :ref:`not-callable <not-callable>` for instances with unknown bases.
 
   Closes #1213
 
-* Treat keyword only arguments the same as positional arguments with regard to :ref:`unused-argument` check
+* Treat keyword only arguments the same as positional arguments with regard to :ref:`unused-argument <unused-argument>` check
 
 * Don't try to access variables defined in a separate scope when checking for ``protected-access``
 
@@ -84,7 +84,7 @@ Release date: 2017-04-13
 
 * Added new extension to detect comparisons of integers against zero
 
-* Added new error conditions for :ref:`bad-super-call`'
+* Added new error conditions for :ref:`bad-super-call <bad-super-call>`'
 
   Now detects ``super(type(self), self)`` and ``super(self.__class__, self)``
   which can lead to recursion loop in derived classes.
@@ -97,7 +97,7 @@ Release date: 2017-04-13
 
   Closes #1035
 
-* Add a new warning, :ref:`redefined-argument-from-local`'
+* Add a new warning, :ref:`redefined-argument-from-local <redefined-argument-from-local>`'
 
   Closes #649
 
@@ -111,20 +111,20 @@ Release date: 2017-04-13
 
   Closes #441
 
-* Added a new warning, :ref:`useless-super-delegation`'
+* Added a new warning, :ref:`useless-super-delegation <useless-super-delegation>`'
 
   Close 839.
 
-* Added a new error, :ref:`invalid-metaclass`', raised when
+* Added a new error, :ref:`invalid-metaclass <invalid-metaclass>`', raised when
   we can detect that a class is using an improper metaclass.
 
   Closes #579
 
-* Added a new refactoring message, :ref:`literal-comparison`'.
+* Added a new refactoring message, :ref:`literal-comparison <literal-comparison>`'.
 
   Closes #786
 
-* :ref:`arguments-differ` takes in consideration kwonlyargs and variadics
+* :ref:`arguments-differ <arguments-differ>` takes in consideration kwonlyargs and variadics
 
   Closes #983
 
@@ -142,13 +142,13 @@ Release date: 2017-04-13
 
   Fixes part of #975
 
-* ignored-argument-names is now used for ignoring arguments for :ref:`unused-variable` check.
+* ignored-argument-names is now used for ignoring arguments for :ref:`unused-variable <unused-variable>` check.
 
   This option was used for ignoring arguments when computing the correct number of arguments
   a function should have, but for handling the arguments with regard
-  to :ref:`unused-variable` check, dummy-variables-rgx was used instead. Now, ignored-argument-names
+  to :ref:`unused-variable <unused-variable>` check, dummy-variables-rgx was used instead. Now, ignored-argument-names
   is used for its original purpose and also for ignoring the matched arguments for
-  the :ref:`unused-variable` check. This offers a better control of what should be ignored
+  the :ref:`unused-variable <unused-variable>` check. This offers a better control of what should be ignored
   and how.
   Also, the same option was moved from the design checker to the variables checker,
   which means that the option now appears under the ``[VARIABLES]`` section inside
@@ -159,7 +159,7 @@ Release date: 2017-04-13
 * Fix a false positive for keyword variadics with regard to keyword only arguments.
 
   If a keyword only argument was necessary for a function, but that function was called
-  with keyword variadics (\**kwargs), then we were emitting a :ref:`missing-kwoa` false positive,
+  with keyword variadics (\**kwargs), then we were emitting a :ref:`missing-kwoa <missing-kwoa>` false positive,
   which is now fixed.
 
   Closes #934.
@@ -195,30 +195,30 @@ Release date: 2017-04-13
   Refs #746.
 
 * Catch more cases as not proper iterables for __slots__ with
-  regard to :ref:`invalid-slots` pattern.
+  regard to :ref:`invalid-slots <invalid-slots>` pattern.
 
   Closes #775
 
 * empty indent strings are rejected.
 
-* Added a new error, :ref:`relative-beyond-top-level`', which is emitted
+* Added a new error, :ref:`relative-beyond-top-level <relative-beyond-top-level>`', which is emitted
   when a relative import was attempted beyond the top level package.
 
   Closes #588
 
-* Added a new warning, :ref:`unsupported-assignment-operation`', which is
+* Added a new warning, :ref:`unsupported-assignment-operation <unsupported-assignment-operation>`', which is
   emitted when item assignment is tried on an object which doesn't
   have this ability.
 
   Closes #591
 
-* Added a new warning, :ref:`unsupported-delete-operation`', which is
+* Added a new warning, :ref:`unsupported-delete-operation <unsupported-delete-operation>`', which is
   emitted when item deletion is tried on an object which doesn't
   have this ability.
 
   Closes #592
 
-* Fix a false positive of :ref:`redundant-returns-doc`', occurred when the documented
+* Fix a false positive of :ref:`redundant-returns-doc <redundant-returns-doc>`', occurred when the documented
   function was using *yield* instead of *return*.
 
   Closes #984.
@@ -226,13 +226,13 @@ Release date: 2017-04-13
 * Fix false positives of 'missing-[raises|params|type]-doc' due to not
   recognizing keyword synonyms supported by Sphinx.
 
-* Added a new refactoring message, :ref:`consider-merging-isinstance`', which is
+* Added a new refactoring message, :ref:`consider-merging-isinstance <consider-merging-isinstance>`', which is
   emitted whenever we can detect that consecutive isinstance calls can be
   merged together.
 
   Closes #968
 
-* Fix a false positive of :ref:`missing-param-doc`' and :ref:`missing-type-doc`',
+* Fix a false positive of :ref:`missing-param-doc <missing-param-doc>`' and :ref:`missing-type-doc <missing-type-doc>`',
   occurred when a class docstring uses the 'For the parameters, see'
   magic string but the class __init__ docstring does not, or vice versa.
 
@@ -241,7 +241,7 @@ Release date: 2017-04-13
 
   Closes #911.
 
-* Added proper exception type inference for :ref:`missing-raises-doc`'.
+* Added proper exception type inference for :ref:`missing-raises-doc <missing-raises-doc>`'.
 
 * Added InvalidMessageError exception class to replace asserts in
   pylint.utils.
@@ -274,7 +274,7 @@ Release date: 2017-04-13
 * Added a new Python 3 warning around implementing '__div__', '__idiv__', or
   '__rdiv__' as those methods are phased out in Python 3.
 
-* Added a new warning, :ref:`overlapping-except`', which is
+* Added a new warning, :ref:`overlapping-except <overlapping-except>`', which is
   emitted when two exceptions in the same except-clause are aliases
   for each other or one exceptions is an ancestor of another.
 
@@ -283,7 +283,7 @@ Release date: 2017-04-13
 * Added a new Python 3 warning for calling 'str.encode' or 'str.decode' with a non-text
   encoding.
 
-* Added new coding convention message, :ref:`single-string-used-for-slots`'.
+* Added new coding convention message, :ref:`single-string-used-for-slots <single-string-used-for-slots>`'.
 
   Closes #1166
 
@@ -299,7 +299,7 @@ Release date: 2017-04-13
 
   Closes #1032 and #1034
 
-* Added refactoring message :ref:`no-else-return`'.
+* Added refactoring message :ref:`no-else-return <no-else-return>`'.
 
 * Improve the :ref:`unused-variable <unused-variable>` check to warn about unused variables in module scope.
 
@@ -313,7 +313,7 @@ Release date: 2017-04-13
 
   Closes #1177
 
-* Added refactoring message :ref:`consider-using-ternary`'.
+* Added refactoring message :ref:`consider-using-ternary <consider-using-ternary>`'.
 
   Closes #1204
 

--- a/doc/whatsnew/1/1.7/full.rst
+++ b/doc/whatsnew/1/1.7/full.rst
@@ -301,7 +301,7 @@ Release date: 2017-04-13
 
 * Added refactoring message :ref:`no-else-return`'.
 
-* Improve :ref:`unused-variable` checker to warn about unused variables in module scope.
+* Improve the :ref:`unused-variable <unused-variable>` check to warn about unused variables in module scope.
 
   Closes #919
 

--- a/doc/whatsnew/1/1.7/summary.rst
+++ b/doc/whatsnew/1/1.7/summary.rst
@@ -596,7 +596,7 @@ Other Changes
   default True. The inference can return  multiple potential results while
   evaluating a Python object, but some branches might not be evaluated, which
   results in partial inference. In that case, it might be useful to still emit
-  :ref:`no-member` and other checks for the rest of the inferred objects.
+  :ref:`no-member <no-member>` and other checks for the rest of the inferred objects.
 
 * Namespace packages are now supported by pylint. This includes both explicit namespace
   packages and implicit namespace packages, supported in Python 3 through PEP 420.
@@ -609,13 +609,13 @@ Other Changes
   can enable the analysis for both branches using this flag.
 
 * ``ignored-argument-names`` option is now used for ignoring arguments
-  for :ref:`unused-variable` check.
+  for :ref:`unused-variable <unused-variable>` check.
 
   This option was used for ignoring arguments when computing the correct number of arguments
   a function should have, but for handling the arguments with regard
-  to :ref:`unused-variable` check, dummy-variables-rgx was used instead. Now, ignored-argument-names
+  to :ref:`unused-variable <unused-variable>` check, dummy-variables-rgx was used instead. Now, ignored-argument-names
   is used for its original purpose and also for ignoring the matched arguments for
-  the :ref:`unused-variable` check. This offers a better control of what should be ignored
+  the :ref:`unused-variable <unused-variable>` check. This offers a better control of what should be ignored
   and how.
   Also, the same option was moved from the design checker to the variables checker,
   which means that the option now appears under the ``[VARIABLES]`` section inside

--- a/doc/whatsnew/1/1.8/full.rst
+++ b/doc/whatsnew/1/1.8/full.rst
@@ -35,7 +35,7 @@ Release date: 2017-12-15
 
   Closes #1713
 
-* Fixing u'' string in :ref:`superfluous-parens` message
+* Fixing u'' string in :ref:`superfluous-parens <superfluous-parens>` message
 
   Closes #1420
 
@@ -76,9 +76,9 @@ Release date: 2017-12-15
 
 * Added a couple of new Python 3 checks for accessing dict methods in non-iterable context
 
-* Protocol checks (:ref:`not-a-mapping`, :ref:`not-an-iterable` and co.) aren't emitted on classes with dynamic getattr
+* Protocol checks (:ref:`not-a-mapping <not-a-mapping>`, :ref:`not-an-iterable <not-an-iterable>` and co.) aren't emitted on classes with dynamic getattr
 
-* Added a new warning, :ref:`bad-thread-instantiation`'
+* Added a new warning, :ref:`bad-thread-instantiation <bad-thread-instantiation>`'
 
   This message is emitted when the threading.Thread class does not
   receive the target argument, but receives just one argument, which
@@ -147,8 +147,8 @@ Release date: 2017-12-15
 
   Closes #1085
 
-* Disabling :ref:`wrong-import-order`', :ref:`wrong-import-position`', or
-  :ref:`ungrouped-imports`' for a single line now prevents that line from
+* Disabling :ref:`wrong-import-order <wrong-import-order>`', :ref:`wrong-import-position <wrong-import-position>`', or
+  :ref:`ungrouped-imports <ungrouped-imports>`' for a single line now prevents that line from
   triggering violations on subsequent lines.
 
   Closes #1336

--- a/doc/whatsnew/1/1.8/full.rst
+++ b/doc/whatsnew/1/1.8/full.rst
@@ -28,7 +28,7 @@ Release date: 2017-12-15
 
   Closes #1301
 
-* Do not display no-absolute-import warning multiple times per file.
+* Do not display :ref:`no-absolute-import <no-absolute-import>` warning multiple times per file.
 
 * ``trailing-comma-tuple`` refactor check now extends to assignment with
    more than one element (such as lists)
@@ -66,7 +66,7 @@ Release date: 2017-12-15
 
   Closes #1614
 
-* Fix a false positive with bad-python3-import on relative imports
+* Fix a false positive with :ref:`bad-python3-import <bad-python3-import>` on relative imports
 
   Closes #1608
 

--- a/doc/whatsnew/1/1.8/summary.rst
+++ b/doc/whatsnew/1/1.8/summary.rst
@@ -271,7 +271,7 @@ New checkers
 Other Changes
 =============
 
-* Fixing u'' string in :ref:`superfluous-parens` message.
+* Fixing u'' string in :ref:`superfluous-parens <superfluous-parens>` message.
 
 * Configuration options of invalid name checker are significantly redesigned.
   Predefined rules for common naming styles were introduced. For typical
@@ -312,7 +312,7 @@ Other Changes
 * Spelling checker has a new configuration parameter ``max-spelling-suggestions``, which
   affects maximum count of suggestions included in emitted message.
 
-* The **:ref:`invalid-name`** check contains the name of the template that caused the failure.
+* The **:ref:`invalid-name <invalid-name>`** check contains the name of the template that caused the failure.
 
   For the given code, **pylint** used to emit ``invalid-name`` in the form ``Invalid constant name var``,
   without offering any context why ``var`` is not such a good name.

--- a/doc/whatsnew/2/2.0/full.rst
+++ b/doc/whatsnew/2/2.0/full.rst
@@ -65,7 +65,7 @@ Release date: 2018-07-15
 
   Closes #2081
 
-* Support typing.TYPE_CHECKING for *:ref:`unused-import`* errors
+* Support typing.TYPE_CHECKING for *:ref:`unused-import <unused-import>`* errors
 
   Closes #1948
 
@@ -106,14 +106,14 @@ Release date: 2018-07-15
 
   Closes #2076
 
-* :ref:`invalid-slice-index` is not emitted when the slice is used as index for a complex object.
+* :ref:`invalid-slice-index <invalid-slice-index>` is not emitted when the slice is used as index for a complex object.
 
   We only use a handful of known objects (list, set and friends) to figure out if
-  we should emit :ref:`invalid-slice-index` when the slice is used to subscript an object.
+  we should emit :ref:`invalid-slice-index <invalid-slice-index>` when the slice is used to subscript an object.
 
 * Don't emit ``unused-import`` anymore for typing imports used in type comments.
 
-* Add a new check :ref:`useless-import-alias`'.
+* Add a new check :ref:`useless-import-alias <useless-import-alias>`'.
 
   Closes #2052
 
@@ -140,12 +140,12 @@ Release date: 2018-07-15
 
   Closes #2051
 
-* Add a new warning, :ref:`logging-fstring-interpolation`', emitted when f-string
+* Add a new warning, :ref:`logging-fstring-interpolation <logging-fstring-interpolation>`', emitted when f-string
   is used within logging function calls.
 
   Closes #1998
 
-* Don't show :ref:`useless-super-delegation`' if the subclass method has different type annotations.
+* Don't show :ref:`useless-super-delegation <useless-super-delegation>`' if the subclass method has different type annotations.
 
   Closes #1923
 
@@ -198,7 +198,7 @@ Release date: 2018-07-15
 
   Closes #1788
 
-* Don't trigger :ref:`misplaced-bare-raise` when the raise is in a finally clause
+* Don't trigger :ref:`misplaced-bare-raise <misplaced-bare-raise>` when the raise is in a finally clause
 
   Closes #1924
 
@@ -256,7 +256,7 @@ Release date: 2018-07-15
 
   Closes #1831
 
-* Fix :ref:`stop-iteration-return` false positive when next builtin has a
+* Fix :ref:`stop-iteration-return <stop-iteration-return>` false positive when next builtin has a
   default value in a generator
 
   Closes #1830
@@ -329,7 +329,7 @@ Release date: 2018-07-15
 
   Closes #1120
 
-* Fix false positive :ref:`undefined-variable` for lambda argument in class definitions
+* Fix false positive :ref:`undefined-variable <undefined-variable>` for lambda argument in class definitions
 
   Closes #1824
 
@@ -351,7 +351,7 @@ Release date: 2018-07-15
 
   Closes #638
 
-* Fix false positive :ref:`unused-variable` in lambda default arguments
+* Fix false positive :ref:`unused-variable <unused-variable>` in lambda default arguments
 
   Closes #1921
   Closes #1552
@@ -368,7 +368,7 @@ Release date: 2018-07-15
 
   Closes #2102
 
-* Fix :ref:`method-hidden`' raised when assigning to a property or data descriptor.
+* Fix :ref:`method-hidden <method-hidden>`' raised when assigning to a property or data descriptor.
 
 * Fix emitting ``useless-super-delegation`` when changing the default value of keyword arguments.
 
@@ -378,7 +378,7 @@ Release date: 2018-07-15
 
   Closes #2214
 
-* Fix false-positive :ref:`undefined-variable` in nested lambda
+* Fix false-positive :ref:`undefined-variable <undefined-variable>` in nested lambda
 
   Closes #760
 

--- a/doc/whatsnew/2/2.0/full.rst
+++ b/doc/whatsnew/2/2.0/full.rst
@@ -251,7 +251,7 @@ Release date: 2018-07-15
   ``__doc__`` can be used to specify a docstring for a module without
   passing it as a first-statement string.
 
-* Fix false positive bad-whitespace from function arguments with default
+* Fix false positive :ref:`bad-whitespace <bad-whitespace>` from function arguments with default
   values and annotations
 
   Closes #1831

--- a/doc/whatsnew/2/2.0/summary.rst
+++ b/doc/whatsnew/2/2.0/summary.rst
@@ -280,7 +280,7 @@ Other Changes
 
 * Skip wildcard import check for ``__init__.py``.
 
-* Don't warn :ref:`useless-super-delegation`' if the subclass method has different type annotations.
+* Don't warn :ref:`useless-super-delegation <useless-super-delegation>`' if the subclass method has different type annotations.
 
 * Don't warn that a global variable is unused if it is defined by an import
 
@@ -321,10 +321,10 @@ Other Changes
 
 * Fix emitting ``useless-super-delegation`` when changing the default value of keyword arguments.
 
-* Support ``typing.TYPE_CHECKING`` for *:ref:`unused-import`* errors
+* Support ``typing.TYPE_CHECKING`` for *:ref:`unused-import <unused-import>`* errors
 
   When modules are imported under ``typing.TYPE_CHECKING`` guard, ``pylint``
-  will no longer emit *:ref:`unused-import`*.
+  will no longer emit *:ref:`unused-import <unused-import>`*.
 
 * Fix false positive ``unused-variable`` in lambda default arguments
 

--- a/doc/whatsnew/2/2.1/full.rst
+++ b/doc/whatsnew/2/2.1/full.rst
@@ -36,7 +36,7 @@ Release date: 2018-08-01
 
 * ``chain.from_iterable`` no longer emits `dict-{}-not-iterating` when dealing with dict values and keys
 
-* Demote the ``try-except-raise`` message from an error to a warning (:ref:`E0705 <bad-exception-cause>` -> :ref:`W0706 <try-except-raise>`)
+* Demote the ``try-except-raise`` message from an error to a warning (E0705 -> W0706)
 
   Closes #2323
 

--- a/doc/whatsnew/2/2.1/full.rst
+++ b/doc/whatsnew/2/2.1/full.rst
@@ -78,7 +78,7 @@ Release date: 2018-08-01
 
   Closes #2300
 
-* Fix false-positive :ref:`undefined-variable` for self referential class name in lamdbas
+* Fix false-positive :ref:`undefined-variable <undefined-variable>` for self referential class name in lamdbas
 
   Closes #704
 

--- a/doc/whatsnew/2/2.1/full.rst
+++ b/doc/whatsnew/2/2.1/full.rst
@@ -36,7 +36,7 @@ Release date: 2018-08-01
 
 * ``chain.from_iterable`` no longer emits `dict-{}-not-iterating` when dealing with dict values and keys
 
-* Demote the ``try-except-raise`` message from an error to a warning (E0705 -> W0706)
+* Demote the ``try-except-raise`` message from an error to a warning (:ref:`E0705 <bad-exception-cause>` -> :ref:`W0706 <try-except-raise>`)
 
   Closes #2323
 
@@ -61,7 +61,7 @@ Release date: 2018-08-01
 
   Closes #2295
 
-* Fix inconsistent behaviour for bad-continuation on first line of file
+* Fix inconsistent behaviour for :ref:`bad-continuation <bad-continuation>` on first line of file
 
   Closes #2281
 

--- a/doc/whatsnew/2/2.1/summary.rst
+++ b/doc/whatsnew/2/2.1/summary.rst
@@ -48,7 +48,7 @@ Other Changes
 
 * ``no-else-return`` also specifies the type of the branch that is causing the error.
 
-* Fixed inconsistent behaviour for bad-continuation on first line of file.
+* Fixed inconsistent behaviour for :ref:`bad-continuation <bad-continuation>` on first line of file.
 
 * Fixed a bug where ``pylint`` was not able to disable certain messages on the last line through
   the global disable option.

--- a/doc/whatsnew/2/2.10/full.rst
+++ b/doc/whatsnew/2/2.10/full.rst
@@ -55,7 +55,7 @@ Release date: 2021-08-20
   Closes #4775
 
 * Added ``ignored-parents`` option to the design checker to ignore specific
-  classes from the ``too-many-ancestors`` check (R0901).
+  classes from the ``too-many-ancestors`` check (:ref:`R0901 <too-many-ancestors>`).
 
   Fixes part of #3057
 

--- a/doc/whatsnew/2/2.10/full.rst
+++ b/doc/whatsnew/2/2.10/full.rst
@@ -179,4 +179,4 @@ Release date: 2021-08-20
 
 * Improve performance when inferring ``Call`` nodes, by utilizing caching.
 
-* Improve error message for :ref:`invalid-metaclass` when the node is an Instance.
+* Improve error message for :ref:`invalid-metaclass <invalid-metaclass>` when the node is an Instance.

--- a/doc/whatsnew/2/2.10/full.rst
+++ b/doc/whatsnew/2/2.10/full.rst
@@ -55,7 +55,7 @@ Release date: 2021-08-20
   Closes #4775
 
 * Added ``ignored-parents`` option to the design checker to ignore specific
-  classes from the ``too-many-ancestors`` check (:ref:`R0901 <too-many-ancestors>`).
+  classes from the :ref:`too-many-ancestors <too-many-ancestors>` check.
 
   Fixes part of #3057
 

--- a/doc/whatsnew/2/2.10/summary.rst
+++ b/doc/whatsnew/2/2.10/summary.rst
@@ -90,7 +90,7 @@ Other Changes
 * Added ``time.clock`` to deprecated functions/methods for python 3.3
 
 * Added ``ignored-parents`` option to the design checker to ignore specific
-  classes from the ``too-many-ancestors`` check (R0901).
+  classes from the ``too-many-ancestors`` check (:ref:`R0901 <too-many-ancestors>`).
 
 * Don't emit ``no-member`` error if guarded behind if statement.
 

--- a/doc/whatsnew/2/2.10/summary.rst
+++ b/doc/whatsnew/2/2.10/summary.rst
@@ -90,7 +90,7 @@ Other Changes
 * Added ``time.clock`` to deprecated functions/methods for python 3.3
 
 * Added ``ignored-parents`` option to the design checker to ignore specific
-  classes from the ``too-many-ancestors`` check (:ref:`R0901 <too-many-ancestors>`).
+  classes from the :ref:`too-many-ancestors <too-many-ancestors>` check.
 
 * Don't emit ``no-member`` error if guarded behind if statement.
 

--- a/doc/whatsnew/2/2.11/full.rst
+++ b/doc/whatsnew/2/2.11/full.rst
@@ -88,7 +88,7 @@ Release date: 2021-09-16
   Closes #1375
   Closes #330
 
-* Fix false positives for :ref:`invalid-all-format` that are lists or tuples at runtime
+* Fix false positives for :ref:`invalid-all-format <invalid-all-format>` that are lists or tuples at runtime
 
   Closes #4711
 

--- a/doc/whatsnew/2/2.12/full.rst
+++ b/doc/whatsnew/2/2.12/full.rst
@@ -235,7 +235,7 @@ Release date: 2021-11-24
   is set to a version that does not support ``typing.final`` (< 3.8)
 
 * Added configuration option ``exclude-too-few-public-methods`` to allow excluding
-  classes from the ``min-public-methods`` checker.
+  classes from the ``min-public-methods`` check.
 
   Closes #3370
 

--- a/doc/whatsnew/2/2.12/summary.rst
+++ b/doc/whatsnew/2/2.12/summary.rst
@@ -101,7 +101,7 @@ Other Changes
   Closes #5178
 
 * Added configuration option ``exclude-too-few-public-methods`` to allow excluding
-  classes from the ``min-public-methods`` checker.
+  classes from the ``min-public-methods`` check.
 
   Closes #3370
 

--- a/doc/whatsnew/2/2.13/full.rst
+++ b/doc/whatsnew/2/2.13/full.rst
@@ -179,7 +179,7 @@ Release date: 2022-03-29
 
   Closes #5998
 
-* Fix false positive for :ref:`nonexistent-operator`' when repeated '-' are
+* Fix false positive for :ref:`nonexistent-operator <nonexistent-operator>`' when repeated '-' are
   separated (e.g. by parens).
 
   Closes #5769

--- a/doc/whatsnew/2/2.13/summary.rst
+++ b/doc/whatsnew/2/2.13/summary.rst
@@ -600,7 +600,7 @@ Other Changes
 
   Closes #6388
 
-* Fix false positive for :ref:`nonexistent-operator`' when repeated '-' are
+* Fix false positive for :ref:`nonexistent-operator <nonexistent-operator>`' when repeated '-' are
   separated (e.g. by parens).
 
   Closes #5769

--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -157,8 +157,8 @@ Release date: 2022-06-06
 
   Closes #6624
 
-* ``bad-option-value`` (E0012) is now a warning ``unknown-option-value`` (W0012). Deleted messages that do not exist
-  anymore in pylint now raise ``useless-option-value`` (R0022) instead of ``bad-option-value``. This allows to
+* ``bad-option-value`` (:ref:`E0012 <bad-option-value>`) is now a warning ``unknown-option-value`` (:ref:`W0012 <unknown-option-value>`). Deleted messages that do not exist
+  anymore in pylint now raise ``useless-option-value`` (:ref:`R0022 <useless-option-value>`) instead of ``bad-option-value``. This allows to
   distinguish between genuine typos and configuration that could be cleaned up.  Existing message disables for
   ``bad-option-value`` will still work on both new messages.
 
@@ -264,7 +264,7 @@ Release date: 2022-06-01
   by making ``ImportsChecker`` solely responsible for emitting ``deprecated-module`` instead
   of sharing responsibility with ``StdlibChecker``. (This could have led to double messages.)
 
-* The ``no-init`` (W0232) warning has been removed. It's ok to not have an ``__init__`` in a class.
+* The ``no-init`` (:ref:`W0232 <no-init>`) warning has been removed. It's ok to not have an ``__init__`` in a class.
 
   Closes #2409
 

--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -170,7 +170,7 @@ What's New in Pylint 2.14.0?
 Release date: 2022-06-01
 
 
-* The refactoring checker now also raises :ref:`consider-using-generator`' messages for
+* The refactoring checker now also raises :ref:`consider-using-generator <consider-using-generator>`' messages for
   ``max()``, ``min()`` and ``sum()``.
 
   Refs #6595

--- a/doc/whatsnew/2/2.14/full.rst
+++ b/doc/whatsnew/2/2.14/full.rst
@@ -157,8 +157,8 @@ Release date: 2022-06-06
 
   Closes #6624
 
-* ``bad-option-value`` (:ref:`E0012 <bad-option-value>`) is now a warning ``unknown-option-value`` (:ref:`W0012 <unknown-option-value>`). Deleted messages that do not exist
-  anymore in pylint now raise ``useless-option-value`` (:ref:`R0022 <useless-option-value>`) instead of ``bad-option-value``. This allows to
+* :ref:`bad-option-value <bad-option-value>` is now a warning :ref:`unknown-option-value <unknown-option-value>`. Deleted messages that do not exist
+  anymore in pylint now raise :ref:`useless-option-value <useless-option-value>` instead of ``bad-option-value``. This allows to
   distinguish between genuine typos and configuration that could be cleaned up.  Existing message disables for
   ``bad-option-value`` will still work on both new messages.
 
@@ -264,7 +264,7 @@ Release date: 2022-06-01
   by making ``ImportsChecker`` solely responsible for emitting ``deprecated-module`` instead
   of sharing responsibility with ``StdlibChecker``. (This could have led to double messages.)
 
-* The ``no-init`` (:ref:`W0232 <no-init>`) warning has been removed. It's ok to not have an ``__init__`` in a class.
+* The :ref:`no-init <no-init>` warning has been removed. It's ok to not have an ``__init__`` in a class.
 
   Closes #2409
 

--- a/doc/whatsnew/2/2.14/summary.rst
+++ b/doc/whatsnew/2/2.14/summary.rst
@@ -79,7 +79,7 @@ New checkers
 Removed checkers
 ================
 
-* The ``no-init`` (W0232) warning has been removed. It's ok to not have an ``__init__`` in a class.
+* The ``no-init`` (:ref:`W0232 <no-init>`) warning has been removed. It's ok to not have an ``__init__`` in a class.
 
   Closes #2409
 

--- a/doc/whatsnew/2/2.14/summary.rst
+++ b/doc/whatsnew/2/2.14/summary.rst
@@ -79,7 +79,7 @@ New checkers
 Removed checkers
 ================
 
-* The ``no-init`` (:ref:`W0232 <no-init>`) warning has been removed. It's ok to not have an ``__init__`` in a class.
+* The :ref:`no-init <no-init>` warning has been removed. It's ok to not have an ``__init__`` in a class.
 
   Closes #2409
 

--- a/doc/whatsnew/2/2.15/index.rst
+++ b/doc/whatsnew/2/2.15/index.rst
@@ -497,7 +497,7 @@ Other Bug Fixes
 - Fix a failure to lint packages with ``__init__.py`` contained in directories lacking ``__init__.py``.
 
   Closes #1667 (`#1667 <https://github.com/pylint-dev/pylint/issues/1667>`_)
-- Fixed a :ref:`syntax-error` crash that was not handled properly when the declared encoding of a file
+- Fixed a :ref:`syntax-error <syntax-error>` crash that was not handled properly when the declared encoding of a file
   was ``utf-9``.
 
   Closes #3860 (`#3860 <https://github.com/pylint-dev/pylint/issues/3860>`_)

--- a/doc/whatsnew/2/2.16/index.rst
+++ b/doc/whatsnew/2/2.16/index.rst
@@ -149,7 +149,7 @@ Changes requiring user actions
 - The ``accept-no-raise-doc`` option related to ``missing-raises-doc`` will now
   be correctly taken into account all the time.
 
-  Pylint will no longer raise :ref:`missing-raises-doc` (W9006) when no exceptions are
+  Pylint will no longer raise :ref:`missing-raises-doc <missing-raises-doc>` when no exceptions are
   documented and accept-no-raise-doc is true (issue #7208).
   If you were expecting :ref:`missing-raises-doc` errors to be raised in that case,
   you

--- a/doc/whatsnew/2/2.16/index.rst
+++ b/doc/whatsnew/2/2.16/index.rst
@@ -40,7 +40,7 @@ Release date: 2023-03-06
 False Positives Fixed
 ---------------------
 
-- Fix false positive for :ref:`isinstance-second-argument-not-valid-type` with union
+- Fix false positive for :ref:`isinstance-second-argument-not-valid-type <isinstance-second-argument-not-valid-type>` with union
   types.
 
   Closes #8205 (`#8205 <https://github.com/pylint-dev/pylint/issues/8205>`_)
@@ -151,7 +151,7 @@ Changes requiring user actions
 
   Pylint will no longer raise :ref:`missing-raises-doc <missing-raises-doc>` when no exceptions are
   documented and accept-no-raise-doc is true (issue #7208).
-  If you were expecting :ref:`missing-raises-doc` errors to be raised in that case,
+  If you were expecting :ref:`missing-raises-doc <missing-raises-doc>` errors to be raised in that case,
   you
   will now have to add ``accept-no-raise-doc=no`` in your configuration to keep
   the same behavior.

--- a/doc/whatsnew/2/2.17/index.rst
+++ b/doc/whatsnew/2/2.17/index.rst
@@ -220,7 +220,7 @@ False Positives Fixed
 
   Closes #8410 (`#8410 <https://github.com/pylint-dev/pylint/issues/8410>`_)
 
-- Fix false positive for :ref:`isinstance-second-argument-not-valid-type` when union
+- Fix false positive for :ref:`isinstance-second-argument-not-valid-type <isinstance-second-argument-not-valid-type>` when union
   types contains None.
 
   Closes #8424 (`#8424 <https://github.com/pylint-dev/pylint/issues/8424>`_)
@@ -424,7 +424,7 @@ False Positives Fixed
 
   Closes #7574 (`#7574 <https://github.com/pylint-dev/pylint/issues/7574>`_)
 
-- Fix false positive for :ref:`isinstance-second-argument-not-valid-type` with union
+- Fix false positive for :ref:`isinstance-second-argument-not-valid-type <isinstance-second-argument-not-valid-type>` with union
   types.
 
   Closes #8205 (`#8205 <https://github.com/pylint-dev/pylint/issues/8205>`_)
@@ -444,7 +444,7 @@ False Positives Fixed
 False Negatives Fixed
 ---------------------
 
-- Fix a false negative for :ref:`missing-parentheses-for-call-in-test`' when
+- Fix a false negative for :ref:`missing-parentheses-for-call-in-test <missing-parentheses-for-call-in-test>`' when
   inference
   failed for the internal of the call as we did not need that information to
   raise

--- a/doc/whatsnew/2/2.2/full.rst
+++ b/doc/whatsnew/2/2.2/full.rst
@@ -64,7 +64,7 @@ Release date: 2018-11-25
 
   Closes #2522
 
-* Remove ``enumerate`` usage suggestion when defining ``__iter__`` (:ref:`C0200 <consider-using-enumerate>`)
+* Remove ``enumerate`` usage suggestion when defining ``__iter__`` (:ref:`consider-using-enumerate <consider-using-enumerate>`)
 
   Closes #2477
 
@@ -88,7 +88,7 @@ Release date: 2018-11-25
 
   Closes #2488
 
-* Remove wrong modules from ':ref:`bad-python3-import <bad-python3-import>`'.
+* Remove wrong modules from :ref:`bad-python3-import <bad-python3-import>`.
 
   Closes #2453
 
@@ -197,6 +197,6 @@ Release date: 2018-11-25
   Closes #1422
   Closes #2019
 
-* Add a new check ':ref:`implicit-str-concat-in-sequence <implicit-str-concat-in-sequence>`' to spot string concatenation inside lists, sets & tuples.
+* Add a new check :ref:`implicit-str-concat-in-sequence <implicit-str-concat-in-sequence>` to spot string concatenation inside lists, sets & tuples.
 
 * ``literal-comparison`` is now emitted for 0 and 1 literals.

--- a/doc/whatsnew/2/2.2/full.rst
+++ b/doc/whatsnew/2/2.2/full.rst
@@ -64,7 +64,7 @@ Release date: 2018-11-25
 
   Closes #2522
 
-* Remove ``enumerate`` usage suggestion when defining ``__iter__`` (C0200)
+* Remove ``enumerate`` usage suggestion when defining ``__iter__`` (:ref:`C0200 <consider-using-enumerate>`)
 
   Closes #2477
 
@@ -88,7 +88,7 @@ Release date: 2018-11-25
 
   Closes #2488
 
-* Remove wrong modules from 'bad-python3-import'.
+* Remove wrong modules from ':ref:`bad-python3-import <bad-python3-import>`'.
 
   Closes #2453
 
@@ -134,7 +134,7 @@ Release date: 2018-11-25
 
   Closes #2442
 
-* Infer decorated methods when looking for method-hidden
+* Infer decorated methods when looking for :ref:`method-hidden <method-hidden>`
 
   Closes #2369
 
@@ -197,6 +197,6 @@ Release date: 2018-11-25
   Closes #1422
   Closes #2019
 
-* Add a new check 'implicit-str-concat-in-sequence' to spot string concatenation inside lists, sets & tuples.
+* Add a new check ':ref:`implicit-str-concat-in-sequence <implicit-str-concat-in-sequence>`' to spot string concatenation inside lists, sets & tuples.
 
 * ``literal-comparison`` is now emitted for 0 and 1 literals.

--- a/doc/whatsnew/2/2.3/full.rst
+++ b/doc/whatsnew/2/2.3/full.rst
@@ -58,7 +58,7 @@ Release date: 2019-02-27
 
   Closes #2635
 
-* Fix :ref:`missing-raises-doc` false positive (W9006)
+* Fix :ref:`missing-raises-doc <missing-raises-doc>` false positive
 
   Closes #1502
 
@@ -70,7 +70,7 @@ Release date: 2019-02-27
 
   Closes #2645
 
-* Add ``no-else-raise`` warning (R1720)
+* Add ``no-else-raise`` warning (:ref:`R1720 <no-else-raise>`)
 
   Closes #2558
 
@@ -78,7 +78,7 @@ Release date: 2019-02-27
 
   Closes #2643
 
-* Fix incorrect generation of ``no-else-return`` warnings (R1705)
+* Fix incorrect generation of ``no-else-return`` warnings (:ref:`R1705 <no-else-return>`)
 
   Fixed issue where ``if`` statements with nested ``if`` statements
   were incorrectly being flagged as ``no-else-return`` in some cases and

--- a/doc/whatsnew/2/2.3/full.rst
+++ b/doc/whatsnew/2/2.3/full.rst
@@ -125,7 +125,7 @@ Release date: 2019-02-27
 
   Closes #2689
 
-* Add a new option 'check-str-concat-over-line-jumps' to check :ref:`implicit-str-concat-in-sequence`'
+* Add a new option 'check-str-concat-over-line-jumps' to check :ref:`implicit-str-concat-in-sequence <implicit-str-concat-in-sequence>`'
 
 * Fixes for the new style logging format linter.
 

--- a/doc/whatsnew/2/2.3/full.rst
+++ b/doc/whatsnew/2/2.3/full.rst
@@ -70,7 +70,7 @@ Release date: 2019-02-27
 
   Closes #2645
 
-* Add ``no-else-raise`` warning (:ref:`R1720 <no-else-raise>`)
+* Add :ref:`no-else-raise <no-else-raise>` warning
 
   Closes #2558
 
@@ -78,7 +78,7 @@ Release date: 2019-02-27
 
   Closes #2643
 
-* Fix incorrect generation of ``no-else-return`` warnings (:ref:`R1705 <no-else-return>`)
+* Fix incorrect generation of :ref:`no-else-return <no-else-return>` warnings
 
   Fixed issue where ``if`` statements with nested ``if`` statements
   were incorrectly being flagged as ``no-else-return`` in some cases and

--- a/doc/whatsnew/2/2.4/full.rst
+++ b/doc/whatsnew/2/2.4/full.rst
@@ -326,7 +326,7 @@ Release date: 2019-09-24
   This check is emitted when ``pylint`` finds a class variable that conflicts with a slot
   name, which would raise a ``ValueError`` at runtime.
 
-* Added new check: :ref:`dict-iter-missing-items` (E1141)
+* Added new check: :ref:`dict-iter-missing-items <dict-iter-missing-items>`
 
   Closes #2761
 
@@ -340,7 +340,7 @@ Release date: 2019-09-24
 
   Closes #2816
 
-* C0412 (ungrouped-import) is now compatible with isort.
+* :ref:`C0412 <ungrouped-imports>` (ungrouped-import) is now compatible with isort.
 
   Closes #2806
 
@@ -378,7 +378,7 @@ Release date: 2019-09-24
 
   Closes #2581
 
-* Changed description of W0199 to use the term 2-item-tuple instead of 2-uple.
+* Changed description of :ref:`W0199 <assert-on-tuple>` to use the term 2-item-tuple instead of 2-uple.
 
 * Allow a ``.`` as a prefix for Sphinx name resolution.
 

--- a/doc/whatsnew/2/2.4/full.rst
+++ b/doc/whatsnew/2/2.4/full.rst
@@ -280,7 +280,7 @@ Release date: 2019-09-24
 
   Closes #2837
 
-* Ignore raw docstrings when running Similarities checker with ``ignore-docstrings=yes`` option
+* Ignore raw docstrings when running the :ref:`Similarities <similarities-checker>` checker with ``ignore-docstrings=yes`` option
 
 * Fix crash when calling ``inherit_from_std_ex`` on a class which is its own ancestor
 

--- a/doc/whatsnew/2/2.4/full.rst
+++ b/doc/whatsnew/2/2.4/full.rst
@@ -340,7 +340,7 @@ Release date: 2019-09-24
 
   Closes #2816
 
-* :ref:`C0412 <ungrouped-imports>` (ungrouped-import) is now compatible with isort.
+* :ref:`ungrouped-imports <ungrouped-imports>` is now compatible with isort.
 
   Closes #2806
 
@@ -378,7 +378,7 @@ Release date: 2019-09-24
 
   Closes #2581
 
-* Changed description of :ref:`W0199 <assert-on-tuple>` to use the term 2-item-tuple instead of 2-uple.
+* Changed description of :ref:`assert-on-tuple <assert-on-tuple>` to use the term 2-item-tuple instead of 2-uple.
 
 * Allow a ``.`` as a prefix for Sphinx name resolution.
 

--- a/doc/whatsnew/2/2.4/full.rst
+++ b/doc/whatsnew/2/2.4/full.rst
@@ -98,7 +98,7 @@ Release date: 2019-09-25
   for emitting ``used-before-assignment`` if a variable was only defined
   inside a type checking guard (using ``TYPE_CHECKING`` variable from `typing`)
   Unfortunately that missed the case of using those type checking imports
-  inside the guard itself, which triggered spurious :ref:`used-before-assignment` errors.
+  inside the guard itself, which triggered spurious :ref:`used-before-assignment <used-before-assignment>` errors.
 
   Closes #3119
 
@@ -184,7 +184,7 @@ Release date: 2019-09-24
 
   Inferring variadic positional arguments and keyword arguments
   will result into empty Tuples and Dicts, which can lead in
-  some cases to false positives with regard to :ref:`no-value-for-parameter`.
+  some cases to false positives with regard to :ref:`no-value-for-parameter <no-value-for-parameter>`.
   In order to avoid this, until we'll have support for call context
   propagation, we're ignoring such cases if detected.
   We already did that for function calls, but the previous fix

--- a/doc/whatsnew/2/2.5/full.rst
+++ b/doc/whatsnew/2/2.5/full.rst
@@ -112,7 +112,7 @@ Release date: 2020-04-27
 
   Closes #3445
 
-* Fix :ref:`dangerous-default-value` rule to account for keyword argument defaults
+* Fix :ref:`dangerous-default-value <dangerous-default-value>` rule to account for keyword argument defaults
 
   Closes #3373
 

--- a/doc/whatsnew/2/2.5/full.rst
+++ b/doc/whatsnew/2/2.5/full.rst
@@ -336,7 +336,7 @@ Release date: 2020-04-27
   check for nested statements (e.g., inside of an ``if`` statement).
 
 * Recognize classes explicitly inheriting from ``abc.ABC`` or having an
-  ``abc.ABCMeta`` metaclass as abstract. This makes them not trigger :ref:`W0223 <abstract-method>`.
+  ``abc.ABCMeta`` metaclass as abstract. This makes them not trigger :ref:`abstract-method <abstract-method>`.
 
   Closes #3098
 

--- a/doc/whatsnew/2/2.5/full.rst
+++ b/doc/whatsnew/2/2.5/full.rst
@@ -184,16 +184,16 @@ Release date: 2020-04-27
   Closes #3281
 
 * Added errors for protocol functions when invalid return types are detected.
-  E0304 (:ref:`invalid-bool-returned`): __bool__ did not return a bool
-  E0305 (:ref:`invalid-index-returned`): __index__ did not return an integer
-  E0306 (:ref:`invalid-repr-returned`): __repr__ did not return a string
-  E0307 (:ref:`invalid-str-returned`): __str__ did not return a string
-  E0308 (:ref:`invalid-bytes-returned`): __bytes__ did not return a string
-  E0309 (:ref:`invalid-hash-returned`): __hash__ did not return an integer
-  E0310 (:ref:`invalid-length-hint-returned`): __length_hint__ did not return a non-negative integer
-  E0311 (:ref:`invalid-format-returned`): __format__ did not return a string
-  E0312 (:ref:`invalid-getnewargs-returned`): __getnewargs__ did not return a tuple
-  E0313 (:ref:`invalid-getnewargs-ex-returned`): __getnewargs_ex__ did not return a tuple of the form (tuple, dict)
+  :ref:`invalid-bool-returned <invalid-bool-returned>`: __bool__ did not return a bool
+  :ref:`invalid-index-returned <invalid-index-returned>`: __index__ did not return an integer
+  :ref:`invalid-repr-returned <invalid-repr-returned>`: __repr__ did not return a string
+  :ref:`invalid-str-returned <invalid-str-returned>`: __str__ did not return a string
+  :ref:`invalid-bytes-returned <invalid-bytes-returned>`: __bytes__ did not return a string
+  :ref:`invalid-hash-returned <invalid-hash-returned>`: __hash__ did not return an integer
+  :ref:`invalid-length-hint-returned <invalid-length-hint-returned>`: __length_hint__ did not return a non-negative integer
+  :ref:`invalid-format-returned <invalid-format-returned>`: __format__ did not return a string
+  :ref:`invalid-getnewargs-returned <invalid-getnewargs-returned>`: __getnewargs__ did not return a tuple
+  :ref:`invalid-getnewargs-ex-returned <invalid-getnewargs-ex-returned>`: __getnewargs_ex__ did not return a tuple of the form (tuple, dict)
 
   Closes #560
 
@@ -272,7 +272,7 @@ Release date: 2020-04-27
 
   Closes #617
 
-* Fix exception-escape false positive with generators
+* Fix :ref:`exception-escape <exception-escape>` false positive with generators
 
   Closes #3128
 
@@ -336,7 +336,7 @@ Release date: 2020-04-27
   check for nested statements (e.g., inside of an ``if`` statement).
 
 * Recognize classes explicitly inheriting from ``abc.ABC`` or having an
-  ``abc.ABCMeta`` metaclass as abstract. This makes them not trigger W0223.
+  ``abc.ABCMeta`` metaclass as abstract. This makes them not trigger :ref:`W0223 <abstract-method>`.
 
   Closes #3098
 

--- a/doc/whatsnew/2/2.6/full.rst
+++ b/doc/whatsnew/2/2.6/full.rst
@@ -38,7 +38,7 @@ Release date: 2020-08-20
 
 * Add an faq detailing which messages to disable to avoid duplicates w/ other popular linters
 
-* Fix :ref:`superfluous-parens` false-positive for the walrus operator
+* Fix :ref:`superfluous-parens <superfluous-parens>` false-positive for the walrus operator
 
   Closes #3383
 

--- a/doc/whatsnew/2/2.6/full.rst
+++ b/doc/whatsnew/2/2.6/full.rst
@@ -18,7 +18,7 @@ Release date: 2020-08-20
 
   Closes #1082, #3434, #3461
 
-* bad-continuation and bad-whitespace have been removed, black or another formatter can help you with this better than Pylint
+* :ref:`bad-continuation <bad-continuation>` and :ref:`bad-whitespace <bad-whitespace>` have been removed, black or another formatter can help you with this better than Pylint
 
   Closes #246, #289, #638, #747, #1148, #1179, #1943, #2041, #2301, #2304, #2944, #3565
 
@@ -30,7 +30,7 @@ Release date: 2020-08-20
 
   Closes #3655
 
-* mixed-indentation has been removed, it is no longer useful since TabError is included directly in python3
+* :ref:`mixed-indentation <mixed-indentation>` has been removed, it is no longer useful since TabError is included directly in python3
 
   Closes #2984 #3573
 

--- a/doc/whatsnew/2/2.6/summary.rst
+++ b/doc/whatsnew/2/2.6/summary.rst
@@ -23,6 +23,6 @@ Other Changes
 
 * ``mixed-indentation`` has been removed, it is no longer useful since TabError is included directly in python3
 
-* Fix :ref:`superfluous-parens` false-positive for the walrus operator
+* Fix :ref:`superfluous-parens <superfluous-parens>` false-positive for the walrus operator
 
 * Add support for both isort 4 and isort 5. If you have pinned isort 4 in your project requirements, nothing changes. If you use isort 5, though, note that the ``known-standard-library`` option is not interpreted the same in isort 4 and isort 5 (see `the migration guide in isort documentation` (no longer available) for further details). For compatibility's sake for most pylint users, the ``known-standard-library`` option in pylint now maps to ``extra-standard-library`` in isort 5. If you really want what ``known-standard-library`` now means in isort 5, you must disable the ``wrong-import-order`` check in pylint and run isort manually with a proper isort configuration file.

--- a/doc/whatsnew/2/2.7/full.rst
+++ b/doc/whatsnew/2/2.7/full.rst
@@ -137,7 +137,7 @@ Release date: 2021-02-21
 
 * Add ``nan-comparison`` check for NaN comparisons
 
-* Bug fix for empty-comment message line number.
+* Bug fix for :ref:`empty-comment <empty-comment>` message line number.
 
   Closes #4009
 
@@ -179,7 +179,7 @@ Release date: 2021-02-21
 
   Closes #3347, #3953, #3865, #3275
 
-* Fix TypedDict inherit-non-class false-positive Python 3.9+
+* Fix TypedDict :ref:`inherit-non-class <inherit-non-class>` false-positive Python 3.9+
 
   Closes #1927
 

--- a/doc/whatsnew/2/2.8/full.rst
+++ b/doc/whatsnew/2/2.8/full.rst
@@ -52,7 +52,7 @@ Release date: 2021-04-24
 
   Closes #4252
 
-* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (R5601 ``confusing-consecutive-elif``)
+* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (:ref:`R5601 <confusing-consecutive-elif>` ``confusing-consecutive-elif``)
   if if/elif statements with different indentation levels follow directly one after the other.
 
 * New option ``--output=<file>`` to output result to a file rather than printing to stdout.

--- a/doc/whatsnew/2/2.8/full.rst
+++ b/doc/whatsnew/2/2.8/full.rst
@@ -52,7 +52,7 @@ Release date: 2021-04-24
 
   Closes #4252
 
-* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (:ref:`R5601 <confusing-consecutive-elif>` ``confusing-consecutive-elif``)
+* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (:ref:`confusing-consecutive-elif <confusing-consecutive-elif>`)
   if if/elif statements with different indentation levels follow directly one after the other.
 
 * New option ``--output=<file>`` to output result to a file rather than printing to stdout.

--- a/doc/whatsnew/2/2.8/summary.rst
+++ b/doc/whatsnew/2/2.8/summary.rst
@@ -25,7 +25,7 @@ New checkers
 
 * Add ``deprecated-argument`` check for deprecated arguments.
 
-* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (R5601 ``confusing-consecutive-elif``)
+* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (:ref:`R5601 <confusing-consecutive-elif>` ``confusing-consecutive-elif``)
   if if/elif statements with different indentation levels follow directly one after the other.
 
 * Add ``consider-using-min-max-builtin`` check for if statement which could be replaced by Python builtin min or max.

--- a/doc/whatsnew/2/2.8/summary.rst
+++ b/doc/whatsnew/2/2.8/summary.rst
@@ -25,7 +25,7 @@ New checkers
 
 * Add ``deprecated-argument`` check for deprecated arguments.
 
-* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (:ref:`R5601 <confusing-consecutive-elif>` ``confusing-consecutive-elif``)
+* Add new extension ``ConfusingConsecutiveElifChecker``. This optional checker emits a refactoring message (:ref:`confusing-consecutive-elif <confusing-consecutive-elif>`)
   if if/elif statements with different indentation levels follow directly one after the other.
 
 * Add ``consider-using-min-max-builtin`` check for if statement which could be replaced by Python builtin min or max.

--- a/doc/whatsnew/2/2.9/full.rst
+++ b/doc/whatsnew/2/2.9/full.rst
@@ -79,7 +79,7 @@ Release date: 2021-07-20
 
   Closes #4715
 
-* Clarify documentation for :ref:`consider-using-from-import`
+* Clarify documentation for :ref:`consider-using-from-import <consider-using-from-import>`
 
 * Don't emit ``unreachable`` warning for empty generator functions
 
@@ -288,7 +288,7 @@ Release date: 2021-06-29
   Closes #585
 
 * Fix a crash when a plugin from the configuration could not be loaded and raise an error
-  :ref:`bad-plugin-value`' instead
+  :ref:`bad-plugin-value <bad-plugin-value>`' instead
 
   Closes #4555
 

--- a/doc/whatsnew/2/2.9/full.rst
+++ b/doc/whatsnew/2/2.9/full.rst
@@ -45,7 +45,7 @@ Release date: 2021-07-20
 
   Closes #4687
 
-* Fix false-positive ``consider-using-with`` (R1732) if a ternary conditional is used together with ``with``
+* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if a ternary conditional is used together with ``with``
 
   Closes #4676
 
@@ -53,7 +53,7 @@ Release date: 2021-07-20
 
   Closes #4629
 
-* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
 
   Closes #4654
 

--- a/doc/whatsnew/2/2.9/full.rst
+++ b/doc/whatsnew/2/2.9/full.rst
@@ -45,7 +45,7 @@ Release date: 2021-07-20
 
   Closes #4687
 
-* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if a ternary conditional is used together with ``with``
+* Fix false-positive :ref:`consider-using-with <consider-using-with>` if a ternary conditional is used together with ``with``
 
   Closes #4676
 
@@ -53,7 +53,7 @@ Release date: 2021-07-20
 
   Closes #4629
 
-* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+* Fix false-positive :ref:`consider-using-with <consider-using-with>` if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
 
   Closes #4654
 

--- a/doc/whatsnew/2/2.9/summary.rst
+++ b/doc/whatsnew/2/2.9/summary.rst
@@ -58,9 +58,9 @@ New checkers
 Other Changes
 =============
 
-* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if a ternary conditional is used together with ``with``
+* Fix false-positive :ref:`consider-using-with <consider-using-with>` if a ternary conditional is used together with ``with``
 
-* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+* Fix false-positive :ref:`consider-using-with <consider-using-with>` if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
 
 * Add type annotations to pyreverse dot files
 

--- a/doc/whatsnew/2/2.9/summary.rst
+++ b/doc/whatsnew/2/2.9/summary.rst
@@ -58,9 +58,9 @@ New checkers
 Other Changes
 =============
 
-* Fix false-positive ``consider-using-with`` (R1732) if a ternary conditional is used together with ``with``
+* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if a ternary conditional is used together with ``with``
 
-* Fix false-positive ``consider-using-with`` (R1732) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
+* Fix false-positive ``consider-using-with`` (:ref:`R1732 <consider-using-with>`) if ``contextlib.ExitStack`` takes care of calling the ``__exit__`` method
 
 * Add type annotations to pyreverse dot files
 

--- a/doc/whatsnew/3/3.0/index.rst
+++ b/doc/whatsnew/3/3.0/index.rst
@@ -84,7 +84,7 @@ False Positives Fixed
 
   Closes #9246 (`#9246 <https://github.com/pylint-dev/pylint/issues/9246>`_)
 
-- Fixed false positive :ref:`nested-min-max` for nested lists.
+- Fixed false positive :ref:`nested-min-max <nested-min-max>` for nested lists.
 
   Closes #9307 (`#9307 <https://github.com/pylint-dev/pylint/issues/9307>`_)
 
@@ -117,10 +117,10 @@ False Positives Fixed
 
   Closes #9148 (`#9148 <https://github.com/pylint-dev/pylint/issues/9148>`_)
 
-- Fixed incorrect suggestion for shallow copy in :ref:`unnecessary-comprehension`
+- Fixed incorrect suggestion for shallow copy in :ref:`unnecessary-comprehension <unnecessary-comprehension>`
 
   Example of the suggestion:
-  #pylint: disable=:ref:`missing-module-docstring`
+  #pylint: disable=:ref:`missing-module-docstring <missing-module-docstring>`
   a = [1, 2, 3]
   b = [x for x in a]
   b[0] = 0
@@ -437,7 +437,7 @@ False Positives Fixed
 
 - When checking for unbalanced dict unpacking in for-loops, Pylint will now test whether the length of each value to be
   unpacked matches the number of unpacking targets. Previously, Pylint would test the number of values for the loop
-  iteration, which would produce a false :ref:`unbalanced-dict-unpacking` warning.
+  iteration, which would produce a false :ref:`unbalanced-dict-unpacking <unbalanced-dict-unpacking>` warning.
 
   Closes #8156 (`#8156 <https://github.com/pylint-dev/pylint/issues/8156>`_)
 
@@ -456,7 +456,7 @@ False Positives Fixed
 
   Closes #8410 (`#8410 <https://github.com/pylint-dev/pylint/issues/8410>`_)
 
-- Fix false positive for :ref:`isinstance-second-argument-not-valid-type` when union types contains None.
+- Fix false positive for :ref:`isinstance-second-argument-not-valid-type <isinstance-second-argument-not-valid-type>` when union types contains None.
 
   Closes #8424 (`#8424 <https://github.com/pylint-dev/pylint/issues/8424>`_)
 
@@ -694,7 +694,7 @@ Other Changes
 
   Closes #8760 (`#8760 <https://github.com/pylint-dev/pylint/issues/8760>`_)
 
-- Renamed the ":ref:`unneeded-not`" error into "unnecessary_negation" to be clearer.
+- Renamed the ":ref:`unneeded-not <unneeded-not>`" error into "unnecessary_negation" to be clearer.
 
   Closes #8789 (`#8789 <https://github.com/pylint-dev/pylint/issues/8789>`_)
 

--- a/doc/whatsnew/3/3.1/index.rst
+++ b/doc/whatsnew/3/3.1/index.rst
@@ -100,7 +100,7 @@ False Positives Fixed
 False Negatives Fixed
 ---------------------
 
-- Extend :ref:`broad-exception-raised` and :ref:`broad-exception-caught` to except*.
+- Extend :ref:`broad-exception-raised <broad-exception-raised>` and :ref:`broad-exception-caught <broad-exception-caught>` to except*.
 
   Closes #8827 (`#8827 <https://github.com/pylint-dev/pylint/issues/8827>`_)
 
@@ -113,7 +113,7 @@ False Negatives Fixed
 Other Bug Fixes
 ---------------
 
-- Improve the message provided for :ref:`wrong-import-order` check.  Instead of the import statement ("import x"), the message now specifies the import that is out of order and which imports should come after it.  As reported in the issue, this is particularly helpful if there are multiple imports on a single line that do not follow the PEP8 convention.
+- Improve the message provided for :ref:`wrong-import-order <wrong-import-order>` check.  Instead of the import statement ("import x"), the message now specifies the import that is out of order and which imports should come after it.  As reported in the issue, this is particularly helpful if there are multiple imports on a single line that do not follow the PEP8 convention.
 
   The message will report imports as follows:
   For "import X", it will report "(standard/third party/first party/local) import X"

--- a/doc/whatsnew/3/3.2/index.rst
+++ b/doc/whatsnew/3/3.2/index.rst
@@ -148,7 +148,7 @@ Release date: 2024-06-06
 False Positives Fixed
 ---------------------
 
-- Classes with only an Ellipsis (``...``) in their body do not trigger :ref:`multiple-statements`'
+- Classes with only an Ellipsis (``...``) in their body do not trigger :ref:`multiple-statements <multiple-statements>`'
   anymore if they are inlined (in accordance with black's 2024 style).
 
   Closes #9398 (`#9398 <https://github.com/pylint-dev/pylint/issues/9398>`_)

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -34,7 +34,7 @@ False Positives Fixed
 
   Closes #10508 (`#10508 <https://github.com/pylint-dev/pylint/issues/10508>`_)
 
-- Fix false positive ``undefined-variable`` (:ref:`E0602 <undefined-variable>`) for for-loop variable shadowing patterns like ``for item in item:`` when the variable was previously defined.
+- Fix false positive :ref:`undefined-variable <undefined-variable>` for for-loop variable shadowing patterns like ``for item in item:`` when the variable was previously defined.
 
   Closes #10562 (`#10562 <https://github.com/pylint-dev/pylint/issues/10562>`_)
 

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -34,7 +34,7 @@ False Positives Fixed
 
   Closes #10508 (`#10508 <https://github.com/pylint-dev/pylint/issues/10508>`_)
 
-- Fix false positive ``undefined-variable`` (E0602) for for-loop variable shadowing patterns like ``for item in item:`` when the variable was previously defined.
+- Fix false positive ``undefined-variable`` (:ref:`E0602 <undefined-variable>`) for for-loop variable shadowing patterns like ``for item in item:`` when the variable was previously defined.
 
   Closes #10562 (`#10562 <https://github.com/pylint-dev/pylint/issues/10562>`_)
 

--- a/doc/whatsnew/3/3.3/index.rst
+++ b/doc/whatsnew/3/3.3/index.rst
@@ -22,7 +22,7 @@ Release date: 2025-10-05
 False Positives Fixed
 ---------------------
 
-- Fix :ref:`used-before-assignment` for PEP 695 type aliases and parameters.
+- Fix :ref:`used-before-assignment <used-before-assignment>` for PEP 695 type aliases and parameters.
 
   Closes #9815 (`#9815 <https://github.com/pylint-dev/pylint/issues/9815>`_)
 
@@ -63,16 +63,16 @@ For details, see: https://github.com/pylint-dev/pylint/pull/10482#issuecomment-3
 False Positives Fixed
 ---------------------
 
-- Fix false positives for :ref:`possibly-used-before-assignment` when variables are exhaustively
+- Fix false positives for :ref:`possibly-used-before-assignment <possibly-used-before-assignment>` when variables are exhaustively
   assigned within a :keyword:`match` block.
 
   Closes #9668 (`#9668 <https://github.com/pylint-dev/pylint/issues/9668>`_)
 
-- Fix false positive for :ref:`missing-raises-doc` and :ref:`missing-yield-doc` when the method length is less than docstring-min-length.
+- Fix false positive for :ref:`missing-raises-doc <missing-raises-doc>` and :ref:`missing-yield-doc <missing-yield-doc>` when the method length is less than docstring-min-length.
 
   Refs #10104 (`#10104 <https://github.com/pylint-dev/pylint/issues/10104>`_)
 
-- Fix a false positive for :ref:`unused-variable` when multiple except handlers bind the same name under a try block.
+- Fix a false positive for :ref:`unused-variable <unused-variable>` when multiple except handlers bind the same name under a try block.
 
   Closes #10426 (`#10426 <https://github.com/pylint-dev/pylint/issues/10426>`_)
 
@@ -81,7 +81,7 @@ False Positives Fixed
 False Negatives Fixed
 ---------------------
 
-- Fix false-negative for :ref:`used-before-assignment` with ``from __future__ import annotations`` in function definitions.
+- Fix false-negative for :ref:`used-before-assignment <used-before-assignment>` with ``from __future__ import annotations`` in function definitions.
 
   Refs #10482 (`#10482 <https://github.com/pylint-dev/pylint/issues/10482>`_)
 
@@ -108,7 +108,7 @@ Release date: 2025-05-04
 False Positives Fixed
 ---------------------
 
-- Comparisons between two calls to `type()` won't raise an :ref:`unidiomatic-typecheck` warning anymore, consistent with the behavior applied only for ``==`` previously.
+- Comparisons between two calls to `type()` won't raise an :ref:`unidiomatic-typecheck <unidiomatic-typecheck>` warning anymore, consistent with the behavior applied only for ``==`` previously.
 
   Closes #10161 (`#10161 <https://github.com/pylint-dev/pylint/issues/10161>`_)
 
@@ -125,7 +125,7 @@ Other Bug Fixes
 
   Closes #10282 (`#10282 <https://github.com/pylint-dev/pylint/issues/10282>`_)
 
-- Using a slice as a class decorator now raises a :ref:`not-callable` message instead of crashing. A lot of checks that dealt with decorators (too many to list) are now shortcut if the decorator can't immediately be inferred to a function or class definition.
+- Using a slice as a class decorator now raises a :ref:`not-callable <not-callable>` message instead of crashing. A lot of checks that dealt with decorators (too many to list) are now shortcut if the decorator can't immediately be inferred to a function or class definition.
 
   Closes #10334 (`#10334 <https://github.com/pylint-dev/pylint/issues/10334>`_)
 
@@ -134,7 +134,7 @@ Other Bug Fixes
 Other Changes
 -------------
 
-- The algorithm used for :ref:`no-member` suggestions is now more efficient and cuts the
+- The algorithm used for :ref:`no-member <no-member>` suggestions is now more efficient and cuts the
   calculation when the distance score is already above the threshold.
 
   Refs #10277 (`#10277 <https://github.com/pylint-dev/pylint/issues/10277>`_)
@@ -149,7 +149,7 @@ Release date: 2025-03-20
 False Positives Fixed
 ---------------------
 
-- Fix a false positive for :ref:`used-before-assignment` when an inner function's return type
+- Fix a false positive for :ref:`used-before-assignment <used-before-assignment>` when an inner function's return type
   annotation is a class defined at module scope.
 
   Closes #9391 (`#9391 <https://github.com/pylint-dev/pylint/issues/9391>`_)
@@ -164,12 +164,12 @@ Release date: 2025-03-09
 False Positives Fixed
 ---------------------
 
-- Fix false positives for :ref:`use-implicit-booleaness-not-comparison`, :ref:`use-implicit-booleaness-not-comparison-to-string`
-  and :ref:`use-implicit-booleaness-not-comparison-to-zero` when chained comparisons are checked.
+- Fix false positives for :ref:`use-implicit-booleaness-not-comparison <use-implicit-booleaness-not-comparison>`, :ref:`use-implicit-booleaness-not-comparison-to-string <use-implicit-booleaness-not-comparison-to-string>`
+  and :ref:`use-implicit-booleaness-not-comparison-to-zero <use-implicit-booleaness-not-comparison-to-zero>` when chained comparisons are checked.
 
   Closes #10065 (`#10065 <https://github.com/pylint-dev/pylint/issues/10065>`_)
 
-- Fix a false positive for :ref:`invalid-getnewargs-ex-returned` when the tuple or dict has been assigned to a name.
+- Fix a false positive for :ref:`invalid-getnewargs-ex-returned <invalid-getnewargs-ex-returned>` when the tuple or dict has been assigned to a name.
 
   Closes #10208 (`#10208 <https://github.com/pylint-dev/pylint/issues/10208>`_)
 
@@ -182,7 +182,7 @@ False Positives Fixed
 Other Bug Fixes
 ---------------
 
-- Fixed conditional import x.y causing false positive :ref:`possibly-used-before-assignment`.
+- Fixed conditional import x.y causing false positive :ref:`possibly-used-before-assignment <possibly-used-before-assignment>`.
 
   Closes #10081 (`#10081 <https://github.com/pylint-dev/pylint/issues/10081>`_)
 
@@ -190,7 +190,7 @@ Other Bug Fixes
 
   Closes #10106 (`#10106 <https://github.com/pylint-dev/pylint/issues/10106>`_)
 
-- Fixed raising :ref:`invalid-name` when using camelCase for private methods with two leading underscores.
+- Fixed raising :ref:`invalid-name <invalid-name>` when using camelCase for private methods with two leading underscores.
 
   Closes #10189 (`#10189 <https://github.com/pylint-dev/pylint/issues/10189>`_)
 
@@ -235,12 +235,12 @@ Release date: 2024-12-23
 False Positives Fixed
 ---------------------
 
-- Fix false positives for :ref:`undefined-variable` for classes using Python 3.12
+- Fix false positives for :ref:`undefined-variable <undefined-variable>` for classes using Python 3.12
   generic type syntax.
 
   Closes #9335 (`#9335 <https://github.com/pylint-dev/pylint/issues/9335>`_)
 
-- Fix a false positive for :ref:`use-implicit-booleaness-not-len`. No lint should be emitted for
+- Fix a false positive for :ref:`use-implicit-booleaness-not-len <use-implicit-booleaness-not-len>`. No lint should be emitted for
   generators (:py:func:`len` is not defined for generators).
 
   Refs #10100 (`#10100 <https://github.com/pylint-dev/pylint/issues/10100>`_)
@@ -264,7 +264,7 @@ Release date: 2024-12-01
 False Positives Fixed
 ---------------------
 
-- Fix a false positive for :ref:`potential-index-error` when an indexed iterable
+- Fix a false positive for :ref:`potential-index-error <potential-index-error>` when an indexed iterable
   contains a starred element that evaluates to more than one item.
 
   Closes #10076 (`#10076 <https://github.com/pylint-dev/pylint/issues/10076>`_)
@@ -314,7 +314,7 @@ Changes requiring user actions
 New Features
 ------------
 
-- Add new :ref:`declare-non-slot` error which reports when a class has a `__slots__` member and a type hint on the class is not present in `__slots__`.
+- Add new :ref:`declare-non-slot <declare-non-slot>` error which reports when a class has a `__slots__` member and a type hint on the class is not present in `__slots__`.
 
   Refs #9499 (`#9499 <https://github.com/pylint-dev/pylint/issues/9499>`_)
 
@@ -323,7 +323,7 @@ New Features
 New Checks
 ----------
 
-- Added :ref:`too-many-positional-arguments` to allow distinguishing the configuration for too many
+- Added :ref:`too-many-positional-arguments <too-many-positional-arguments>` to allow distinguishing the configuration for too many
   total arguments (with keyword-only params specified after `*`) from the configuration
   for too many positional-or-keyword or positional-only arguments.
 
@@ -332,23 +332,23 @@ New Checks
 
   Closes #9099 (`#9099 <https://github.com/pylint-dev/pylint/issues/9099>`_)
 
-- Add :ref:`using-exception-groups-in-unsupported-version` and
-  :ref:`using-generic-type-syntax-in-unsupported-version` for uses of Python 3.11+ or
+- Add :ref:`using-exception-groups-in-unsupported-version <using-exception-groups-in-unsupported-version>` and
+  :ref:`using-generic-type-syntax-in-unsupported-version <using-generic-type-syntax-in-unsupported-version>` for uses of Python 3.11+ or
   3.12+ features on lower supported versions provided with ``--py-version``.
 
   Closes #9791 (`#9791 <https://github.com/pylint-dev/pylint/issues/9791>`_)
 
-- Add :ref:`using-assignment-expression-in-unsupported-version` for uses of ``:=`` (walrus operator)
+- Add :ref:`using-assignment-expression-in-unsupported-version <using-assignment-expression-in-unsupported-version>` for uses of ``:=`` (walrus operator)
   on Python versions below 3.8 provided with ``--py-version``.
 
   Closes #9820 (`#9820 <https://github.com/pylint-dev/pylint/issues/9820>`_)
 
-- Add :ref:`using-positional-only-args-in-unsupported-version` for uses of positional-only args on
+- Add :ref:`using-positional-only-args-in-unsupported-version <using-positional-only-args-in-unsupported-version>` for uses of positional-only args on
   Python versions below 3.8 provided with ``--py-version``.
 
   Closes #9823 (`#9823 <https://github.com/pylint-dev/pylint/issues/9823>`_)
 
-- Add :ref:`unnecessary-default-type-args` to the ``typing`` extension to detect the use
+- Add :ref:`unnecessary-default-type-args <unnecessary-default-type-args>` to the ``typing`` extension to detect the use
   of unnecessary default type args for :py:class:`typing.Generator` and :py:class:`typing.AsyncGenerator`.
 
   Refs #9938 (`#9938 <https://github.com/pylint-dev/pylint/issues/9938>`_)
@@ -362,20 +362,20 @@ False Negatives Fixed
 
   Closes #7565. (`#7565 <https://github.com/pylint-dev/pylint/issues/7565>`_)
 
-- Fix a false negative for :ref:`await-outside-async` when await is inside Lambda.
+- Fix a false negative for :ref:`await-outside-async <await-outside-async>` when await is inside Lambda.
 
   Refs #9653 (`#9653 <https://github.com/pylint-dev/pylint/issues/9653>`_)
 
-- Fix a false negative for :ref:`duplicate-argument-name` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check.
+- Fix a false negative for :ref:`duplicate-argument-name <duplicate-argument-name>` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check.
 
   Closes #9669 (`#9669 <https://github.com/pylint-dev/pylint/issues/9669>`_)
 
-- Fix false negative for :ref:`multiple-statements` when multiple statements are present on :keyword:`else` and :keyword:`finally` lines of :keyword:`try`.
+- Fix false negative for :ref:`multiple-statements <multiple-statements>` when multiple statements are present on :keyword:`else` and :keyword:`finally` lines of :keyword:`try`.
 
   Refs #9759 (`#9759 <https://github.com/pylint-dev/pylint/issues/9759>`_)
 
 - Fix false negatives when :py:func::`isinstance` does not have exactly two arguments.
-  pylint now emits a :ref:`too-many-function-args` or :ref:`no-value-for-parameter`
+  pylint now emits a :ref:`too-many-function-args <too-many-function-args>` or :ref:`no-value-for-parameter <no-value-for-parameter>`
   appropriately for :py:func:`isinstance` calls.
 
   Closes #9847 (`#9847 <https://github.com/pylint-dev/pylint/issues/9847>`_)
@@ -424,7 +424,7 @@ Internal Changes
 ----------------
 
 - All variables, classes, functions and file names containing the word 'similar', when it was,
-  in fact, referring to 'symilar' (the standalone program for the :ref:`duplicate-code` check) were renamed
+  in fact, referring to 'symilar' (the standalone program for the :ref:`duplicate-code <duplicate-code>` check) were renamed
   to 'symilar'.
 
   Closes #9734 (`#9734 <https://github.com/pylint-dev/pylint/issues/9734>`_)

--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -129,7 +129,7 @@ Other Bug Fixes
 
   Closes #11147 (`#11147 <https://github.com/pylint-dev/pylint/issues/11147>`_)
 
-- Fix a false positive for :ref:`useless-parent-delegation` when an override changes
+- Fix a false positive for :ref:`useless-parent-delegation <useless-parent-delegation>` when an override changes
   the default value of a positional-only parameter.
 
   Closes #11148 (`#11148 <https://github.com/pylint-dev/pylint/issues/11148>`_)
@@ -433,17 +433,17 @@ Release date: 2025-10-20
 False Positives Fixed
 ---------------------
 
-- Fix false positive for :ref:`invalid-name` on a partially uninferable module-level constant.
+- Fix false positive for :ref:`invalid-name <invalid-name>` on a partially uninferable module-level constant.
 
   Closes #10652 (`#10652 <https://github.com/pylint-dev/pylint/issues/10652>`_)
 
-- Fix a false positive for :ref:`invalid-name` on exclusive module-level assignments
-  composed of three or more branches. We won't raise :ref:`disallowed-name` on module-level names that can't be inferred
+- Fix a false positive for :ref:`invalid-name <invalid-name>` on exclusive module-level assignments
+  composed of three or more branches. We won't raise :ref:`disallowed-name <disallowed-name>` on module-level names that can't be inferred
   until a further refactor to remove this false negative is done.
 
   Closes #10664 (`#10664 <https://github.com/pylint-dev/pylint/issues/10664>`_)
 
-- Fix false positive for :ref:`invalid-name` for ``TypedDict`` instances.
+- Fix false positive for :ref:`invalid-name <invalid-name>` for ``TypedDict`` instances.
 
   Closes #10672 (`#10672 <https://github.com/pylint-dev/pylint/issues/10672>`_)
 
@@ -466,7 +466,7 @@ False Positives Fixed
   Closes #10647 (`#10647 <https://github.com/pylint-dev/pylint/issues/10647>`_)
 
 - Check enums created with the ``Enum()`` functional syntax to pass against the
-  ``--class-rgx`` for the :ref:`invalid-name` check, like other enums.
+  ``--class-rgx`` for the :ref:`invalid-name <invalid-name>` check, like other enums.
 
   Closes #10660 (`#10660 <https://github.com/pylint-dev/pylint/issues/10660>`_)
 
@@ -523,7 +523,7 @@ Breaking Changes
 
   Refs #10480 (`#10480 <https://github.com/pylint-dev/pylint/issues/10480>`_)
 
-- Removed support for ``nmp.NaN`` alias for ``numpy.NaN`` being recognized in :ref:`nan-comparison`. Use ``np`` or ``numpy`` instead.
+- Removed support for ``nmp.NaN`` alias for ``numpy.NaN`` being recognized in :ref:`nan-comparison <nan-comparison>`. Use ``np`` or ``numpy`` instead.
 
   Refs #10583 (`#10583 <https://github.com/pylint-dev/pylint/issues/10583>`_)
 
@@ -626,17 +626,17 @@ New Checks
 
 - Add new checks for invalid uses of class patterns in :keyword:`match`.
 
-  * :ref:`invalid-match-args-definition` is emitted if :py:data:`object.__match_args__` isn't a tuple of strings.
-  * :ref:`too-many-positional-sub-patterns` if there are more positional sub-patterns than specified in :py:data:`object.__match_args__`.
-  * :ref:`multiple-class-sub-patterns` if there are multiple sub-patterns for the same attribute.
+  * :ref:`invalid-match-args-definition <invalid-match-args-definition>` is emitted if :py:data:`object.__match_args__` isn't a tuple of strings.
+  * :ref:`too-many-positional-sub-patterns <too-many-positional-sub-patterns>` if there are more positional sub-patterns than specified in :py:data:`object.__match_args__`.
+  * :ref:`multiple-class-sub-patterns <multiple-class-sub-patterns>` if there are multiple sub-patterns for the same attribute.
 
   Refs #10559 (`#10559 <https://github.com/pylint-dev/pylint/issues/10559>`_)
 
 - Add additional checks for suboptimal uses of class patterns in :keyword:`match`.
 
-  * :ref:`match-class-bind-self` is emitted if a name is bound to ``self`` instead of
+  * :ref:`match-class-bind-self <match-class-bind-self>` is emitted if a name is bound to ``self`` instead of
     using an ``as`` pattern.
-  * :ref:`match-class-positional-attributes` is emitted if a class pattern has positional
+  * :ref:`match-class-positional-attributes <match-class-positional-attributes>` is emitted if a class pattern has positional
     attributes when keywords could be used.
 
   Refs #10587 (`#10587 <https://github.com/pylint-dev/pylint/issues/10587>`_)
@@ -661,7 +661,7 @@ False Positives Fixed
 
   Closes #10061 (`#10061 <https://github.com/pylint-dev/pylint/issues/10061>`_)
 
-- Fix :ref:`no-name-in-module` for members of ``concurrent.futures`` with Python 3.14.
+- Fix :ref:`no-name-in-module <no-name-in-module>` for members of ``concurrent.futures`` with Python 3.14.
 
   Closes #10632 (`#10632 <https://github.com/pylint-dev/pylint/issues/10632>`_)
 
@@ -710,7 +710,7 @@ False Negatives Fixed
 
   Refs #10542 (`#10542 <https://github.com/pylint-dev/pylint/issues/10542>`_)
 
-- Fix false-negative where :ref:`unused-import` was not reported for names referenced in a preceding ``global`` statement.
+- Fix false-negative where :ref:`unused-import <unused-import>` was not reported for names referenced in a preceding ``global`` statement.
 
   Refs #10633 (`#10633 <https://github.com/pylint-dev/pylint/issues/10633>`_)
 
@@ -737,12 +737,12 @@ Other Bug Fixes
 
   Closes #10508 (`#10508 <https://github.com/pylint-dev/pylint/issues/10508>`_)
 
-- Fix a crash in :ref:`nested-min-max` when using ``builtins.min`` or ``builtins.max``
+- Fix a crash in :ref:`nested-min-max <nested-min-max>` when using ``builtins.min`` or ``builtins.max``
   instead of ``min`` or ``max`` directly.
 
   Closes #10626 (`#10626 <https://github.com/pylint-dev/pylint/issues/10626>`_)
 
-- Fixed a crash in :ref:`unnecessary-dict-index-lookup` when the index of an enumerated list
+- Fixed a crash in :ref:`unnecessary-dict-index-lookup <unnecessary-dict-index-lookup>` when the index of an enumerated list
   was deleted inside a for loop.
 
   Closes #10627 (`#10627 <https://github.com/pylint-dev/pylint/issues/10627>`_)

--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -167,7 +167,7 @@ False Positives Fixed
 
   Closes #6663 (`#6663 <https://github.com/pylint-dev/pylint/issues/6663>`_)
 
-- Fix a false positive for ``invalid-name`` (:ref:`C0103 <invalid-name>`) where the default
+- Fix a false positive for :ref:`invalid-name <invalid-name>` where the default
   ``typevar-rgx`` rejected ``TypeVar`` names containing digits, such as
   ``Ec2T``.
 
@@ -182,7 +182,7 @@ False Positives Fixed
 
   Closes #9833 (`#9833 <https://github.com/pylint-dev/pylint/issues/9833>`_)
 
-- Fix a false positive for ``function-redefined`` (:ref:`E0102 <function-redefined>`) when reusing names that
+- Fix a false positive for :ref:`function-redefined <function-redefined>` when reusing names that
   match ``dummy-variables-rgx`` (such as ``_``), which is common for
   ``pytest-bdd`` step definitions. This restores the behavior from before pylint
   4.0.0; as a consequence the false negative fixed in #9894 is reintroduced for
@@ -293,8 +293,8 @@ Other Bug Fixes
 - Allow digits in ParamSpec and TypeVarTuple names for `invalid-name` check.
 
   The default `paramspec-rgx` and `typevartuple-rgx` patterns rejected names
-  containing digits (e.g. ``Ec2P``, ``S3Ts``), emitting a false ``invalid-name``
-  (:ref:`C0103 <invalid-name>`). Allow digits in the lowercase segments, consistent with the
+  containing digits (e.g. ``Ec2P``, ``S3Ts``), emitting a false
+  :ref:`invalid-name <invalid-name>`. Allow digits in the lowercase segments, consistent with the
   ``typevar`` and ``typealias`` patterns.
 
   Closes #11090 (`#11090 <https://github.com/pylint-dev/pylint/issues/11090>`_)
@@ -333,7 +333,7 @@ False Positives Fixed
 
   Closes #10790 (`#10790 <https://github.com/pylint-dev/pylint/issues/10790>`_)
 
-- Avoid emitting `unspecified-encoding` (:ref:`W1514 <unspecified-encoding>`) when `py-version` is 3.15+.
+- Avoid emitting :ref:`unspecified-encoding <unspecified-encoding>` when `py-version` is 3.15+.
 
   Refs #10791 (`#10791 <https://github.com/pylint-dev/pylint/issues/10791>`_)
 
@@ -523,7 +523,7 @@ Breaking Changes
 
   Refs #10480 (`#10480 <https://github.com/pylint-dev/pylint/issues/10480>`_)
 
-- Removed support for ``nmp.NaN`` alias for ``numpy.NaN`` being recognized in ':ref:`nan-comparison`'. Use ``np`` or ``numpy`` instead.
+- Removed support for ``nmp.NaN`` alias for ``numpy.NaN`` being recognized in :ref:`nan-comparison`. Use ``np`` or ``numpy`` instead.
 
   Refs #10583 (`#10583 <https://github.com/pylint-dev/pylint/issues/10583>`_)
 

--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -304,7 +304,7 @@ Other Bug Fixes
 Performance Improvements
 ------------------------
 
-- The :ref:`duplicate-code <duplicate-code>` checker no longer runs when its message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
+- The Similarities checker no longer runs when its :ref:`duplicate-code <duplicate-code>` message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
 
   Closes #3443 (`#3443 <https://github.com/pylint-dev/pylint/issues/3443>`_)
 

--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -304,7 +304,7 @@ Other Bug Fixes
 Performance Improvements
 ------------------------
 
-- The Similarities checker no longer runs when its :ref:`duplicate-code <duplicate-code>` message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
+- The :ref:`Similarities <similarities-checker>` checker no longer runs when its :ref:`duplicate-code <duplicate-code>` message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
 
   Closes #3443 (`#3443 <https://github.com/pylint-dev/pylint/issues/3443>`_)
 

--- a/doc/whatsnew/4/4.0/index.rst
+++ b/doc/whatsnew/4/4.0/index.rst
@@ -167,7 +167,7 @@ False Positives Fixed
 
   Closes #6663 (`#6663 <https://github.com/pylint-dev/pylint/issues/6663>`_)
 
-- Fix a false positive for ``invalid-name`` (C0103) where the default
+- Fix a false positive for ``invalid-name`` (:ref:`C0103 <invalid-name>`) where the default
   ``typevar-rgx`` rejected ``TypeVar`` names containing digits, such as
   ``Ec2T``.
 
@@ -182,7 +182,7 @@ False Positives Fixed
 
   Closes #9833 (`#9833 <https://github.com/pylint-dev/pylint/issues/9833>`_)
 
-- Fix a false positive for ``function-redefined`` (E0102) when reusing names that
+- Fix a false positive for ``function-redefined`` (:ref:`E0102 <function-redefined>`) when reusing names that
   match ``dummy-variables-rgx`` (such as ``_``), which is common for
   ``pytest-bdd`` step definitions. This restores the behavior from before pylint
   4.0.0; as a consequence the false negative fixed in #9894 is reintroduced for
@@ -294,7 +294,7 @@ Other Bug Fixes
 
   The default `paramspec-rgx` and `typevartuple-rgx` patterns rejected names
   containing digits (e.g. ``Ec2P``, ``S3Ts``), emitting a false ``invalid-name``
-  (C0103). Allow digits in the lowercase segments, consistent with the
+  (:ref:`C0103 <invalid-name>`). Allow digits in the lowercase segments, consistent with the
   ``typevar`` and ``typealias`` patterns.
 
   Closes #11090 (`#11090 <https://github.com/pylint-dev/pylint/issues/11090>`_)
@@ -304,7 +304,7 @@ Other Bug Fixes
 Performance Improvements
 ------------------------
 
-- The duplicate-code checker no longer runs when its message (R0801) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (RP0801) would cause the expensive similarity computation to run regardless.
+- The :ref:`duplicate-code <duplicate-code>` checker no longer runs when its message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
 
   Closes #3443 (`#3443 <https://github.com/pylint-dev/pylint/issues/3443>`_)
 
@@ -318,7 +318,7 @@ Release date: 2026-02-20
 False Positives Fixed
 ---------------------
 
-- Fix possibly-used-before-assignment false positive when using self.fail() in tests.
+- Fix :ref:`possibly-used-before-assignment <possibly-used-before-assignment>` false positive when using self.fail() in tests.
 
   Closes #10743 (`#10743 <https://github.com/pylint-dev/pylint/issues/10743>`_)
 
@@ -333,7 +333,7 @@ False Positives Fixed
 
   Closes #10790 (`#10790 <https://github.com/pylint-dev/pylint/issues/10790>`_)
 
-- Avoid emitting `unspecified-encoding` (W1514) when `py-version` is 3.15+.
+- Avoid emitting `unspecified-encoding` (:ref:`W1514 <unspecified-encoding>`) when `py-version` is 3.15+.
 
   Refs #10791 (`#10791 <https://github.com/pylint-dev/pylint/issues/10791>`_)
 
@@ -683,7 +683,7 @@ False Negatives Fixed
 
   Closes #9770 (`#9770 <https://github.com/pylint-dev/pylint/issues/9770>`_)
 
-- Fix false negative where function-redefined (E0102) was not reported for functions with a leading underscore.
+- Fix false negative where :ref:`function-redefined <function-redefined>` was not reported for functions with a leading underscore.
 
   Closes #9894 (`#9894 <https://github.com/pylint-dev/pylint/issues/9894>`_)
 
@@ -725,7 +725,7 @@ Other Bug Fixes
 
   Closes #8736. (`#8736 <https://github.com/pylint-dev/pylint/issues/8736>`_)
 
-- Fixed unidiomatic-typecheck only checking left-hand side.
+- Fixed :ref:`unidiomatic-typecheck <unidiomatic-typecheck>` only checking left-hand side.
 
   Closes #10217 (`#10217 <https://github.com/pylint-dev/pylint/issues/10217>`_)
 

--- a/doc/whatsnew/4/4.1/index.rst
+++ b/doc/whatsnew/4/4.1/index.rst
@@ -12,7 +12,7 @@
 Summary -- Release highlights
 =============================
 
-The duplicate-code checker and ``symilar`` received optimizations that
+The :ref:`duplicate-code <duplicate-code>` checker and ``symilar`` received optimizations that
 result in considerable performance improvements and memory use reduction
 on larger codebases. For example, pandas analysis went from 20 min to
 55 s and pylint does not get OOM-killed when analyzing cpython anymore.

--- a/doc/whatsnew/4/4.1/index.rst
+++ b/doc/whatsnew/4/4.1/index.rst
@@ -12,7 +12,7 @@
 Summary -- Release highlights
 =============================
 
-The Similarities checker (:ref:`duplicate-code <duplicate-code>`) and ``symilar`` received optimizations that
+The :ref:`Similarities <similarities-checker>` checker (:ref:`duplicate-code <duplicate-code>`) and ``symilar`` received optimizations that
 result in considerable performance improvements and memory use reduction
 on larger codebases. For example, pandas analysis went from 20 min to
 55 s and pylint does not get OOM-killed when analyzing cpython anymore.

--- a/doc/whatsnew/4/4.1/index.rst
+++ b/doc/whatsnew/4/4.1/index.rst
@@ -12,7 +12,7 @@
 Summary -- Release highlights
 =============================
 
-The :ref:`duplicate-code <duplicate-code>` checker and ``symilar`` received optimizations that
+The Similarities checker (:ref:`duplicate-code <duplicate-code>`) and ``symilar`` received optimizations that
 result in considerable performance improvements and memory use reduction
 on larger codebases. For example, pandas analysis went from 20 min to
 55 s and pylint does not get OOM-killed when analyzing cpython anymore.

--- a/doc/whatsnew/fragments/10665.false_positive
+++ b/doc/whatsnew/fragments/10665.false_positive
@@ -1,4 +1,4 @@
-Fix a false positive for ``function-redefined`` (E0102) when reusing names that
+Fix a false positive for ``function-redefined`` (:ref:`E0102 <function-redefined>`) when reusing names that
 match ``dummy-variables-rgx`` (such as ``_``), which is common for
 ``pytest-bdd`` step definitions. This restores the behavior from before pylint
 4.0.0; as a consequence the false negative fixed in #9894 is reintroduced for

--- a/doc/whatsnew/fragments/10665.false_positive
+++ b/doc/whatsnew/fragments/10665.false_positive
@@ -1,4 +1,4 @@
-Fix a false positive for ``function-redefined`` (:ref:`E0102 <function-redefined>`) when reusing names that
+Fix a false positive for :ref:`function-redefined <function-redefined>` when reusing names that
 match ``dummy-variables-rgx`` (such as ``_``), which is common for
 ``pytest-bdd`` step definitions. This restores the behavior from before pylint
 4.0.0; as a consequence the false negative fixed in #9894 is reintroduced for

--- a/doc/whatsnew/fragments/10743.false_positive
+++ b/doc/whatsnew/fragments/10743.false_positive
@@ -1,3 +1,3 @@
-Fix possibly-used-before-assignment false positive when using self.fail() in tests.
+Fix :ref:`possibly-used-before-assignment <possibly-used-before-assignment>` false positive when using self.fail() in tests.
 
 Closes #10743

--- a/doc/whatsnew/fragments/10791.false_positive
+++ b/doc/whatsnew/fragments/10791.false_positive
@@ -1,3 +1,3 @@
-Avoid emitting `unspecified-encoding` (:ref:`W1514 <unspecified-encoding>`) when `py-version` is 3.15+.
+Avoid emitting :ref:`unspecified-encoding <unspecified-encoding>` when `py-version` is 3.15+.
 
 Refs #10791

--- a/doc/whatsnew/fragments/10791.false_positive
+++ b/doc/whatsnew/fragments/10791.false_positive
@@ -1,3 +1,3 @@
-Avoid emitting `unspecified-encoding` (W1514) when `py-version` is 3.15+.
+Avoid emitting `unspecified-encoding` (:ref:`W1514 <unspecified-encoding>`) when `py-version` is 3.15+.
 
 Refs #10791

--- a/doc/whatsnew/fragments/11090.bugfix
+++ b/doc/whatsnew/fragments/11090.bugfix
@@ -2,7 +2,7 @@ Allow digits in ParamSpec and TypeVarTuple names for `invalid-name` check.
 
 The default `paramspec-rgx` and `typevartuple-rgx` patterns rejected names
 containing digits (e.g. ``Ec2P``, ``S3Ts``), emitting a false ``invalid-name``
-(C0103). Allow digits in the lowercase segments, consistent with the
+(:ref:`C0103 <invalid-name>`). Allow digits in the lowercase segments, consistent with the
 ``typevar`` and ``typealias`` patterns.
 
 Closes #11090

--- a/doc/whatsnew/fragments/11090.bugfix
+++ b/doc/whatsnew/fragments/11090.bugfix
@@ -1,8 +1,8 @@
 Allow digits in ParamSpec and TypeVarTuple names for `invalid-name` check.
 
 The default `paramspec-rgx` and `typevartuple-rgx` patterns rejected names
-containing digits (e.g. ``Ec2P``, ``S3Ts``), emitting a false ``invalid-name``
-(:ref:`C0103 <invalid-name>`). Allow digits in the lowercase segments, consistent with the
+containing digits (e.g. ``Ec2P``, ``S3Ts``), emitting a false
+:ref:`invalid-name <invalid-name>`. Allow digits in the lowercase segments, consistent with the
 ``typevar`` and ``typealias`` patterns.
 
 Closes #11090

--- a/doc/whatsnew/fragments/11148.bugfix
+++ b/doc/whatsnew/fragments/11148.bugfix
@@ -1,4 +1,4 @@
-Fix a false positive for :ref:`useless-parent-delegation` when an override changes
+Fix a false positive for :ref:`useless-parent-delegation <useless-parent-delegation>` when an override changes
 the default value of a positional-only parameter.
 
 Closes #11148

--- a/doc/whatsnew/fragments/3443.performance
+++ b/doc/whatsnew/fragments/3443.performance
@@ -1,3 +1,3 @@
-The duplicate-code checker no longer runs when its message (R0801) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (RP0801) would cause the expensive similarity computation to run regardless.
+The :ref:`duplicate-code <duplicate-code>` checker no longer runs when its message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
 
 Closes #3443

--- a/doc/whatsnew/fragments/3443.performance
+++ b/doc/whatsnew/fragments/3443.performance
@@ -1,3 +1,3 @@
-The :ref:`duplicate-code <duplicate-code>` checker no longer runs when its message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
+The Similarities checker no longer runs when its :ref:`duplicate-code <duplicate-code>` message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
 
 Closes #3443

--- a/doc/whatsnew/fragments/3443.performance
+++ b/doc/whatsnew/fragments/3443.performance
@@ -1,3 +1,3 @@
-The Similarities checker no longer runs when its :ref:`duplicate-code <duplicate-code>` message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
+The :ref:`Similarities <similarities-checker>` checker no longer runs when its :ref:`duplicate-code <duplicate-code>` message (``R0801``) is disabled, even if ``reports=yes`` is set. Previously, the checker's report (``RP0801``) would cause the expensive similarity computation to run regardless.
 
 Closes #3443

--- a/doc/whatsnew/fragments/7819.feature
+++ b/doc/whatsnew/fragments/7819.feature
@@ -1,3 +1,3 @@
-The dict-init-mutate message now includes a suggested dictionary literal showing how to combine the initialization and subsequent mutations into a single statement.
+The :ref:`dict-init-mutate <dict-init-mutate>` message now includes a suggested dictionary literal showing how to combine the initialization and subsequent mutations into a single statement.
 
 Closes #7819

--- a/doc/whatsnew/fragments/8499.false_positive
+++ b/doc/whatsnew/fragments/8499.false_positive
@@ -1,4 +1,4 @@
-Fix a false positive for ``invalid-name`` (:ref:`C0103 <invalid-name>`) where the default
+Fix a false positive for :ref:`invalid-name <invalid-name>` where the default
 ``typevar-rgx`` rejected ``TypeVar`` names containing digits, such as
 ``Ec2T``.
 

--- a/doc/whatsnew/fragments/8499.false_positive
+++ b/doc/whatsnew/fragments/8499.false_positive
@@ -1,4 +1,4 @@
-Fix a false positive for ``invalid-name`` (C0103) where the default
+Fix a false positive for ``invalid-name`` (:ref:`C0103 <invalid-name>`) where the default
 ``typevar-rgx`` rejected ``TypeVar`` names containing digits, such as
 ``Ec2T``.
 

--- a/doc/whatsnew/fragments/8801.other
+++ b/doc/whatsnew/fragments/8801.other
@@ -1,4 +1,4 @@
-Document that the ``wrong-import-order`` (:ref:`C0411 <wrong-import-order>`) classification of imports as
+Document that the :ref:`wrong-import-order <wrong-import-order>` classification of imports as
 third-party vs first-party depends on the current working directory and
 recommend ``known-first-party`` as the deterministic workaround.
 

--- a/doc/whatsnew/fragments/8801.other
+++ b/doc/whatsnew/fragments/8801.other
@@ -1,4 +1,4 @@
-Document that the ``wrong-import-order`` (C0411) classification of imports as
+Document that the ``wrong-import-order`` (:ref:`C0411 <wrong-import-order>`) classification of imports as
 third-party vs first-party depends on the current working directory and
 recommend ``known-first-party`` as the deterministic workaround.
 


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

A bare message symbol like no-member was plain text, so a reader who wanted to know what it means had to go and search for its page. Turn the symbols the documentation and the changelogs mention into links to that page.

Symbols inside an inline literal are left alone: there they are almost always part of a command line or of a configuration snippet meant to be copied.

Refs #10568
