### PR TITLE
Recognize version guards however `sys.version_info` is spelled

### DIFF
--- a/doc/whatsnew/fragments/11293.false_positive
+++ b/doc/whatsnew/fragments/11293.false_positive
@@ -1,0 +1,4 @@
+A version guard no longer has to spell out ``sys.version_info`` literally to be
+recognized as one.
+
+Refs #11293

--- a/doc/whatsnew/fragments/11294.internal
+++ b/doc/whatsnew/fragments/11294.internal
@@ -1,0 +1,5 @@
+New function ``pylint.checkers.utils.is_module_member`` permits checking whether a
+node is a member of a module, through the various import syntaxes and aliases. The
+``typing`` checks that each rolled their own version of that question now share it.
+
+Refs #11294

--- a/doc/whatsnew/fragments/11294.other
+++ b/doc/whatsnew/fragments/11294.other
@@ -1,0 +1,6 @@
+``pylint.checkers.utils.is_typing_member`` is deprecated: it is
+``is_module_member(node, "typing.<name>")`` with the module filled in. Call
+``is_module_member`` directly instead. ``is_typing_member`` will be removed in
+pylint 5.0.
+
+Refs #11294

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1868,6 +1868,44 @@ def is_module_member(node: nodes.NodeNG, *qnames: str) -> bool:
     return False
 
 
+def is_sys_guard(node: nodes.If) -> bool:
+    """Return True if the 'if' node is a system version guard equivalent.
+
+    >>> import sys
+    >>> from typing import Literal
+    """
+    return _is_version_guard_test(node.test)
+
+
+def _is_version_guard_test(test: nodes.NodeNG) -> bool:
+    match test:
+        case nodes.BoolOp():
+            return any(_is_version_guard_test(value) for value in test.values)
+        case nodes.UnaryOp(op="not"):
+            return _is_version_guard_test(test.operand)
+        case nodes.Compare():
+            operands = [test.left] + [operand for _, operand in test.ops]
+            return any(_is_version_info_value(operand) for operand in operands)
+        case _:
+            # A bare truthiness guard: only six's version flags qualify.
+            return is_module_member(test, "six.PY2", "six.PY3")
+
+
+def _is_version_info_value(value: nodes.NodeNG) -> bool:
+    """Whether the value grows with the version of the running interpreter."""
+    if is_module_member(value, "sys.version_info", "sys.hexversion"):
+        return True
+    match value:
+        case nodes.Subscript():
+            # e.g. the `[:2]` in `version_info[:2]`
+            return _is_version_info_value(value.value)
+        case nodes.Attribute():
+            # e.g. the `major` in `version_info.major`
+            return _is_version_info_value(value.expr)
+        case _:
+            return False
+
+
 def _resolves_to_module(expr: nodes.NodeNG, modname: str) -> bool:
     if isinstance(expr, nodes.Name):
         # Answer from the binding rather than from inference, which comes up
@@ -1903,29 +1941,6 @@ def _binds_module_member(
         )
         for assignment in assignments
     )
-
-
-def is_sys_guard(node: nodes.If) -> bool:
-    """Return True if IF stmt is a sys.version_info guard.
-
-    >>> import sys
-    >>> from typing import Literal
-    """
-    if isinstance(node.test, nodes.Compare):
-        value = node.test.left
-        if isinstance(value, nodes.Subscript):
-            value = value.value
-        if (
-            isinstance(value, nodes.Attribute)
-            and value.as_string() == "sys.version_info"
-        ):
-            return True
-    elif isinstance(node.test, nodes.Attribute) and node.test.as_string() in {
-        "six.PY2",
-        "six.PY3",
-    }:
-        return True
-    return False
 
 
 def _is_node_in_same_scope(

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -56,6 +56,20 @@ TYPING_PROTOCOLS = frozenset(
     {"typing.Protocol", "typing_extensions.Protocol", ".Protocol"}
 )
 COMMUTATIVE_OPERATORS = frozenset({"*", "+", "^", "&", "|"})
+REVERSED_COMPS = {
+    "<": ">",
+    "<=": ">=",
+    ">": "<",
+    ">=": "<=",
+    "==": "==",
+    "!=": "!=",
+}
+"""Comparators mapped to the comparator to use once the operands are swapped.
+
+Membership and identity operators are left out on purpose: unlike for
+:func:`get_inverse_comparator`, swapping the operands of ``in`` or ``is``
+changes the meaning of the comparison.
+"""
 ITER_METHOD = "__iter__"
 AITER_METHOD = "__aiter__"
 NEXT_METHOD = "__next__"

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -13,6 +13,7 @@ import itertools
 import numbers
 import re
 import string
+import warnings
 from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache, partial
 from re import Match
@@ -904,42 +905,11 @@ def uninferable_final_decorators(
     """
     decorators = []
     for decorator in getattr(node, "nodes", []):
-        import_nodes: tuple[nodes.Import | nodes.ImportFrom] | None = None
-
-        # Get the `Import` node. The decorator is of the form: @module.name
-        if isinstance(decorator, nodes.Attribute):
-            inferred = safe_infer(decorator.expr)
-            if isinstance(inferred, nodes.Module) and inferred.qname() == "typing":
-                _, import_nodes = decorator.expr.lookup(decorator.expr.name)
-
-        # Get the `ImportFrom` node. The decorator is of the form: @name
-        elif isinstance(decorator, nodes.Name):
-            _, import_nodes = decorator.lookup(decorator.name)
-
-        # The `final` decorator is expected to be found in the
-        # import_nodes. Continue if we don't find any `Import` or `ImportFrom`
-        # nodes for this decorator.
-        if not import_nodes:
+        if not is_module_member(decorator, "typing.final"):
             continue
-        import_node = import_nodes[0]
-
-        if not isinstance(import_node, (nodes.Import, nodes.ImportFrom)):
-            continue
-
-        import_names = dict(import_node.names)
-
-        # Check if the import is of the form: `from typing import final`
-        is_from_import = ("final" in import_names) and import_node.modname == "typing"
-
-        # Check if the import is of the form: `import typing`
-        is_import = ("typing" in import_names) and getattr(
-            decorator, "attrname", None
-        ) == "final"
-
-        if is_from_import or is_import:
-            inferred = safe_infer(decorator)
-            if inferred is None or isinstance(inferred, util.UninferableBase):
-                decorators.append(decorator)
+        inferred = safe_infer(decorator)
+        if inferred is None or isinstance(inferred, util.UninferableBase):
+            decorators.append(decorator)
     return decorators
 
 
@@ -1843,6 +1813,84 @@ def get_import_name(importnode: ImportNode, modname: str | None) -> str | None:
     return modname
 
 
+@lru_cache(maxsize=512)
+def _split_qnames(qnames: tuple[str, ...]) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Group qualified names by the module that owns them.
+
+    Grouping is not an optimization: resolving a module is a scope lookup, so
+    members sharing a module have to be asked for together to pay for it once.
+    Cached because a call site passes the same literal names every time.
+    """
+    grouped: dict[str, tuple[str, ...]] = {}
+    for qname in qnames:
+        modname, _, member = qname.rpartition(".")
+        if not modname:
+            raise ValueError(
+                f"{qname!r} is not a qualified name, expected 'module.member'"
+            )
+        grouped[modname] = (*grouped.get(modname, ()), member)
+    return tuple(grouped.items())
+
+
+def is_module_member(node: nodes.NodeNG, *qnames: str) -> bool:
+    """Return True if the node refers to one of the given qualified names.
+
+    However it is spelled: ``module.member`` and the name bound by
+    ``from module import member`` both count, each of them possibly aliased. The
+    module is identified by the import that binds it rather than by the name it
+    is spelled with, so a class or a variable named after it does not pass for
+    it.
+    """
+    if isinstance(node, nodes.Attribute):
+        return any(
+            node.attrname in members and _resolves_to_module(node.expr, modname)
+            for modname, members in _split_qnames(qnames)
+        )
+    if isinstance(node, nodes.Name):
+        return any(
+            _binds_module_member(node, modname, members)
+            for modname, members in _split_qnames(qnames)
+        )
+    return False
+
+
+def _resolves_to_module(expr: nodes.NodeNG, modname: str) -> bool:
+    if isinstance(expr, nodes.Name):
+        # Answer from the binding rather than from inference, which comes up
+        # empty when the ``import`` itself sits inside a guarded block. It also
+        # rejects a class or a variable named after the module, which the
+        # spelling alone cannot tell the module apart from.
+        _, assignments = expr.lookup(expr.name)
+        return any(
+            isinstance(assignment, nodes.Import)
+            and any(
+                real == modname and (alias or real) == expr.name
+                for real, alias in assignment.names
+            )
+            for assignment in assignments
+        )
+    match safe_infer(expr):
+        case nodes.Module(name=name) if name == modname:
+            return True
+    return False
+
+
+def _binds_module_member(
+    name: nodes.Name, modname: str, members: tuple[str, ...]
+) -> bool:
+    """Whether the name is bound by a ``from modname import <member>``."""
+    _, assignments = name.lookup(name.name)
+    return any(
+        isinstance(assignment, nodes.ImportFrom)
+        and assignment.modname == modname
+        and any(
+            real in members and (alias or real) == name.name
+            for real, alias in assignment.names
+        )
+        for assignment in assignments
+    )
+
+
 def is_sys_guard(node: nodes.If) -> bool:
     """Return True if IF stmt is a sys.version_info guard.
 
@@ -1993,52 +2041,36 @@ def in_type_checking_block(node: nodes.NodeNG) -> bool:
     for ancestor in node.node_ancestors():
         if not isinstance(ancestor, nodes.If):
             continue
-        if isinstance(ancestor.test, nodes.Name):
-            if ancestor.test.name != "TYPE_CHECKING":
-                continue
-            lookup_result = ancestor.test.lookup(ancestor.test.name)[1]
-            if not lookup_result:
-                return False
-            maybe_import_from = lookup_result[0]
-            if (
-                isinstance(maybe_import_from, nodes.ImportFrom)
-                and maybe_import_from.modname == "typing"
-            ):
-                return True
+        if is_module_member(ancestor.test, "typing.TYPE_CHECKING"):
+            return True
+        # A flag standing in for typing's, e.g. `TYPE_CHECKING = False` in the
+        # module itself, which is only ever true for a type checker.
+        if (
+            isinstance(ancestor.test, nodes.Name)
+            and ancestor.test.name == "TYPE_CHECKING"
+        ):
             match safe_infer(ancestor.test):
                 case nodes.Const(value=False):
                     return True
-        elif isinstance(ancestor.test, nodes.Attribute):
-            if ancestor.test.attrname != "TYPE_CHECKING":
-                continue
-            match safe_infer(ancestor.test.expr):
-                case nodes.Module(name="typing"):
-                    return True
 
     return False
 
 
+# TODO: 5.0: Remove is_typing_member, deprecated in favor of is_module_member.
 def is_typing_member(node: nodes.NodeNG, names_to_check: tuple[str, ...]) -> bool:
     """Check if `node` is a member of the `typing` module and has one of the names from
     `names_to_check`.
-    """
-    match node:
-        case nodes.Name():
-            try:
-                import_from = node.lookup(node.name)[1][0]
-            except IndexError:
-                return False
 
-            match import_from:
-                case nodes.ImportFrom(modname="typing"):
-                    return import_from.real_name(node.name) in names_to_check
-            return False
-        case nodes.Attribute():
-            match safe_infer(node.expr):
-                case nodes.Module(name="typing"):
-                    return node.attrname in names_to_check
-            return False
-    return False
+    Deprecated: call ``is_module_member(node, "typing.<name>")`` instead.
+    """
+    warnings.warn(
+        "is_typing_member has been deprecated. Use "
+        "is_module_member(node, 'typing.<name>') instead. "
+        "It will be removed in pylint 5.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return is_module_member(node, *(f"typing.{name}" for name in names_to_check))
 
 
 @lru_cache

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3540,8 +3540,8 @@ class VariablesChecker(BaseChecker):
             parent = parent.parent
         if isinstance(parent, nodes.Subscript):
             origin = next(parent.get_children(), None)
-            if origin is not None and utils.is_typing_member(
-                origin, ("Annotated", "Literal")
+            if origin is not None and utils.is_module_member(
+                origin, "typing.Annotated", "typing.Literal"
             ):
                 return
 

--- a/pylint/extensions/comparison_placement.py
+++ b/pylint/extensions/comparison_placement.py
@@ -13,12 +13,12 @@ from typing import TYPE_CHECKING
 from astroid import nodes
 
 from pylint.checkers import BaseChecker, utils
+from pylint.checkers.utils import REVERSED_COMPS
 
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
-REVERSED_COMPS = {"<": ">", "<=": ">=", ">": "<", ">=": "<="}
-COMPARISON_OPERATORS = frozenset(("==", "!=", "<", ">", "<=", ">="))
+COMPARISON_OPERATORS = frozenset(REVERSED_COMPS)
 
 
 class MisplacedComparisonConstantChecker(BaseChecker):

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -564,6 +564,103 @@ def test_if_sys_guard() -> None:
     assert utils.is_sys_guard(code[5]) is False
 
 
+def test_if_sys_guard_alternative_spellings() -> None:
+    """A version guard is recognized however the version is spelled."""
+    code = astroid.extract_node("""
+    import sys
+    import sys as system
+    from sys import version_info
+    from sys import version_info as vi
+    from sys import hexversion
+    from six import PY2
+
+    if version_info >= (3, 8):  #@
+        pass
+
+    if vi[:2] >= (3, 8):  #@
+        pass
+
+    if system.version_info >= (3, 8):  #@
+        pass
+
+    if sys.version_info.major >= 3:  #@
+        pass
+
+    if (3, 8) <= sys.version_info:  #@
+        pass
+
+    if hexversion >= 0x030800F0:  #@
+        pass
+
+    if sys.version_info >= (3, 8) and sys.platform == "linux":  #@
+        pass
+
+    if not sys.version_info >= (3, 8):  #@
+        pass
+
+    if PY2:  #@
+        pass
+    """)
+    assert isinstance(code, list) and len(code) == 9
+
+    for guard in code:
+        assert isinstance(guard, nodes.If)
+        assert utils.is_sys_guard(guard) is True, guard.as_string()
+
+
+def test_if_sys_guard_lookalikes() -> None:
+    """Something that merely reads like a version check is not a guard."""
+    code = astroid.extract_node("""
+    import os
+    import sys
+    import os as compat
+    from django import VERSION as version_info
+
+    if sys.some_other_function > (3, 8):  #@
+        pass
+
+    if version_info >= (3, 8):  #@
+        pass
+
+    if compat.PY2:  #@
+        pass
+
+    if os.version_info >= (3, 8):  #@
+        pass
+
+    if os.getenv("PY2"):  #@
+        pass
+
+    if sys.platform == "linux":  #@
+        pass
+    """)
+    assert isinstance(code, list) and len(code) == 6
+
+    for not_a_guard in code:
+        assert isinstance(not_a_guard, nodes.If)
+        assert utils.is_sys_guard(not_a_guard) is False, not_a_guard.as_string()
+
+
+def test_if_sys_guard_shadowed_sys() -> None:
+    """A local class named sys reads exactly like the module and is not it."""
+    code = astroid.extract_node("""
+    class sys:
+        version_info = (3, 12)
+        hexversion = 0x030C00F0
+
+    if sys.version_info >= (3, 8):  #@
+        pass
+
+    if sys.hexversion >= 0x030800F0:  #@
+        pass
+    """)
+    assert isinstance(code, list) and len(code) == 2
+
+    for not_a_guard in code:
+        assert isinstance(not_a_guard, nodes.If)
+        assert utils.is_sys_guard(not_a_guard) is False, not_a_guard.as_string()
+
+
 def test_if_typing_guard() -> None:
     code = astroid.extract_node("""
     import typing

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -344,6 +344,185 @@ def test_get_node_last_lineno_combined() -> None:
     assert utils.get_node_last_lineno(node) == 11
 
 
+def test_is_module_member() -> None:
+    """Only the asked-for member, however the module is spelled."""
+    code = astroid.extract_node("""
+    import os
+    import sys
+    import sys as system
+    from sys import version_info
+    from sys import version_info as vi
+    from django import VERSION as version_info_of_a_library
+
+    sys.version_info  #@
+    system.version_info  #@
+    version_info  #@
+    vi  #@
+
+    sys.version_info[0]  #@
+    sys.version_info.major  #@
+    sys.hexversion  #@
+    os.version_info  #@
+    version_info_of_a_library  #@
+    """)
+    assert isinstance(code, list) and len(code) == 9
+
+    for spelling in code[:4]:
+        assert (
+            utils.is_module_member(spelling, "sys.version_info") is True
+        ), spelling.as_string()
+
+    for lookalike in code[4:]:
+        assert (
+            utils.is_module_member(lookalike, "sys.version_info") is False
+        ), lookalike.as_string()
+
+
+def test_is_module_member_several_members() -> None:
+    """Any of the members asked for counts, and nothing else does."""
+    code = astroid.extract_node("""
+    import sys
+    from sys import hexversion
+
+    sys.version_info  #@
+    sys.hexversion  #@
+    hexversion  #@
+
+    sys.maxsize  #@
+    """)
+    assert isinstance(code, list) and len(code) == 4
+
+    for member in code[:3]:
+        assert (
+            utils.is_module_member(member, "sys.version_info", "sys.hexversion") is True
+        ), member.as_string()
+
+    assert (
+        utils.is_module_member(code[3], "sys.version_info", "sys.hexversion") is False
+    ), code[3].as_string()
+
+
+def test_uninferable_final_decorators() -> None:
+    """A `typing.final` decorator is reported only when it cannot be inferred.
+
+    `unsupported_version` reaches for this only after `safe_infer` came up empty,
+    which needs the name to have more than one possible value.
+    """
+    module = astroid.parse("""
+    from typing import final
+    if unknown_condition:
+        final = something_else
+
+    @final
+    def ambiguous():
+        pass
+
+    @typing.final
+    def not_even_imported():
+        pass
+    """)
+    ambiguous, not_even_imported = module.body[-2], module.body[-1]
+
+    assert utils.uninferable_final_decorators(ambiguous.decorators) == [
+        ambiguous.decorators.nodes[0]
+    ]
+    assert not utils.uninferable_final_decorators(not_even_imported.decorators)
+
+
+def test_is_module_member_needs_a_qualified_name() -> None:
+    """A bare member name would silently match nothing, so it is refused.
+
+    ``"version_info".rpartition(".")`` leaves an empty module name, which no
+    import can bind, so the mistake has to be loud rather than a missed message.
+    """
+    code = astroid.extract_node("""
+    import sys
+
+    sys.version_info  #@
+    """)
+
+    with pytest.raises(ValueError, match="is not a qualified name"):
+        utils.is_module_member(code, "version_info")
+
+
+def test_is_module_member_aliases() -> None:
+    """An alias is followed, and never taken at face value.
+
+    What the import brings in and what it binds the result to are two different
+    names, so a module or a member wearing the other one's name is not it.
+    """
+    code = astroid.extract_node("""
+    import sys as system
+    from sys import version_info as vi
+
+    import os as sys
+    import sys as version_info
+    from sys import maxsize as version_info
+    from os import sep as version_info
+
+    system.version_info  #@
+    vi  #@
+
+    sys.version_info  #@
+    version_info  #@
+    """)
+    assert isinstance(code, list) and len(code) == 4
+
+    # `import sys as system`, then `from sys import version_info as vi`.
+    assert utils.is_module_member(code[0], "sys.version_info") is True
+    assert utils.is_module_member(code[1], "sys.version_info") is True
+
+    # `sys` is really `os` here, and `version_info` is really `sys.maxsize`.
+    assert utils.is_module_member(code[2], "sys.version_info") is False
+    assert utils.is_module_member(code[3], "sys.version_info") is False
+
+
+def test_is_module_member_dotted_module() -> None:
+    """A module reached through a dotted name is resolved by inference.
+
+    ``os.path`` is deliberately not the example: it infers to ``posixpath`` or
+    to ``ntpath`` depending on the platform, so it is not its own module.
+    """
+    code = astroid.extract_node("""
+    import xml.etree.ElementTree
+
+    xml.etree.ElementTree.parse  #@
+    xml.etree.ElementTree.does_not_matter  #@
+    xml.etree.parse  #@
+    """)
+    assert isinstance(code, list) and len(code) == 3
+
+    assert utils.is_module_member(code[0], "xml.etree.ElementTree.parse") is True
+    # The right module, a member it does not have.
+    assert utils.is_module_member(code[1], "xml.etree.ElementTree.parse") is False
+    # The right member name, hanging off a different module.
+    assert utils.is_module_member(code[2], "xml.etree.ElementTree.parse") is False
+
+
+def test_is_module_member_shadowed_module() -> None:
+    """A class named after a module reads like it and is not it."""
+    code = astroid.extract_node("""
+    class sys:
+        version_info = (3, 12)
+
+    sys.version_info  #@
+    """)
+    assert utils.is_module_member(code, "sys.version_info") is False
+
+
+def test_is_module_member_import_in_a_block() -> None:
+    """The import binding the module need not be at module level."""
+    code = astroid.extract_node("""
+    try:
+        import sys
+    except ImportError:
+        sys = None
+
+    sys.version_info  #@
+    """)
+    assert utils.is_module_member(code, "sys.version_info") is True
+
+
 def test_if_sys_guard() -> None:
     code = astroid.extract_node("""
     import sys
@@ -446,7 +625,7 @@ def test_is_empty_literal() -> None:
     assert not utils.is_empty_str_literal(not_empty_string_node.value)
 
 
-def test_is_typing_member() -> None:
+def test_is_module_member_typing() -> None:
     code = astroid.extract_node("""
     from typing import Literal as Lit, Set as Literal
     import typing as t
@@ -456,16 +635,28 @@ def test_is_typing_member() -> None:
     t.Literal #@
     """)
 
-    assert not utils.is_typing_member(code[0], ("Literal",))
-    assert utils.is_typing_member(code[1], ("Literal",))
-    assert utils.is_typing_member(code[2], ("Literal",))
+    assert not utils.is_module_member(code[0], "typing.Literal")
+    assert utils.is_module_member(code[1], "typing.Literal")
+    assert utils.is_module_member(code[2], "typing.Literal")
 
     code = astroid.extract_node("""
     Literal #@
     typing.Literal #@
     """)
-    assert not utils.is_typing_member(code[0], ("Literal",))
-    assert not utils.is_typing_member(code[1], ("Literal",))
+    assert not utils.is_module_member(code[0], "typing.Literal")
+    assert not utils.is_module_member(code[1], "typing.Literal")
+
+
+def test_is_typing_member_is_deprecated() -> None:
+    """It still answers, but is_module_member is the one to call now."""
+    code = astroid.extract_node("""
+    from typing import Literal
+
+    Literal #@
+    """)
+
+    with pytest.warns(DeprecationWarning, match="is_typing_member has been deprecated"):
+        assert utils.is_typing_member(code, ("Literal",)) is True
 
 
 def test_is_reassigned_after_current_requires_isinstance_check() -> None:

--- a/tests/functional/d/deprecated/deprecated_class_sys_guard.py
+++ b/tests/functional/d/deprecated/deprecated_class_sys_guard.py
@@ -13,3 +13,27 @@ if sys.platform == "win32":
 
 if sys.version_info >= (3, 3):
     from xml.etree.cElementTree import Element  # [deprecated-module]
+
+# The guard counts however `sys.version_info` is spelled
+from sys import version_info
+
+if version_info >= (3, 9):
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+
+if (3, 9) <= version_info:
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
+
+if version_info[:2] >= (3, 9):
+    from collections.abc import Sized
+else:
+    from collections import Sized
+
+# A name that merely looks like the version does not guard anything
+from collections import OrderedDict as version_info_fake
+
+if version_info_fake >= (3, 9):
+    from collections import Callable  # [deprecated-class]

--- a/tests/functional/d/deprecated/deprecated_class_sys_guard.txt
+++ b/tests/functional/d/deprecated/deprecated_class_sys_guard.txt
@@ -1,2 +1,3 @@
 deprecated-class:12:4:12:36::Using deprecated class Iterable of module collections:UNDEFINED
 deprecated-module:15:4:15:46::Deprecated module 'xml.etree.cElementTree':UNDEFINED
+deprecated-class:39:4:39:36::Using deprecated class Callable of module collections:UNDEFINED

--- a/tests/functional/i/import_error.py
+++ b/tests/functional/i/import_error.py
@@ -114,3 +114,27 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     with contextlib.suppress(TypeError):
         import foo2
+
+# Version guards are recognized however `sys.version_info` is spelled
+from sys import version_info
+
+if version_info >= (3, 9):
+    import some_module
+    from some_module import some_class
+else:
+    import some_module_alt
+
+if (3, 9) <= version_info:
+    import some_module
+
+if version_info[:2] >= (3, 9):
+    import some_module
+
+
+def shadowed_sys():
+    """A local class named `sys` reads like the module without being it."""
+    class sys:
+        version_info = (3, 12)
+
+    if sys.version_info >= (3, 9):
+        import missing_module  # [import-error]

--- a/tests/functional/i/import_error.txt
+++ b/tests/functional/i/import_error.txt
@@ -4,3 +4,4 @@ no-name-in-module:33:0:33:49::No name 'syntax_error' in module 'functional.s.syn
 syntax-error:33:0:None:None::Cannot import 'functional.s.syntax.syntax_error' due to 'invalid syntax (functional.s.syntax.syntax_error, line 1)':HIGH
 multiple-imports:78:0:78:15::Multiple imports on one line (foo, bar):UNDEFINED
 import-error:96:4:96:15::Unable to import 'foo2':UNDEFINED
+import-error:140:8:140:29:shadowed_sys:Unable to import 'missing_module':UNDEFINED

--- a/tests/functional/n/no/no_name_in_module.py
+++ b/tests/functional/n/no/no_name_in_module.py
@@ -84,3 +84,25 @@ from argparse import THIS_does_not_EXIST
 # only if numpy is installed. We are not installing numpy on CI (for now)
 from numpy.distutils.misc_util import is_sequence
 from pydantic import BaseModel
+
+
+# A version guard counts however `sys.version_info` is spelled
+from sys import version_info
+
+if version_info >= (3, 9):
+    from collections import only_on_new_pythons
+    import collections.only_on_new_pythons
+else:
+    from collections import only_on_old_pythons
+
+if (3, 9) <= version_info:
+    from collections import right_hand_side
+
+if version_info[:2] >= (3, 9):
+    import collections.sliced_guard
+
+# A name that merely looks like the version does not guard anything
+from collections import OrderedDict as version_info_fake
+
+if version_info_fake >= (3, 9):
+    from collections import not_guarded_at_all  # [no-name-in-module]

--- a/tests/functional/n/no/no_name_in_module.txt
+++ b/tests/functional/n/no/no_name_in_module.txt
@@ -12,3 +12,4 @@ no-name-in-module:54:4:54:27::No name 'emit' in module 'collections':UNDEFINED
 no-name-in-module:71:8:71:32::No name 'emit2' in module 'collections':UNDEFINED
 no-name-in-module:76:0:76:34::No name 'lala' in module 'functional.n.no.no_self_argument':UNDEFINED
 no-name-in-module:77:0:77:39::No name 'bla' in module 'functional.n.no.no_self_argument':UNDEFINED
+no-name-in-module:108:4:108:46::No name 'not_guarded_at_all' in module 'collections':UNDEFINED

--- a/tests/functional/u/ungrouped_imports.py
+++ b/tests/functional/u/ungrouped_imports.py
@@ -32,3 +32,18 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import re
     from typing import List
+
+# Imports in a version guard should not either, however `sys.version_info`
+# is spelled
+from sys import version_info
+if version_info >= (3, 9):
+    from typing import Any
+if (3, 9) <= version_info:
+    from os import altsep
+if version_info[:2] >= (3, 9):
+    from typing import Optional
+
+# Another package's version says nothing about the interpreter
+from astroid import __version__ as astroid_version
+if astroid_version >= (3, 9):
+    from os import devnull  # [ungrouped-imports]

--- a/tests/functional/u/ungrouped_imports.txt
+++ b/tests/functional/u/ungrouped_imports.txt
@@ -3,3 +3,4 @@ ungrouped-imports:11:4:11:13::Imports from package os are not grouped:UNDEFINED
 ungrouped-imports:17:0:17:30::Imports from package astroid are not grouped:UNDEFINED
 ungrouped-imports:19:4:19:27::Imports from package logging are not grouped:UNDEFINED
 ungrouped-imports:20:0:20:24::Imports from package os are not grouped:UNDEFINED
+ungrouped-imports:49:4:49:26::Imports from package os are not grouped:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type       |
| --- | ---------- |
| ✓   | :bug: Bug fix |

## Description

> **Stacked on #11294.** Its commit shows up here until it lands, so review the
> last two commits only. I will rebase down once #11294 is merged.

Split out of #11209, where the change was reviewed: it is about version guards,
not about PEP 810.

`is_sys_guard` matched the literal `sys.version_info` attribute access and
nothing else, so an import guarded by `from sys import version_info` still
raised `import-error` when the guarded module was missing. The same blind spot
let `no-name-in-module`, `ungrouped-imports` and `deprecated-class` fire inside
such a guard.

It asks `is_module_member(value, "sys.version_info", "sys.hexversion")` (#11294)
instead of matching a spelling, so all of these are recognized:

| Guard | Why it used to be missed |
| --- | --- |
| `if version_info >= (3, 9):` | `from sys import version_info` binds a plain `Name` |
| `if vi[:2] >= (3, 9):` | same, through an alias and a slice |
| `if system.version_info >= (3, 9):` | `import sys as system` |
| `if sys.version_info.major >= 3:` | the compared value is the `major` attribute |
| `if (3, 9) <= sys.version_info:` | only the left-hand operand was looked at |
| `if hexversion >= 0x030900F0:` | `sys.hexversion` was not considered at all |
| `if sys.version_info >= (3, 9) and sys.platform == "linux":` | the test is a `BoolOp` |
| `if not sys.version_info >= (3, 9):` | the test is a `UnaryOp` |
| `if PY2:` | `six.PY2` was matched by spelling only |

Lookalikes stay out: `os.version_info`, `sys.some_other_function`,
`os` aliased to `compat` so that `compat.PY2` looks like six's flag, and
`from django import VERSION as version_info` — another project's version, spelled
exactly like the interpreter's.

Resolving cuts the other way too, and fixes a **false negative** `main` has today:

```python
class sys:
    version_info = (3, 12)

if sys.version_info >= (3, 9):
    import missing_module   # main says nothing, this PR reports import-error
```

A local class named `sys` reads exactly like the module, and matching the spelling
could not tell them apart. `is_module_member` resolves the module through `lookup`
rather than through inference, which is what tells them apart — and which also
keeps working when the `import sys` is itself inside a guarded block (`try`, an
`if`, or a function body). That reasoning is reviewed in #11294.

@DanielNoord asked on #11209 whether the thorough version could just replace the
cheap one everywhere instead of sitting beside it as a second
`zealous_is_sys_guard` helper. It does. Every call site only reaches it once the
import sits directly inside an `if`, which is rare enough that correctness beats
saving a `lookup`.

### Groundwork for `useless-version-check`

#11274 needs `REVERSED_COMPS` in `pylint.checkers.utils`, which is not about its
own message, so that move lands here: a core checker cannot import from an
extension. `==` and `!=` are added, which `comparison_placement` used to leave to
the `.get()` default, so the keys are exactly the comparison operators and
`COMPARISON_OPERATORS` is derived from them.

The other thing #11274 needs is `is_module_member`, which #11294 adds. A checker
that *reads* a version comparison rather than merely recognizing one calls
`is_module_member(node, "sys.version_info")` and gets every spelling above for free.

### Testing

Each of the four call sites gets functional coverage, and I checked every new case
against `main` in a worktree to be sure it is actually load-bearing — `main`
emits the false positive, this branch does not:

| Message | Test file | False positives on `main` |
| --- | --- | --- |
| `import-error` | `tests/functional/i/import_error.py` | 5, plus the missing `import-error` under the shadowed `sys` |
| `no-name-in-module` | `tests/functional/n/no/no_name_in_module.py` | 5, covering both `visit_import` and `visit_importfrom` |
| `ungrouped-imports` | `tests/functional/u/ungrouped_imports.py` | 3 |
| `deprecated-class` | `tests/functional/d/deprecated/deprecated_class_sys_guard.py` | 3 |

Each file also keeps a negative control, so the widening is pinned from both
sides. `no-name-in-module` had no version-guard coverage at all before, and
`ungrouped-imports` had none either — only a `TYPE_CHECKING` case.

`tests/` and `doc/test_messages_documentation.py` are green on 3.13, at each
commit.

To gauge the risk of the widening, I parsed the primer checkouts (all but
cpython, whose scan ran out of memory) looking for `if` statements that directly
contain an import — the only ones any call site can reach. Of the 1745 found,
the verdict changes for none, so no primer diff is expected.

Refs #11209
Refs #7803
