### PR TITLE
Don't report redefined-outer-name for PEP 695 type parameters

### DIFF
--- a/doc/whatsnew/fragments/11169.false_positive
+++ b/doc/whatsnew/fragments/11169.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``redefined-outer-name`` (W0621) when a PEP 695
+type parameter (e.g. ``def f[T]``) reuses the name of a type parameter from
+an outer scope, such as a ``type`` alias. Type parameters are scoped to
+their declaration, so this common idiom is no longer flagged.
+
+Closes #11169

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1532,7 +1532,13 @@ class VariablesChecker(BaseChecker):
         ):
             return
         globs = node.root().globals
+        type_params = {tp.name.name for tp in node.type_params}
         for name, stmt in node.items():
+            if name in type_params:
+                # PEP 695 type parameters are scoped to the function, so
+                # reusing a type-parameter name from an outer scope (e.g. a
+                # type alias) is intentional and should not be flagged.
+                continue
             if name in globs and not isinstance(stmt, nodes.Global):
                 definition = globs[name][0]
                 if (

--- a/tests/functional/r/redefined/redefined_outer_name_type_parameter.py
+++ b/tests/functional/r/redefined/redefined_outer_name_type_parameter.py
@@ -1,0 +1,28 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11169.
+
+PEP 695 type parameters are scoped to their declaration. Reusing a
+type-parameter name from an outer scope (e.g. a type alias) is a common
+idiom and must not trigger ``redefined-outer-name``.
+"""
+# pylint: disable=missing-function-docstring,invalid-name,unused-argument
+
+from collections.abc import Callable
+
+type S[T] = list[T]
+
+
+def f[T](s: S[T]) -> T | None:
+    return None
+
+
+type A[**P] = Callable[P, int]
+
+
+def g[**P](cb: A[P]) -> None:
+    return None
+
+
+# Genuine shadowing of an outer type-parameter name is still reported.
+def h():
+    T = 1  # [redefined-outer-name]
+    return T

--- a/tests/functional/r/redefined/redefined_outer_name_type_parameter.rc
+++ b/tests/functional/r/redefined/redefined_outer_name_type_parameter.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/r/redefined/redefined_outer_name_type_parameter.txt
+++ b/tests/functional/r/redefined/redefined_outer_name_type_parameter.txt
@@ -1,0 +1,1 @@
+redefined-outer-name:27:4:27:5:h:Redefining name 'T' from outer scope (line 11):UNDEFINED

--- a/tests/functional/u/used/used_before_assignment_py312.py
+++ b/tests/functional/u/used/used_before_assignment_py312.py
@@ -19,5 +19,5 @@ class Good[T: Y]: ...
 type OtherAlias[T: Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T: Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T: Y](x: T) -> None:
     ...

--- a/tests/functional/u/used/used_before_assignment_py312.txt
+++ b/tests/functional/u/used/used_before_assignment_py312.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:22:9:22:13:func:Redefining name 'T' from outer scope (line 6):UNDEFINED

--- a/tests/functional/u/used/used_before_assignment_py313.py
+++ b/tests/functional/u/used/used_before_assignment_py313.py
@@ -12,5 +12,5 @@ class Good3[**P = [int, Y]]: ...
 type Alias[T = Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T = Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T = Y](x: T) -> None:
     ...

--- a/tests/functional/u/used/used_before_assignment_py313.txt
+++ b/tests/functional/u/used/used_before_assignment_py313.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:15:9:15:14:func:Redefining name 'T' from outer scope (line 12):UNDEFINED

--- a/tests/functional/u/used_02/used_before_assignment_py313.py
+++ b/tests/functional/u/used_02/used_before_assignment_py313.py
@@ -12,5 +12,5 @@ class Good3[**P = [int, Y]]: ...
 type Alias[T = Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T = Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T = Y](x: T) -> None:
     ...

--- a/tests/functional/u/used_02/used_before_assignment_py313.txt
+++ b/tests/functional/u/used_02/used_before_assignment_py313.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:15:9:15:14:func:Redefining name 'T' from outer scope (line 12):UNDEFINED


### PR DESCRIPTION
Closes #11169

## Description

PEP 695 type parameters are scoped to their declaration. Reusing a
type-parameter name from an outer scope (e.g. a `type` alias) is a common
idiom:

```python
type S[T] = list[T]

def f[T](s: S[T]) -> T | None:  # W0621 redefined-outer-name (false positive)
    return None
```

`visit_functiondef` in the variables checker emitted `redefined-outer-name`
(W0621) because the outer `T` (from the type alias) is present in the
module globals and the function's own type parameter `T` appears in
`node.items()`. Type parameters are not ordinary names, so they should not
be reported.

This change skips names that are type parameters of the current function.
Genuine shadowing of an outer type-parameter name is still reported.

## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Related Issue

Closes #11169

## Additional Notes

- New functional test `redefined_outer_name_type_parameter` covers type
  aliases, `TypeVar`, `ParamSpec`, and a genuine shadowing case.
- `used_before_assignment_py312`/`py313` functional tests previously
  documented this exact false positive (`# [redefined-outer-name] FALSE
  POSITIVE`); those markers and expected-output lines are removed.
- Functional suite: no new failures vs clean `main` (pre-existing
  environment failures unchanged); `tests/checkers`: 409 passed.
