### PR TITLE
Update _check_attribute_defined_outside_init for helper functions

### DIFF
--- a/doc/whatsnew/fragments/5214.false_positive
+++ b/doc/whatsnew/fragments/5214.false_positive
@@ -1,3 +1,3 @@
-Fix false positives where ``__init__`` (etc) uses a helper method to create attributes.
+Fix false positives for :ref:attribute-defined-outside-init`` where ``__init__`` (etc.) uses a helper method to create attributes.
 
 Closes #5214

--- a/doc/whatsnew/fragments/5214.false_positive
+++ b/doc/whatsnew/fragments/5214.false_positive
@@ -1,3 +1,4 @@
-Fix false positives for :ref:attribute-defined-outside-init`` where ``__init__`` (etc.) uses a helper method to create attributes.
+Fix false positives for :ref:`attribute-defined-outside-init` where ``__init__``
+(etc.) uses a helper method to create attributes.
 
 Closes #5214

--- a/doc/whatsnew/fragments/5214.false_positive
+++ b/doc/whatsnew/fragments/5214.false_positive
@@ -1,0 +1,3 @@
+Fix false positives where ``__init__`` (etc) uses a helper method to create attributes.
+
+Closes #5214

--- a/doc/whatsnew/fragments/5214.false_positive.rst
+++ b/doc/whatsnew/fragments/5214.false_positive.rst
@@ -1,1 +1,0 @@
-Fix false positives where __init__ uses a helper method to create attributes

--- a/doc/whatsnew/fragments/5214.false_positive.rst
+++ b/doc/whatsnew/fragments/5214.false_positive.rst
@@ -1,0 +1,1 @@
+Fix false positives where __init__ uses a helper method to create attributes

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1359,7 +1359,9 @@ a metaclass class method.",
                     # of the defining methods, then don't emit
                     # the warning.
                     if _called_in_methods(node.frame(), cnode, defining_methods):
-                        continue
+                        break
+            else:
+                for node in filtered_nodes:
                     self.add_message(
                         "attribute-defined-outside-init", args=attr, node=node
                     )
@@ -1367,9 +1369,11 @@ a metaclass class method.",
     def _defined_in_parent_init(
         self, cnode: nodes.ClassDef, attr: str, defining_methods: Sequence[str]
     ) -> bool:
-        # check attribute is defined in a parent's defining method
+        # check attribute is defined in a parent's defining method, either
+        # directly or in a method called from a defining method
         return any(
             node.frame().name in defining_methods
+            or _called_in_methods(node.frame(), parent, defining_methods)
             for parent in cnode.instance_attr_ancestors(attr)
             for node in parent.instance_attrs[attr]
         )

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1353,18 +1353,17 @@ a metaclass class method.",
             if attr in parent_setattr_names:
                 continue
 
+            # If the attribute was set by a call made in any of the defining
+            # methods, then it is initialized after all: don't emit for any of
+            # the assignments.
+            if any(
+                _called_in_methods(node.frame(), cnode, defining_methods)
+                for node in filtered_nodes
+            ):
+                continue
+
             for node in filtered_nodes:
-                if node.frame().name not in defining_methods:
-                    # If the attribute was set by a call in any
-                    # of the defining methods, then don't emit
-                    # the warning.
-                    if _called_in_methods(node.frame(), cnode, defining_methods):
-                        break
-            else:
-                for node in filtered_nodes:
-                    self.add_message(
-                        "attribute-defined-outside-init", args=attr, node=node
-                    )
+                self.add_message("attribute-defined-outside-init", args=attr, node=node)
 
     def _defined_in_parent_init(
         self, cnode: nodes.ClassDef, attr: str, defining_methods: Sequence[str]

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -198,3 +198,28 @@ class SameClassSetattrThenAssign:
 
     def later(self):
         self.from_init = 2
+
+
+class G:
+    """https://github.com/pylint-dev/pylint/issues/5214"""
+
+    def __init__(self):
+        self.init_helper()
+
+    def init_helper(self):
+        self.var1 = True
+
+    def other_func(self):
+        self.var1 = False
+
+
+class HParent:
+    def __init__(self):
+        self.init_helper()
+
+    def init_helper(self):
+        self.var1 = True
+
+class HDerived(HParent):
+    def other_func(self):
+        self.var1 = False

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -220,6 +220,7 @@ class HParent:
     def init_helper(self):
         self.var1 = True
 
+
 class HDerived(HParent):
     def other_func(self):
         self.var1 = False

--- a/tests/functional/a/attribute_defined_outside_init.py
+++ b/tests/functional/a/attribute_defined_outside_init.py
@@ -223,3 +223,23 @@ class HParent:
 class HDerived(HParent):
     def other_func(self):
         self.var1 = False
+
+
+class UnrelatedHelperOwner:
+    def init_helper(self):
+        """Same name as SameNameHelperCall.init_helper, other class."""
+
+
+class SameNameHelperCall:
+    # '_called_in_methods' matches the called method by name only, so calling
+    # 'init_helper' on another object counts as calling our own: both
+    # assignments below are known false negatives.
+    def __init__(self):
+        self.other = UnrelatedHelperOwner()
+        self.other.init_helper()
+
+    def init_helper(self):
+        self.var1 = True
+
+    def other_func(self):
+        self.var1 = False


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!

To ease the process of reviewing your PR, do make sure to complete the following boxes.

- [ ] Document your change, if it is a non-trivial one.
  - A maintainer might label the issue ``skip-news`` if the change does not need to be in the changelog.
  - Otherwise, create a news fragment with ``towncrier create <IssueNumber>.<type>`` which will be
    included in the changelog. ``<type>`` can be one of the types defined in `./towncrier.toml`.
    If necessary you can write details or offer examples on how the new change is supposed to work.
  - Generating the doc is done with ``tox -e docs``
- [ ] Relate your change to an issue in the tracker if such an issue exists (Refs #1234, Closes #1234)
- [ ] Write comprehensive commit messages and/or a good description of what the PR does.
- [ ] Keep the change small, separate the consensual changes from the opinionated one.
  Don't hesitate to open multiple PRs if the change requires it. If your review is so
  big it requires to actually plan and allocate time to review, it's more likely
  that it's going to go stale.
- [ ] If you used multiple emails or multiple names when contributing, add your mails
      and preferred name in ``script/.contributors_aliases.json``
-->

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | 🦟 False positive          |

## Description

From #5241 the following does not work as expected:
```python
"""Module docstring"""

class TestLint:
    """Test doc string"""

    def __init__(self):
        self.init_helper()
        self.var2 = True

    def init_helper(self):
        """Helper doc string"""
        self.var1 = True # no lint error

    def other_func(self):
        """Other func doc string"""
        self.var1 = False # lint error
        self.var2 = False # no lint error
```

This change checks to see if the attribute is defined in any of the helper methods rather than just checking if a particular definition is in a helper method. Note that the PR also applies that test to attributes defined by parent classes.

Refactoring/cleanup avoided in this PR, but I think that [this test](https://github.com/pylint-dev/pylint/pull/11270/changes#diff-28b08eca9b507acd5447a6f7107823b8d5e627963cccc780601da4f88f842813L1254) is redundant due to [this prior check](https://github.com/pylint-dev/pylint/pull/11270/changes#diff-28b08eca9b507acd5447a6f7107823b8d5e627963cccc780601da4f88f842813L1254

<!-- If this PR fixes an issue, use the following to automatically close when we merge: -->

Closes #5214
