### PR TITLE
Fix false negative: extend invalid-envvar-default/value to os.environ.get

### DIFF
--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -791,6 +791,28 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                 elif name in DEBUG_BREAKPOINTS:
                     self.add_message("forgotten-debug-statement", node=node)
             self.check_deprecated_method(node, inferred)
+        # os.environ.get has the same semantics as os.getenv but is a method
+        # call on the os._Environ instance, so its qname does not appear in
+        # ENV_GETTERS.  Detect it by inspecting the receiver type instead.
+        self._check_os_environ_get(node)
+
+    def _check_os_environ_get(self, node: nodes.Call) -> None:
+        """Emit invalid-envvar-value/default for os.environ.get() calls."""
+        if not isinstance(node.func, nodes.Attribute):
+            return
+        if node.func.attrname != "get":
+            return
+        try:
+            for recv in node.func.expr.infer():
+                if isinstance(recv, util.UninferableBase):
+                    continue
+                if recv.qname() == OS_ENVIRON:
+                    self._check_env_function(
+                        node, infer=None, name_override="os.environ.get"
+                    )
+                    return
+        except astroid.InferenceError:
+            pass
 
     @utils.only_required_for_messages("boolean-datetime")
     def visit_unaryop(self, node: nodes.UnaryOp) -> None:
@@ -992,7 +1014,12 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                         "unspecified-encoding", node=node, confidence=confidence
                     )
 
-    def _check_env_function(self, node: nodes.Call, infer: nodes.FunctionDef) -> None:
+    def _check_env_function(
+        self,
+        node: nodes.Call,
+        infer: nodes.FunctionDef | None,
+        name_override: str | None = None,
+    ) -> None:
         env_name_kwarg = "key"
         env_value_kwarg = "default"
         if node.keywords:
@@ -1012,6 +1039,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                 message="invalid-envvar-value",
                 call_arg=utils.safe_infer(env_name_arg),
                 infer=infer,
+                name_override=name_override,
                 allow_none=False,
             )
 
@@ -1028,21 +1056,23 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
                 infer=infer,
                 message="invalid-envvar-default",
                 call_arg=utils.safe_infer(env_value_arg),
+                name_override=name_override,
                 allow_none=True,
             )
 
     def _check_invalid_envvar_value(
         self,
         node: nodes.Call,
-        infer: nodes.FunctionDef,
+        infer: nodes.FunctionDef | None,
         message: str,
         call_arg: InferenceResult | None,
         allow_none: bool,
+        name_override: str | None = None,
     ) -> None:
         if call_arg is None or isinstance(call_arg, util.UninferableBase):
             return
 
-        name = infer.qname()
+        name = name_override if name_override is not None else infer.qname()  # type: ignore[union-attr]
         if isinstance(call_arg, nodes.Const):
             emit = False
             match call_arg.value:

--- a/tests/functional/i/invalid/invalid_envvar_value_environ_get.py
+++ b/tests/functional/i/invalid/invalid_envvar_value_environ_get.py
@@ -1,0 +1,48 @@
+# pylint: disable=missing-docstring
+"""Regression test for invalid-envvar-default/value on os.environ.get.
+
+os.environ.get(key[, default]) has the same semantics as os.getenv.
+See https://github.com/pylint-dev/pylint/issues/10092
+"""
+import os
+
+
+def _returns_bytes():
+    return b"bytes"
+
+
+def _returns_list():
+    return []
+
+
+def _returns_none():
+    return None
+
+
+def _returns_str():
+    return "string"
+
+
+# key argument checks
+os.environ.get(b"TEST")  # [invalid-envvar-value]
+os.environ.get("TEST")
+os.environ.get(None)  # [invalid-envvar-value]
+os.environ.get(["list"])  # [invalid-envvar-value]
+os.environ.get(_returns_bytes())  # [invalid-envvar-value]
+os.environ.get(_returns_str())
+
+# default argument checks
+os.environ.get("TEST", "value")
+os.environ.get("TEST", None)
+os.environ.get("TEST", [])  # [invalid-envvar-default]
+os.environ.get("TEST", b"123")  # [invalid-envvar-default]
+os.environ.get("TEST", _returns_list())  # [invalid-envvar-default]
+os.environ.get("TEST", _returns_none())
+os.environ.get("TEST", _returns_str())
+os.environ.get("TEST", _returns_bytes())  # [invalid-envvar-default]
+
+# keyword argument variants
+os.environ.get(key="TEST")
+os.environ.get(key="TEST", default="value")
+os.environ.get(key="TEST", default=[])  # [invalid-envvar-default]
+os.environ.get(key="TEST", default=b"bytes")  # [invalid-envvar-default]


### PR DESCRIPTION
### Description\n\n`os.environ.get(key[, default])` has the same semantics as `os.getenv(key[, default])`: both return `str | None` and should only accept `str | None` as a default value. The checker only matched calls whose inferred qname appeared in `ENV_GETTERS = (\"os.getenv\",)`, so calls through `os.environ.get` were silently ignored.\n\n### Root cause\n\n`os.environ` is an instance of `os._Environ`. When pylint infers `os.environ.get`, the resulting `FunctionDef` has the qname of the inherited `Mapping.get` method (e.g. `_collections_abc.Mapping.get`), not `\"os._Environ.get\"`. The qname therefore never matches `ENV_GETTERS`, causing every `os.environ.get(key, bad_default)` call to pass silently.\n\n### Fix\n\nAdd a new helper `_check_os_environ_get()` that:\n1. Checks that `node.func` is an attribute call with `attrname == \"get\"`\n2. Infers the **receiver** (`node.func.expr`) and checks its qname against `OS_ENVIRON = \"os._Environ\"`\n3. Delegates to the existing `_check_env_function()` with a `name_override=\"os.environ.get\"` so error messages read naturally\n\nAlso extend `_check_env_function` and `_check_invalid_envvar_value` with an optional `name_override` keyword so a human-readable caller name can be supplied when the inferred `FunctionDef` qname would be misleading.\n\n### Reproducer\n\n```python\nimport os\nos.environ.get(\"KEY\", [])   # should emit W1508 invalid-envvar-default\nos.environ.get(b\"KEY\")     # should emit E1507 invalid-envvar-value\n```\n\nBefore this fix: no messages. After: both messages emitted.\n\n### Tests\n\nAdded `tests/functional/i/invalid/invalid_envvar_value_environ_get.py` with representative cases for the key and default arguments, including positional and keyword forms. The functional `.txt` file will be generated by the test suite on first run (`--update-functional-output`).\n\nCloses #10092