### PR TITLE
Add a generic ``is_module_member`` function in ``pylint.checkers.utils``

### DIFF
--- a/doc/whatsnew/fragments/11294.internal
+++ b/doc/whatsnew/fragments/11294.internal
@@ -1,0 +1,5 @@
+New function ``pylint.checkers.utils.is_module_member`` permits checking whether a
+node is a member of a module, through the various import syntaxes and aliases. The
+``typing`` checks that each rolled their own version of that question now share it.
+
+Refs #11294

--- a/doc/whatsnew/fragments/11294.other
+++ b/doc/whatsnew/fragments/11294.other
@@ -1,0 +1,6 @@
+``pylint.checkers.utils.is_typing_member`` is deprecated: it is
+``is_module_member(node, "typing.<name>")`` with the module filled in. Call
+``is_module_member`` directly instead. ``is_typing_member`` will be removed in
+pylint 5.0.
+
+Refs #11294

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -13,6 +13,7 @@ import itertools
 import numbers
 import re
 import string
+import warnings
 from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache, partial
 from re import Match
@@ -904,42 +905,11 @@ def uninferable_final_decorators(
     """
     decorators = []
     for decorator in getattr(node, "nodes", []):
-        import_nodes: tuple[nodes.Import | nodes.ImportFrom] | None = None
-
-        # Get the `Import` node. The decorator is of the form: @module.name
-        if isinstance(decorator, nodes.Attribute):
-            inferred = safe_infer(decorator.expr)
-            if isinstance(inferred, nodes.Module) and inferred.qname() == "typing":
-                _, import_nodes = decorator.expr.lookup(decorator.expr.name)
-
-        # Get the `ImportFrom` node. The decorator is of the form: @name
-        elif isinstance(decorator, nodes.Name):
-            _, import_nodes = decorator.lookup(decorator.name)
-
-        # The `final` decorator is expected to be found in the
-        # import_nodes. Continue if we don't find any `Import` or `ImportFrom`
-        # nodes for this decorator.
-        if not import_nodes:
+        if not is_module_member(decorator, "typing.final"):
             continue
-        import_node = import_nodes[0]
-
-        if not isinstance(import_node, (nodes.Import, nodes.ImportFrom)):
-            continue
-
-        import_names = dict(import_node.names)
-
-        # Check if the import is of the form: `from typing import final`
-        is_from_import = ("final" in import_names) and import_node.modname == "typing"
-
-        # Check if the import is of the form: `import typing`
-        is_import = ("typing" in import_names) and getattr(
-            decorator, "attrname", None
-        ) == "final"
-
-        if is_from_import or is_import:
-            inferred = safe_infer(decorator)
-            if inferred is None or isinstance(inferred, util.UninferableBase):
-                decorators.append(decorator)
+        inferred = safe_infer(decorator)
+        if inferred is None or isinstance(inferred, util.UninferableBase):
+            decorators.append(decorator)
     return decorators
 
 
@@ -1843,6 +1813,84 @@ def get_import_name(importnode: ImportNode, modname: str | None) -> str | None:
     return modname
 
 
+@lru_cache(maxsize=512)
+def _split_qnames(qnames: tuple[str, ...]) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Group qualified names by the module that owns them.
+
+    Grouping is not an optimization: resolving a module is a scope lookup, so
+    members sharing a module have to be asked for together to pay for it once.
+    Cached because a call site passes the same literal names every time.
+    """
+    grouped: dict[str, tuple[str, ...]] = {}
+    for qname in qnames:
+        modname, _, member = qname.rpartition(".")
+        if not modname:
+            raise ValueError(
+                f"{qname!r} is not a qualified name, expected 'module.member'"
+            )
+        grouped[modname] = (*grouped.get(modname, ()), member)
+    return tuple(grouped.items())
+
+
+def is_module_member(node: nodes.NodeNG, *qnames: str) -> bool:
+    """Return True if the node refers to one of the given qualified names.
+
+    However it is spelled: ``module.member`` and the name bound by
+    ``from module import member`` both count, each of them possibly aliased. The
+    module is identified by the import that binds it rather than by the name it
+    is spelled with, so a class or a variable named after it does not pass for
+    it.
+    """
+    if isinstance(node, nodes.Attribute):
+        return any(
+            node.attrname in members and _resolves_to_module(node.expr, modname)
+            for modname, members in _split_qnames(qnames)
+        )
+    if isinstance(node, nodes.Name):
+        return any(
+            _binds_module_member(node, modname, members)
+            for modname, members in _split_qnames(qnames)
+        )
+    return False
+
+
+def _resolves_to_module(expr: nodes.NodeNG, modname: str) -> bool:
+    if isinstance(expr, nodes.Name):
+        # Answer from the binding rather than from inference, which comes up
+        # empty when the ``import`` itself sits inside a guarded block. It also
+        # rejects a class or a variable named after the module, which the
+        # spelling alone cannot tell the module apart from.
+        _, assignments = expr.lookup(expr.name)
+        return any(
+            isinstance(assignment, nodes.Import)
+            and any(
+                real == modname and (alias or real) == expr.name
+                for real, alias in assignment.names
+            )
+            for assignment in assignments
+        )
+    match safe_infer(expr):
+        case nodes.Module(name=name) if name == modname:
+            return True
+    return False
+
+
+def _binds_module_member(
+    name: nodes.Name, modname: str, members: tuple[str, ...]
+) -> bool:
+    """Whether the name is bound by a ``from modname import <member>``."""
+    _, assignments = name.lookup(name.name)
+    return any(
+        isinstance(assignment, nodes.ImportFrom)
+        and assignment.modname == modname
+        and any(
+            real in members and (alias or real) == name.name
+            for real, alias in assignment.names
+        )
+        for assignment in assignments
+    )
+
+
 def is_sys_guard(node: nodes.If) -> bool:
     """Return True if IF stmt is a sys.version_info guard.
 
@@ -1993,52 +2041,36 @@ def in_type_checking_block(node: nodes.NodeNG) -> bool:
     for ancestor in node.node_ancestors():
         if not isinstance(ancestor, nodes.If):
             continue
-        if isinstance(ancestor.test, nodes.Name):
-            if ancestor.test.name != "TYPE_CHECKING":
-                continue
-            lookup_result = ancestor.test.lookup(ancestor.test.name)[1]
-            if not lookup_result:
-                return False
-            maybe_import_from = lookup_result[0]
-            if (
-                isinstance(maybe_import_from, nodes.ImportFrom)
-                and maybe_import_from.modname == "typing"
-            ):
-                return True
+        if is_module_member(ancestor.test, "typing.TYPE_CHECKING"):
+            return True
+        # A flag standing in for typing's, e.g. `TYPE_CHECKING = False` in the
+        # module itself, which is only ever true for a type checker.
+        if (
+            isinstance(ancestor.test, nodes.Name)
+            and ancestor.test.name == "TYPE_CHECKING"
+        ):
             match safe_infer(ancestor.test):
                 case nodes.Const(value=False):
                     return True
-        elif isinstance(ancestor.test, nodes.Attribute):
-            if ancestor.test.attrname != "TYPE_CHECKING":
-                continue
-            match safe_infer(ancestor.test.expr):
-                case nodes.Module(name="typing"):
-                    return True
 
     return False
 
 
+# TODO: 5.0: Remove is_typing_member, deprecated in favor of is_module_member.
 def is_typing_member(node: nodes.NodeNG, names_to_check: tuple[str, ...]) -> bool:
     """Check if `node` is a member of the `typing` module and has one of the names from
     `names_to_check`.
-    """
-    match node:
-        case nodes.Name():
-            try:
-                import_from = node.lookup(node.name)[1][0]
-            except IndexError:
-                return False
 
-            match import_from:
-                case nodes.ImportFrom(modname="typing"):
-                    return import_from.real_name(node.name) in names_to_check
-            return False
-        case nodes.Attribute():
-            match safe_infer(node.expr):
-                case nodes.Module(name="typing"):
-                    return node.attrname in names_to_check
-            return False
-    return False
+    Deprecated: call ``is_module_member(node, "typing.<name>")`` instead.
+    """
+    warnings.warn(
+        "is_typing_member has been deprecated. Use "
+        "is_module_member(node, 'typing.<name>') instead. "
+        "It will be removed in pylint 5.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return is_module_member(node, *(f"typing.{name}" for name in names_to_check))
 
 
 @lru_cache

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3540,8 +3540,8 @@ class VariablesChecker(BaseChecker):
             parent = parent.parent
         if isinstance(parent, nodes.Subscript):
             origin = next(parent.get_children(), None)
-            if origin is not None and utils.is_typing_member(
-                origin, ("Annotated", "Literal")
+            if origin is not None and utils.is_module_member(
+                origin, "typing.Annotated", "typing.Literal"
             ):
                 return
 

--- a/tests/checkers/unittest_utils.py
+++ b/tests/checkers/unittest_utils.py
@@ -344,6 +344,185 @@ def test_get_node_last_lineno_combined() -> None:
     assert utils.get_node_last_lineno(node) == 11
 
 
+def test_is_module_member() -> None:
+    """Only the asked-for member, however the module is spelled."""
+    code = astroid.extract_node("""
+    import os
+    import sys
+    import sys as system
+    from sys import version_info
+    from sys import version_info as vi
+    from django import VERSION as version_info_of_a_library
+
+    sys.version_info  #@
+    system.version_info  #@
+    version_info  #@
+    vi  #@
+
+    sys.version_info[0]  #@
+    sys.version_info.major  #@
+    sys.hexversion  #@
+    os.version_info  #@
+    version_info_of_a_library  #@
+    """)
+    assert isinstance(code, list) and len(code) == 9
+
+    for spelling in code[:4]:
+        assert (
+            utils.is_module_member(spelling, "sys.version_info") is True
+        ), spelling.as_string()
+
+    for lookalike in code[4:]:
+        assert (
+            utils.is_module_member(lookalike, "sys.version_info") is False
+        ), lookalike.as_string()
+
+
+def test_is_module_member_several_members() -> None:
+    """Any of the members asked for counts, and nothing else does."""
+    code = astroid.extract_node("""
+    import sys
+    from sys import hexversion
+
+    sys.version_info  #@
+    sys.hexversion  #@
+    hexversion  #@
+
+    sys.maxsize  #@
+    """)
+    assert isinstance(code, list) and len(code) == 4
+
+    for member in code[:3]:
+        assert (
+            utils.is_module_member(member, "sys.version_info", "sys.hexversion") is True
+        ), member.as_string()
+
+    assert (
+        utils.is_module_member(code[3], "sys.version_info", "sys.hexversion") is False
+    ), code[3].as_string()
+
+
+def test_uninferable_final_decorators() -> None:
+    """A `typing.final` decorator is reported only when it cannot be inferred.
+
+    `unsupported_version` reaches for this only after `safe_infer` came up empty,
+    which needs the name to have more than one possible value.
+    """
+    module = astroid.parse("""
+    from typing import final
+    if unknown_condition:
+        final = something_else
+
+    @final
+    def ambiguous():
+        pass
+
+    @typing.final
+    def not_even_imported():
+        pass
+    """)
+    ambiguous, not_even_imported = module.body[-2], module.body[-1]
+
+    assert utils.uninferable_final_decorators(ambiguous.decorators) == [
+        ambiguous.decorators.nodes[0]
+    ]
+    assert not utils.uninferable_final_decorators(not_even_imported.decorators)
+
+
+def test_is_module_member_needs_a_qualified_name() -> None:
+    """A bare member name would silently match nothing, so it is refused.
+
+    ``"version_info".rpartition(".")`` leaves an empty module name, which no
+    import can bind, so the mistake has to be loud rather than a missed message.
+    """
+    code = astroid.extract_node("""
+    import sys
+
+    sys.version_info  #@
+    """)
+
+    with pytest.raises(ValueError, match="is not a qualified name"):
+        utils.is_module_member(code, "version_info")
+
+
+def test_is_module_member_aliases() -> None:
+    """An alias is followed, and never taken at face value.
+
+    What the import brings in and what it binds the result to are two different
+    names, so a module or a member wearing the other one's name is not it.
+    """
+    code = astroid.extract_node("""
+    import sys as system
+    from sys import version_info as vi
+
+    import os as sys
+    import sys as version_info
+    from sys import maxsize as version_info
+    from os import sep as version_info
+
+    system.version_info  #@
+    vi  #@
+
+    sys.version_info  #@
+    version_info  #@
+    """)
+    assert isinstance(code, list) and len(code) == 4
+
+    # `import sys as system`, then `from sys import version_info as vi`.
+    assert utils.is_module_member(code[0], "sys.version_info") is True
+    assert utils.is_module_member(code[1], "sys.version_info") is True
+
+    # `sys` is really `os` here, and `version_info` is really `sys.maxsize`.
+    assert utils.is_module_member(code[2], "sys.version_info") is False
+    assert utils.is_module_member(code[3], "sys.version_info") is False
+
+
+def test_is_module_member_dotted_module() -> None:
+    """A module reached through a dotted name is resolved by inference.
+
+    ``os.path`` is deliberately not the example: it infers to ``posixpath`` or
+    to ``ntpath`` depending on the platform, so it is not its own module.
+    """
+    code = astroid.extract_node("""
+    import xml.etree.ElementTree
+
+    xml.etree.ElementTree.parse  #@
+    xml.etree.ElementTree.does_not_matter  #@
+    xml.etree.parse  #@
+    """)
+    assert isinstance(code, list) and len(code) == 3
+
+    assert utils.is_module_member(code[0], "xml.etree.ElementTree.parse") is True
+    # The right module, a member it does not have.
+    assert utils.is_module_member(code[1], "xml.etree.ElementTree.parse") is False
+    # The right member name, hanging off a different module.
+    assert utils.is_module_member(code[2], "xml.etree.ElementTree.parse") is False
+
+
+def test_is_module_member_shadowed_module() -> None:
+    """A class named after a module reads like it and is not it."""
+    code = astroid.extract_node("""
+    class sys:
+        version_info = (3, 12)
+
+    sys.version_info  #@
+    """)
+    assert utils.is_module_member(code, "sys.version_info") is False
+
+
+def test_is_module_member_import_in_a_block() -> None:
+    """The import binding the module need not be at module level."""
+    code = astroid.extract_node("""
+    try:
+        import sys
+    except ImportError:
+        sys = None
+
+    sys.version_info  #@
+    """)
+    assert utils.is_module_member(code, "sys.version_info") is True
+
+
 def test_if_sys_guard() -> None:
     code = astroid.extract_node("""
     import sys
@@ -446,7 +625,7 @@ def test_is_empty_literal() -> None:
     assert not utils.is_empty_str_literal(not_empty_string_node.value)
 
 
-def test_is_typing_member() -> None:
+def test_is_module_member_typing() -> None:
     code = astroid.extract_node("""
     from typing import Literal as Lit, Set as Literal
     import typing as t
@@ -456,16 +635,28 @@ def test_is_typing_member() -> None:
     t.Literal #@
     """)
 
-    assert not utils.is_typing_member(code[0], ("Literal",))
-    assert utils.is_typing_member(code[1], ("Literal",))
-    assert utils.is_typing_member(code[2], ("Literal",))
+    assert not utils.is_module_member(code[0], "typing.Literal")
+    assert utils.is_module_member(code[1], "typing.Literal")
+    assert utils.is_module_member(code[2], "typing.Literal")
 
     code = astroid.extract_node("""
     Literal #@
     typing.Literal #@
     """)
-    assert not utils.is_typing_member(code[0], ("Literal",))
-    assert not utils.is_typing_member(code[1], ("Literal",))
+    assert not utils.is_module_member(code[0], "typing.Literal")
+    assert not utils.is_module_member(code[1], "typing.Literal")
+
+
+def test_is_typing_member_is_deprecated() -> None:
+    """It still answers, but is_module_member is the one to call now."""
+    code = astroid.extract_node("""
+    from typing import Literal
+
+    Literal #@
+    """)
+
+    with pytest.warns(DeprecationWarning, match="is_typing_member has been deprecated"):
+        assert utils.is_typing_member(code, ("Literal",)) is True
 
 
 def test_is_reassigned_after_current_requires_isinstance_check() -> None:


### PR DESCRIPTION
## Type of Changes

|     | Type       |
| --- | ---------- |
| ✓   | :arrows_counterclockwise: Refactor |

## Description

Groundwork split out of #11293, which needs the same question answered for `sys`
and reads much smaller once this lands.

I tried some design first ``(node, modname, *members: str)`` and ``(node, modname, members: tuple[str, ...])``, but I think *qnames is the easier to understand. 

Refs #11293
