### PR TITLE
Add groups for pip and github-actions in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     rebase-strategy: "disabled"
     cooldown:
       default-days: 7
+    groups:
+      pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,3 +27,7 @@ updates:
     rebase-strategy: "disabled"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Avoids stupid stuff like https://github.com/pylint-dev/pylint/pull/11281, https://github.com/pylint-dev/pylint/pull/11282 and https://github.com/pylint-dev/pylint/pull/11283 and generally makes it less work to keep these up to date.