### PR TITLE
Treat 0 as a supplied location in UnittestLinter.add_message

### DIFF
--- a/pylint/testutils/unittest_linter.py
+++ b/pylint/testutils/unittest_linter.py
@@ -44,22 +44,22 @@ class UnittestLinter(PyLinter):
         # Look up "location" data of node if not yet supplied
         if node:
             if node.position:
-                if not line:
+                if line is None:
                     line = node.position.lineno
-                if not col_offset:
+                if col_offset is None:
                     col_offset = node.position.col_offset
-                if not end_lineno:
+                if end_lineno is None:
                     end_lineno = node.position.end_lineno
-                if not end_col_offset:
+                if end_col_offset is None:
                     end_col_offset = node.position.end_col_offset
             else:
-                if not line:
+                if line is None:
                     line = node.fromlineno
-                if not col_offset:
+                if col_offset is None:
                     col_offset = node.col_offset
-                if not end_lineno:
+                if end_lineno is None:
                     end_lineno = node.end_lineno
-                if not end_col_offset:
+                if end_col_offset is None:
                     end_col_offset = node.end_col_offset
 
         self._messages.append(

--- a/tests/testutils/test_checker_test_case.py
+++ b/tests/testutils/test_checker_test_case.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import astroid
 import pytest
 
 from pylint.checkers.base_checker import BaseChecker
@@ -93,3 +94,11 @@ class TestCheckerTestCase(CheckerTestCase):
         # Messages must have been drained; a subsequent assertNoMessages should pass.
         with self.assertNoMessages():
             pass
+
+    def test_explicit_zero_col_offset_is_kept(self) -> None:
+        """col_offset=0 is the first column, not "not supplied"."""
+        node = astroid.extract_node("if True:\n    x = 1  #@\n")
+        assert node.col_offset != 0
+
+        self.linter.add_message("W9901", line=2, node=node, col_offset=0)
+        assert self.linter.release_messages()[0].col_offset == 0


### PR DESCRIPTION
`UnittestLinter.add_message` fills in location data from the node when a value is "not yet supplied", and it tests that with truthiness:

```python
if not col_offset:
    col_offset = node.position.col_offset
```

Column offsets are 0-based, so an explicit `col_offset=0` is the first column and gets overwritten by whatever the node has:

```python
node = astroid.extract_node("if True:\n    x = 1  #@\n")   # col_offset 4
linter.add_message("W9901", line=2, node=node, col_offset=0)
linter.release_messages()[0].col_offset                    # 4
```

A test asserting column 0 cannot fail. It gets rewritten to match whatever the checker did.

The `is None` check was there until #5622, which was removing unrelated `node and hasattr(...)` guards and collapsed `col_offset is None` into `not col_offset` along the way:

```python
-        if col_offset is None and node and hasattr(node, "col_offset"):
+            if not col_offset:
```

All four parameters are `int | None` with `None` as the documented "not supplied" value, so this restores that for the set. For `line` and `end_lineno` it changes nothing, since line 0 does not occur.

`pylint.testutils` is public. So this reaches plugin authors testing their own checkers too.

Nothing in your suite was relying on it: tests/testutils and tests/checkers are 511 passing either way, and the wider unit run has the same 2 pre-existing failures before and after. So no assertion is passing on a wrong value today. This is about assertions that cannot fail, not ones that are wrong now. Reverting just `unittest_linter.py` fails the new test alone.
