### PR TITLE
Fix class checker crashes on `x.__class__` targets outside plain assignments

### DIFF
--- a/doc/whatsnew/fragments/11267.bugfix
+++ b/doc/whatsnew/fragments/11267.bugfix
@@ -1,0 +1,8 @@
+Fix a crash in the class checker when ``x.__class__`` is an assignment target
+outside a plain assignment, such as a for-loop, ``with``, or comprehension
+target, a bare annotation, or a tuple target unpacked from a non-literal or
+too-short right-hand side. This affected both ``invalid-class-object`` and
+``assigning-non-slot``, which also crashed when the assigned value could not
+be resolved by astroid.
+
+Closes #11267

--- a/doc/whatsnew/fragments/11267.bugfix
+++ b/doc/whatsnew/fragments/11267.bugfix
@@ -1,8 +1,3 @@
-Fix a crash in the class checker when ``x.__class__`` is an assignment target
-outside a plain assignment, such as a for-loop, ``with``, or comprehension
-target, a bare annotation, or a tuple target unpacked from a non-literal or
-too-short right-hand side. This affected both ``invalid-class-object`` and
-``assigning-non-slot``, which also crashed when the assigned value could not
-be resolved by astroid.
+Fix a crash in :ref:`invalid-class-object` and :ref:`assigning-non-slot` when ``__class__`` is assigned outside a simple assignment (e.g. ``for obj.__class__ in classes:``).
 
 Closes #11267

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -488,12 +488,32 @@ def _has_same_layout_slots(
         return False
     if isinstance(inferred, nodes.ClassDef):
         other_slots = inferred.slots()
+        if other_slots is None:
+            # A class without ``__slots__`` anywhere in its mro has a
+            # different layout, which CPython rejects at runtime too.
+            return False
         if all(
             first_slot and second_slot and first_slot.value == second_slot.value
             for (first_slot, second_slot) in zip_longest(slots, other_slots)
         ):
             return True
     return False
+
+
+def _assigned_value(node: nodes.AssignAttr) -> nodes.NodeNG | None:
+    """Return the value bound to ``node``, if a single one can be pinpointed.
+
+    An assignment statement carries the value it binds, and a starred target
+    (``head, *foo.attr = ...``) is resolved by astroid through the target
+    itself. A for-loop, ``with``, or comprehension target has no such value,
+    and neither has a bare annotation (``foo.attr: int``).
+    """
+    parent = node.parent
+    if not isinstance(
+        parent, (nodes.Assign, nodes.AnnAssign, nodes.AugAssign, nodes.Starred)
+    ):
+        return None
+    return parent.value
 
 
 MSGS: dict[str, MessageDefinitionTuple] = {
@@ -1742,7 +1762,7 @@ a metaclass class method.",
     def _check_invalid_class_object(self, node: nodes.AssignAttr) -> None:
         if not node.attrname == "__class__":
             return
-        if isinstance(node.parent, nodes.Tuple):
+        if isinstance(node.parent, (nodes.Tuple, nodes.List)):
             assign_node = node.parent.parent
             if not isinstance(assign_node, nodes.Assign) or not isinstance(
                 assign_node.value, (nodes.Tuple, nodes.List)
@@ -1764,16 +1784,12 @@ a metaclass class method.",
                 return
             inferred = safe_infer(assign_node.value.elts[class_index])
         else:
-            if (
-                not isinstance(
-                    node.parent, (nodes.Assign, nodes.AnnAssign, nodes.AugAssign)
-                )
-                or node.parent.value is None
-            ):
+            assigned_value = _assigned_value(node)
+            if assigned_value is None:
                 # A for-loop, ``with``, or comprehension target, or a bare
                 # annotation: there is no assigned value to check.
                 return
-            inferred = safe_infer(node.parent.value)
+            inferred = safe_infer(assigned_value)
         match inferred:
             case nodes.ClassDef() | util.UninferableBase() | None:
                 # If uninferable, we allow it to prevent false positives
@@ -1850,18 +1866,13 @@ a metaclass class method.",
                         # Descriptors circumvent the slots mechanism as well.
                         return
                 if node.attrname == "__class__":
-                    # Only a plain assignment carries a value whose slots
-                    # layout can be compared; a for-loop, ``with``, or
-                    # tuple-unpacking target does not.
-                    if (
-                        not isinstance(
-                            node.parent,
-                            (nodes.Assign, nodes.AnnAssign, nodes.AugAssign),
-                        )
-                        or node.parent.value is None
-                    ):
+                    # Without a single assigned value there is no slots layout
+                    # to compare against, e.g. for a for-loop, ``with``, or
+                    # tuple-unpacking target.
+                    assigned_value = _assigned_value(node)
+                    if assigned_value is None:
                         return
-                    if _has_same_layout_slots(slots, node.parent.value):
+                    if _has_same_layout_slots(slots, assigned_value):
                         return
                 self.add_message(
                     "assigning-non-slot",

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -478,9 +478,14 @@ def _is_attribute_property(name: str, klass: nodes.ClassDef) -> bool:
 
 
 def _has_same_layout_slots(
-    slots: list[nodes.Const | None], assigned_value: nodes.Name
+    slots: list[nodes.Const | None], assigned_value: nodes.NodeNG
 ) -> bool:
-    inferred = next(assigned_value.infer())
+    try:
+        inferred = next(assigned_value.infer())
+    except astroid.InferenceError:
+        # An unresolvable value gets the same answer as any other
+        # value that is not a class definition.
+        return False
     if isinstance(inferred, nodes.ClassDef):
         other_slots = inferred.slots()
         if all(
@@ -1738,6 +1743,14 @@ a metaclass class method.",
         if not node.attrname == "__class__":
             return
         if isinstance(node.parent, nodes.Tuple):
+            assign_node = node.parent.parent
+            if not isinstance(assign_node, nodes.Assign) or not isinstance(
+                assign_node.value, (nodes.Tuple, nodes.List)
+            ):
+                # A for-loop or ``with`` tuple target, a nested tuple, or an
+                # unpacked call result: the value assigned to ``__class__``
+                # cannot be pinpointed, keep quiet to avoid false positives.
+                return
             class_index = -1
             for i, elt in enumerate(node.parent.elts):
                 if hasattr(elt, "attrname") and elt.attrname == "__class__":
@@ -1746,8 +1759,20 @@ a metaclass class method.",
                 # This should not happen because we checked that the node name
                 # is '__class__' earlier, but let's not be too confident here
                 return  # pragma: no cover
-            inferred = safe_infer(node.parent.parent.value.elts[class_index])
+            if class_index >= len(assign_node.value.elts):
+                # Unbalanced unpacking, which fails at runtime anyway.
+                return
+            inferred = safe_infer(assign_node.value.elts[class_index])
         else:
+            if (
+                not isinstance(
+                    node.parent, (nodes.Assign, nodes.AnnAssign, nodes.AugAssign)
+                )
+                or node.parent.value is None
+            ):
+                # A for-loop, ``with``, or comprehension target, or a bare
+                # annotation: there is no assigned value to check.
+                return
             inferred = safe_infer(node.parent.value)
         match inferred:
             case nodes.ClassDef() | util.UninferableBase() | None:
@@ -1824,10 +1849,20 @@ a metaclass class method.",
                     if _has_data_descriptor(klass, node.attrname):
                         # Descriptors circumvent the slots mechanism as well.
                         return
-                if node.attrname == "__class__" and _has_same_layout_slots(
-                    slots, node.parent.value
-                ):
-                    return
+                if node.attrname == "__class__":
+                    # Only a plain assignment carries a value whose slots
+                    # layout can be compared; a for-loop, ``with``, or
+                    # tuple-unpacking target does not.
+                    if (
+                        not isinstance(
+                            node.parent,
+                            (nodes.Assign, nodes.AnnAssign, nodes.AugAssign),
+                        )
+                        or node.parent.value is None
+                    ):
+                        return
+                    if _has_same_layout_slots(slots, node.parent.value):
+                        return
                 self.add_message(
                     "assigning-non-slot",
                     args=(node.attrname,),

--- a/tests/functional/a/assigning/assigning_non_slot.py
+++ b/tests/functional/a/assigning/assigning_non_slot.py
@@ -138,6 +138,10 @@ class ClassWithSlots:
     __slots__ = ['foobar']
 
 
+class ClassWithoutSlots:
+    pass
+
+
 class ClassReassigningDunderClass:
     __slots__ = ['foobar']
 
@@ -258,3 +262,13 @@ class ClassReassigningDunderClassDifferently:
     def release_undefined_name(self):
         # pylint: disable-next=undefined-variable
         self.__class__ = UndefinedClass  # [assigning-non-slot]
+
+    def release_to_class_without_slots(self):
+        # A class without ``__slots__`` has a different layout, which CPython
+        # rejects at runtime too.
+        self.__class__ = ClassWithoutSlots  # [assigning-non-slot]
+
+    def release_in_starred_target(self):
+        # +1: [assigning-non-slot,invalid-class-object]
+        *self.__class__, myvar = [1, 2]
+        print(myvar)

--- a/tests/functional/a/assigning/assigning_non_slot.py
+++ b/tests/functional/a/assigning/assigning_non_slot.py
@@ -239,3 +239,22 @@ class Repro(Base):
 
 repro = Repro()
 repro.attr2 = "anything"
+
+
+# Crash regression: ``x.__class__`` targets outside a plain assignment
+# and unresolvable assigned values used to crash.
+# See https://github.com/pylint-dev/pylint/issues/11267
+class ClassReassigningDunderClassDifferently:
+    __slots__ = ['foobar']
+
+    def release_in_loop(self):
+        for self.__class__ in [ClassWithSlots]:
+            pass
+
+    def release_in_tuple(self):
+        self.__class__, myvar = ClassWithSlots, 'test'
+        print(myvar)
+
+    def release_undefined_name(self):
+        # pylint: disable-next=undefined-variable
+        self.__class__ = UndefinedClass  # [assigning-non-slot]

--- a/tests/functional/a/assigning/assigning_non_slot.txt
+++ b/tests/functional/a/assigning/assigning_non_slot.txt
@@ -3,3 +3,4 @@ assigning-non-slot:28:8:28:20:Bad2.__init__:Assigning to attribute 'missing' not
 assigning-non-slot:38:8:38:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
 assigning-non-slot:152:8:152:22:ClassReassingingInvalidLayoutClass.release:Assigning to attribute '__class__' not defined in class slots:INFERENCE
 assigning-non-slot:153:8:153:17:ClassReassingingInvalidLayoutClass.release:Assigning to attribute 'test' not defined in class slots:INFERENCE
+assigning-non-slot:260:8:260:22:ClassReassigningDunderClassDifferently.release_undefined_name:Assigning to attribute '__class__' not defined in class slots:INFERENCE

--- a/tests/functional/a/assigning/assigning_non_slot.txt
+++ b/tests/functional/a/assigning/assigning_non_slot.txt
@@ -1,6 +1,9 @@
 assigning-non-slot:20:8:20:20:Bad.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
 assigning-non-slot:28:8:28:20:Bad2.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
 assigning-non-slot:38:8:38:20:Bad3.__init__:Assigning to attribute 'missing' not defined in class slots:INFERENCE
-assigning-non-slot:152:8:152:22:ClassReassingingInvalidLayoutClass.release:Assigning to attribute '__class__' not defined in class slots:INFERENCE
-assigning-non-slot:153:8:153:17:ClassReassingingInvalidLayoutClass.release:Assigning to attribute 'test' not defined in class slots:INFERENCE
-assigning-non-slot:260:8:260:22:ClassReassigningDunderClassDifferently.release_undefined_name:Assigning to attribute '__class__' not defined in class slots:INFERENCE
+assigning-non-slot:156:8:156:22:ClassReassingingInvalidLayoutClass.release:Assigning to attribute '__class__' not defined in class slots:INFERENCE
+assigning-non-slot:157:8:157:17:ClassReassingingInvalidLayoutClass.release:Assigning to attribute 'test' not defined in class slots:INFERENCE
+assigning-non-slot:264:8:264:22:ClassReassigningDunderClassDifferently.release_undefined_name:Assigning to attribute '__class__' not defined in class slots:INFERENCE
+assigning-non-slot:269:8:269:22:ClassReassigningDunderClassDifferently.release_to_class_without_slots:Assigning to attribute '__class__' not defined in class slots:INFERENCE
+assigning-non-slot:273:9:273:23:ClassReassigningDunderClassDifferently.release_in_starred_target:Assigning to attribute '__class__' not defined in class slots:INFERENCE
+invalid-class-object:273:9:273:23:ClassReassigningDunderClassDifferently.release_in_starred_target:Invalid assignment to '__class__'. Should be a class definition but got a 'List':INFERENCE

--- a/tests/functional/i/invalid/invalid_class_object.py
+++ b/tests/functional/i/invalid/invalid_class_object.py
@@ -73,3 +73,45 @@ class Pylint7429Good:
             "othervalue",
         )
         print(myvar, other)
+
+
+def get_pair():
+    return AnotherClass, "myvalue"
+
+
+class CrashRegression11267:
+    """``x.__class__`` targets outside a plain assignment used to crash.
+
+    See https://github.com/pylint-dev/pylint/issues/11267
+    """
+
+    def dunder_class_as_loop_target(self):
+        for self.__class__ in [AnotherClass]:
+            pass
+
+    def dunder_class_as_tuple_loop_target(self):
+        for self.__class__, myvar in [(AnotherClass, "myvalue")]:
+            print(myvar)
+
+    def dunder_class_as_with_target(self, ctx):
+        with ctx as self.__class__:
+            pass
+
+    def dunder_class_as_comprehension_target(self):
+        return [0 for self.__class__ in [AnotherClass]]
+
+    def dunder_class_annotation_without_value(self):
+        self.__class__: type
+
+    def dunder_class_unpacked_from_call(self):
+        self.__class__, myvar = get_pair()
+        print(myvar)
+
+    def dunder_class_in_nested_tuple_target(self, other):
+        (other.attr, self.__class__), myvar = (1, AnotherClass), 2
+        print(myvar)
+
+    def dunder_class_unbalanced_unpacking(self):
+        # pylint: disable-next=unbalanced-tuple-unpacking
+        myvar, self.__class__ = (AnotherClass,)
+        print(myvar)

--- a/tests/functional/i/invalid/invalid_class_object.py
+++ b/tests/functional/i/invalid/invalid_class_object.py
@@ -115,3 +115,22 @@ class CrashRegression11267:
         # pylint: disable-next=unbalanced-tuple-unpacking
         myvar, self.__class__ = (AnotherClass,)
         print(myvar)
+
+    def dunder_class_in_list_target(self):
+        [self.__class__, myvar] = 1, 2  # [invalid-class-object]
+        print(myvar)
+
+    def dunder_class_in_list_target_good(self):
+        [self.__class__, myvar] = AnotherClass, 2
+        print(myvar)
+
+    def dunder_class_as_starred_target(self):
+        *self.__class__, myvar = [1, 2]  # [invalid-class-object]
+        print(myvar)
+
+    def dunder_class_as_trailing_starred_target(self, other):
+        other.attr, *self.__class__ = [1, 2]  # [invalid-class-object]
+
+    def dunder_class_as_starred_loop_target(self):
+        for *self.__class__, myvar in [[1, 2]]:  # [invalid-class-object]
+            print(myvar)

--- a/tests/functional/i/invalid/invalid_class_object.txt
+++ b/tests/functional/i/invalid/invalid_class_object.txt
@@ -3,3 +3,7 @@ invalid-class-object:21:0:21:11::Invalid assignment to '__class__'. Should be a 
 invalid-class-object:50:8:50:22:Pylint7429Good.class_defining_function_bad:Invalid assignment to '__class__'. Should be a class definition but got a 'Const':INFERENCE
 invalid-class-object:58:15:58:29:Pylint7429Good.class_defining_function_bad_inverted:Invalid assignment to '__class__'. Should be a class definition but got a 'Const':INFERENCE
 invalid-class-object:62:15:62:29:Pylint7429Good.class_defining_function_complex_bad:Invalid assignment to '__class__'. Should be a class definition but got a 'Const':INFERENCE
+invalid-class-object:120:9:120:23:CrashRegression11267.dunder_class_in_list_target:Invalid assignment to '__class__'. Should be a class definition but got a 'Const':INFERENCE
+invalid-class-object:128:9:128:23:CrashRegression11267.dunder_class_as_starred_target:Invalid assignment to '__class__'. Should be a class definition but got a 'List':INFERENCE
+invalid-class-object:132:21:132:35:CrashRegression11267.dunder_class_as_trailing_starred_target:Invalid assignment to '__class__'. Should be a class definition but got a 'List':INFERENCE
+invalid-class-object:135:13:135:27:CrashRegression11267.dunder_class_as_starred_loop_target:Invalid assignment to '__class__'. Should be a class definition but got a 'List':INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Closes #11267

`visit_assignattr` fires for every `AssignAttr`, but the two `__class__` code paths assumed the target's parent is a plain assignment carrying a literal value, so legal constructs like `for foo.__class__ in [Foo]:` aborted the whole module with a fatal `astroid-error` (F0002):

- `_check_invalid_class_object` read `node.parent.value`, which does not exist for a for-loop, `with`, or comprehension target and is `None` for a bare annotation; its tuple branch indexed `.value.elts`, which crashes when the right-hand side is a call, a nested tuple, or a too-short literal (`AttributeError` / `IndexError`).
- `_check_in_slots` read `node.parent.value` the same way for slotted classes, and `_has_same_layout_slots` called `next(assigned_value.infer())` without handling `astroid.InferenceError`, so an unresolvable value such as an undefined name also crashed.

The fix skips the checks when there is no single assigned value to inspect (the same approach as #11173's non-name loop target fix), and gives an unresolvable value in `_has_same_layout_slots` the same answer as any other non-class value, matching the existing behavior for `Uninferable` (`assigning-non-slot` is still emitted — covered by the existing `ClassReassingingInvalidLayoutClass` expectation and a new test).

Existing behavior is preserved: the #7467 tuple-unpacking cases keep their messages, including starred unpacking like `self.__class__, *rest = ...` (the bound check only skips genuinely unbalanced unpacking).

### Test evidence

Both extended functional tests fail before the fix and pass after it:

```
$ python -m pytest tests/test_functional.py -k "invalid_class_object or assigning_non_slot" -q
# before the fix: 2 failed (AttributeError: 'For' object has no attribute 'value', ...), 1 passed
# after the fix:  3 passed
```

Full functional suite (`python -m pytest tests/test_functional.py -q -n auto`): 874 passed, 29 skipped, 14 failed — the failing set is byte-for-byte identical on current `main` in the same environment (macOS, Python 3.13.3; e.g. `wrong_import_order`, `used_before_assignment_py310/311`), i.e. pre-existing and unrelated. `mypy` and a self-run of pylint on the changed file are clean.

*This PR was prepared with AI assistance as part of a code correctness review; every crash variant was reproduced locally and the fix and tests were reviewed and run by the author.*
