### PR TITLE
Pin astroid as third party in the PEP 810 import order test

### DIFF
--- a/tests/functional/w/wrong_import_order_py315.rc
+++ b/tests/functional/w/wrong_import_order_py315.rc
@@ -1,2 +1,8 @@
 [testoptions]
 min_pyver=3.15
+
+[IMPORTS]
+# ``astroid`` is only third party when it is not sitting in a directory that
+# isort mistakes for a source root. In astroid's own CI the workspace is named
+# ``astroid``, so isort places the import first party and the message changes.
+known-third-party=astroid


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The astroid repository runs pylint's test suite against its own commit, and the reusable workflow checks pylint out into a workspace directory named ``astroid``. isort's ``_src_path`` placement treats a source root whose directory name equals the module name as first party, so ``import astroid`` was reported as a first party import there and ``wrong_import_order_py315`` failed on every astroid pull request.

Declaring ``known-third-party`` makes the placement explicit: isort checks known patterns before source paths, so the message no longer depends on what the checkout directory happens to be called.
