### PR TITLE
Fix pyreverse crash on classes with EmptyNode instance attrs

### DIFF
--- a/doc/whatsnew/fragments/10767.bugfix
+++ b/doc/whatsnew/fragments/10767.bugfix
@@ -1,0 +1,7 @@
+Fix a crash in ``pyreverse`` when a class diagram includes a class whose
+``instance_attrs`` contain synthetic ``EmptyNode`` entries (e.g. classes
+rebuilt by astroid's namedtuple/argparse brains). These placeholder nodes
+are now skipped when extracting composition/aggregation/association
+relationships.
+
+Closes #10767

--- a/doc/whatsnew/fragments/11169.false_positive
+++ b/doc/whatsnew/fragments/11169.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``redefined-outer-name`` (W0621) when a PEP 695
+type parameter (e.g. ``def f[T]``) reuses the name of a type parameter from
+an outer scope, such as a ``type`` alias. Type parameters are scoped to
+their declaration, so this common idiom is no longer flagged.
+
+Closes #11169

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1532,7 +1532,13 @@ class VariablesChecker(BaseChecker):
         ):
             return
         globs = node.root().globals
+        type_params = {tp.name.name for tp in node.type_params}
         for name, stmt in node.items():
+            if name in type_params:
+                # PEP 695 type parameters are scoped to the function, so
+                # reusing a type-parameter name from an outer scope (e.g. a
+                # type alias) is intentional and should not be flagged.
+                continue
             if name in globs and not isinstance(stmt, nodes.Global):
                 definition = globs[name][0]
                 if (

--- a/pylint/pyreverse/inspector.py
+++ b/pylint/pyreverse/inspector.py
@@ -150,7 +150,7 @@ class Linker(IdGeneratorMixIn, utils.LocalsVisitor):
         # resolve instance attributes
         for assignattrs in tuple(node.instance_attrs.values()):
             for assignattr in assignattrs:
-                if not isinstance(assignattr, nodes.Unknown):
+                if not isinstance(assignattr, (nodes.Unknown, nodes.EmptyNode)):
                     self.compositions_handler.handle(assignattr, node, info)
                     self.handle_assignattr_type(assignattr, info)
 

--- a/tests/functional/r/redefined/redefined_outer_name_type_parameter.py
+++ b/tests/functional/r/redefined/redefined_outer_name_type_parameter.py
@@ -1,0 +1,28 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11169.
+
+PEP 695 type parameters are scoped to their declaration. Reusing a
+type-parameter name from an outer scope (e.g. a type alias) is a common
+idiom and must not trigger ``redefined-outer-name``.
+"""
+# pylint: disable=missing-function-docstring,invalid-name,unused-argument
+
+from collections.abc import Callable
+
+type S[T] = list[T]
+
+
+def f[T](s: S[T]) -> T | None:
+    return None
+
+
+type A[**P] = Callable[P, int]
+
+
+def g[**P](cb: A[P]) -> None:
+    return None
+
+
+# Genuine shadowing of an outer type-parameter name is still reported.
+def h():
+    T = 1  # [redefined-outer-name]
+    return T

--- a/tests/functional/r/redefined/redefined_outer_name_type_parameter.rc
+++ b/tests/functional/r/redefined/redefined_outer_name_type_parameter.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/r/redefined/redefined_outer_name_type_parameter.txt
+++ b/tests/functional/r/redefined/redefined_outer_name_type_parameter.txt
@@ -1,0 +1,1 @@
+redefined-outer-name:27:4:27:5:h:Redefining name 'T' from outer scope (line 11):UNDEFINED

--- a/tests/functional/u/used/used_before_assignment_py312.py
+++ b/tests/functional/u/used/used_before_assignment_py312.py
@@ -19,5 +19,5 @@ class Good[T: Y]: ...
 type OtherAlias[T: Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T: Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T: Y](x: T) -> None:
     ...

--- a/tests/functional/u/used/used_before_assignment_py312.txt
+++ b/tests/functional/u/used/used_before_assignment_py312.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:22:9:22:13:func:Redefining name 'T' from outer scope (line 6):UNDEFINED

--- a/tests/functional/u/used/used_before_assignment_py313.py
+++ b/tests/functional/u/used/used_before_assignment_py313.py
@@ -12,5 +12,5 @@ class Good3[**P = [int, Y]]: ...
 type Alias[T = Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T = Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T = Y](x: T) -> None:
     ...

--- a/tests/functional/u/used/used_before_assignment_py313.txt
+++ b/tests/functional/u/used/used_before_assignment_py313.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:15:9:15:14:func:Redefining name 'T' from outer scope (line 12):UNDEFINED

--- a/tests/functional/u/used_02/used_before_assignment_py313.py
+++ b/tests/functional/u/used_02/used_before_assignment_py313.py
@@ -12,5 +12,5 @@ class Good3[**P = [int, Y]]: ...
 type Alias[T = Y] = T | None
 
 # https://github.com/pylint-dev/pylint/issues/9884
-def func[T = Y](x: T) -> None:  # [redefined-outer-name]  FALSE POSITIVE
+def func[T = Y](x: T) -> None:
     ...

--- a/tests/functional/u/used_02/used_before_assignment_py313.txt
+++ b/tests/functional/u/used_02/used_before_assignment_py313.txt
@@ -1,1 +1,0 @@
-redefined-outer-name:15:9:15:14:func:Redefining name 'T' from outer scope (line 12):UNDEFINED

--- a/tests/pyreverse/test_inspector.py
+++ b/tests/pyreverse/test_inspector.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import astroid
 import pytest
+from astroid import nodes
 
 from pylint.pyreverse.inspector import Linker, Project
 from pylint.testutils.utils import _test_cwd
@@ -64,6 +65,19 @@ def test_instance_attrs_resolution(test_context: tuple[Project, Linker]) -> None
     ]
     assert type_dict["relation"][0].name == "DoNothing"
     assert type_dict["_id"][0] is astroid.Uninferable
+
+
+def test_empty_node_instance_attrs_do_not_crash(test_context: tuple[Project, Linker]) -> None:
+    """ClassDefs with EmptyNode instance attrs (e.g. namedtuple brains) must not crash the Linker."""
+    proj, linker = test_context
+    klass = proj.get_module("data.clientmodule_test")["Specialization"]
+    fake = nodes.EmptyNode()
+    fake.attrname = "synthetic"
+    klass.instance_attrs["synthetic"] = [fake]
+    # The visit has already happened in the fixture; ensure a re-visit over the
+    # mutated class node does not raise (see pylint issue #10767).
+    linker._visited.clear()
+    linker.visit(klass)
 
 
 def test_from_directory(test_context: tuple[Project, Linker]) -> None:

--- a/tests/pyreverse/test_inspector.py
+++ b/tests/pyreverse/test_inspector.py
@@ -67,7 +67,9 @@ def test_instance_attrs_resolution(test_context: tuple[Project, Linker]) -> None
     assert type_dict["_id"][0] is astroid.Uninferable
 
 
-def test_empty_node_instance_attrs_do_not_crash(test_context: tuple[Project, Linker]) -> None:
+def test_empty_node_instance_attrs_do_not_crash(
+    test_context: tuple[Project, Linker],
+) -> None:
     """ClassDefs with EmptyNode instance attrs (e.g. namedtuple brains) must not crash the Linker."""
     proj, linker = test_context
     klass = proj.get_module("data.clientmodule_test")["Specialization"]


### PR DESCRIPTION
## Description

Fixes #10767

`pyreverse` crashes with `AttributeError: 'EmptyNode' object has no attribute 'name'` when a class diagram includes a class whose `instance_attrs` contain synthetic `EmptyNode` entries. Astroid injects these placeholders when rebuilding certain classes — e.g. namedtuple results (the `namedtuple` brain sets `attrname` on `EmptyNode` nodes) and `argparse.Namespace` inference results.

The `Linker.visit_classdef` guarded against `nodes.Unknown` placeholders but not `nodes.EmptyNode`, so the placeholder was passed into the composition/aggregation/association relationship handlers, which dereferenced `.name` and crashed.

This change skips both placeholder types when extracting relationships.

## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->
|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Related Issue

Closes #10767
