### PR TITLE
Do not count trailing tool pragmas toward line-too-long

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -281,6 +281,7 @@ pylintrc
 pyproject
 pypy
 pyreverse
+pyright
 pytest
 qname
 rawcheckers

--- a/doc/data/messages/l/line-too-long/details.rst
+++ b/doc/data/messages/l/line-too-long/details.rst
@@ -1,4 +1,4 @@
-Pragma controls such as ``# pylint: disable=all`` are not counted toward line length for the purposes of this message.
+Pragma controls such as ``# pylint: disable=all`` are not counted toward line length for the purposes of this message. The same holds for trailing pragmas understood by other common tooling, namely ``# type: ignore``, ``# noqa`` and ``# pragma: no cover``.
 
 If you attempt to disable this message via ``# pylint: disable=line-too-long`` in a module with no code, you may receive a message for ``useless-suppression``. This is a false positive of ``useless-suppression`` we can't easily fix.
 

--- a/doc/data/messages/l/line-too-long/details.rst
+++ b/doc/data/messages/l/line-too-long/details.rst
@@ -1,4 +1,4 @@
-Pragma controls such as ``# pylint: disable=all`` are not counted toward line length for the purposes of this message. The same holds for trailing pragmas understood by other common tooling, namely ``# type: ignore``, ``# pyright: ignore``, ``# noqa``, ``# pragma: no cover`` and ``# pragma: no branch``.
+Pragma controls from pylint such as ``# pylint: disable=all`` or other tools like ``pragma: no cover`` are not counted toward line length for the purposes of this message.
 
 If you attempt to disable this message via ``# pylint: disable=line-too-long`` in a module with no code, you may receive a message for ``useless-suppression``. This is a false positive of ``useless-suppression`` we can't easily fix.
 

--- a/doc/data/messages/l/line-too-long/details.rst
+++ b/doc/data/messages/l/line-too-long/details.rst
@@ -1,4 +1,4 @@
-Pragma controls such as ``# pylint: disable=all`` are not counted toward line length for the purposes of this message. The same holds for trailing pragmas understood by other common tooling, namely ``# type: ignore``, ``# noqa`` and ``# pragma: no cover``.
+Pragma controls such as ``# pylint: disable=all`` are not counted toward line length for the purposes of this message. The same holds for trailing pragmas understood by other common tooling, namely ``# type: ignore``, ``# pyright: ignore``, ``# noqa``, ``# pragma: no cover`` and ``# pragma: no branch``.
 
 If you attempt to disable this message via ``# pylint: disable=line-too-long`` in a module with no code, you may receive a message for ``useless-suppression``. This is a false positive of ``useless-suppression`` we can't easily fix.
 

--- a/doc/whatsnew/fragments/10172.feature
+++ b/doc/whatsnew/fragments/10172.feature
@@ -1,7 +1,7 @@
 Trailing pragmas understood by other common tooling (``# type: ignore``,
-``# noqa``, ``# pragma: no cover``) are no longer counted toward the line
-length, so a line is not flagged as ``line-too-long`` solely because of such a
-pragma. This mirrors the existing behaviour for Pylint's own ``# pylint:``
-pragmas.
+``# pyright: ignore``, ``# noqa``, ``# pragma: no cover`` and
+``# pragma: no branch``) are no longer counted toward the line length, so a line
+is not flagged as ``line-too-long`` solely because of such a pragma. This mirrors
+the existing behaviour for Pylint's own ``# pylint:`` pragmas.
 
 Closes #10172

--- a/doc/whatsnew/fragments/10172.feature
+++ b/doc/whatsnew/fragments/10172.feature
@@ -1,0 +1,7 @@
+Trailing pragmas understood by other common tooling (``# type: ignore``,
+``# noqa``, ``# pragma: no cover``) are no longer counted toward the line
+length, so a line is not flagged as ``line-too-long`` solely because of such a
+pragma. This mirrors the existing behaviour for Pylint's own ``# pylint:``
+pragmas.
+
+Closes #10172

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -13,6 +13,7 @@ Some parts of the process_token method is based from The Tab Nanny std module.
 
 from __future__ import annotations
 
+import re
 import tokenize
 from functools import reduce
 from re import Match
@@ -30,6 +31,19 @@ from pylint.utils.pragma_parser import OPTION_PO, PragmaParserError, parse_pragm
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
+
+# Trailing pragma comments understood by other common Python tooling. Just like
+# Pylint's own disable pragmas, these are not counted toward the line length so
+# that a line is not flagged as ``line-too-long`` solely because of such a
+# pragma. See https://github.com/pylint-dev/pylint/issues/10172.
+_IGNORED_PRAGMA_RGX = re.compile(
+    r"[ \t]*#[ \t]*"
+    r"(?:"
+    r"type:[ \t]*ignore(?:\[[^\]\n]*\])?"  # mypy / pyright
+    r"|noqa\b(?::[ \t\w,]*)?"  # flake8 / ruff
+    r"|pragma:[ \t]*no[ \t]?cover"  # coverage.py
+    r")"
+)
 
 _KEYWORD_TOKENS = {
     "assert",
@@ -716,6 +730,11 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                 checker_off = True
             # The 'pylint: disable whatever' should not be taken into account for line length count
             lines = self.remove_pylint_option_from_lines(mobj)
+
+        # Trailing pragmas from other tooling (``# type: ignore``, ``# noqa``,
+        # ``# pragma: no cover``, ...) should not be taken into account for the
+        # line length count either.
+        lines = _IGNORED_PRAGMA_RGX.sub("", lines)
 
         ignore_pattern_in_long_lines = self.linter.config.ignore_pattern_in_long_lines
         if ignore_pattern_in_long_lines:

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -32,10 +32,7 @@ if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
 
-# Trailing pragma comments understood by other common Python tooling. Just like
-# Pylint's own disable pragmas, these are not counted toward the line length so
-# that a line is not flagged as ``line-too-long`` solely because of such a
-# pragma. See https://github.com/pylint-dev/pylint/issues/10172.
+# Trailing pragmas from other tooling, discounted from line length like Pylint's own (see #10172).
 _IGNORED_PRAGMA_RGX = re.compile(
     r"[ \t]*#[ \t]*"
     r"(?:"

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -39,9 +39,10 @@ if TYPE_CHECKING:
 _IGNORED_PRAGMA_RGX = re.compile(
     r"[ \t]*#[ \t]*"
     r"(?:"
-    r"type:[ \t]*ignore(?:\[[^\]\n]*\])?"  # mypy / pyright
+    r"type:[ \t]*ignore(?:\[[^\]\n]*\])?"  # mypy
+    r"|pyright:[ \t]*ignore(?:\[[^\]\n]*\])?"  # pyright
     r"|noqa\b(?::[ \t\w,]*)?"  # flake8 / ruff
-    r"|pragma:[ \t]*no[ \t]?cover"  # coverage.py
+    r"|pragma:[ \t]*no[ \t]?(?:cover|branch)"  # coverage.py
     r")"
 )
 

--- a/tests/checkers/unittest_format.py
+++ b/tests/checkers/unittest_format.py
@@ -215,3 +215,44 @@ class TestIgnorePatternInLongLines(CheckerTestCase):
         for msg, code in cases:
             with self.assertAddsMessages(msg):
                 self.checker.process_tokens(_tokenize_str(code + "\n"))
+
+
+class TestIgnoredToolPragmas(CheckerTestCase):
+    CHECKER_CLASS = FormatChecker
+
+    def test_trailing_tool_pragma_not_counted(self) -> None:
+        """Trailing pragmas from other tools do not count toward the length."""
+        self.checker.linter.config.max_line_length = 20
+        self.checker.linter.config.ignore_pattern_in_long_lines = None
+        cases = [
+            "x = '12345'  # type: ignore",
+            "x = '12345'  # type: ignore[assignment]",
+            "x = '12345'  # noqa",
+            "x = '12345'  # noqa: E501, RUF001",
+            "x = '12345'  # pragma: no cover",
+            "x = '123'  # noqa: E501  # pragma: no cover",
+        ]
+        with self.assertNoMessages():
+            for code in cases:
+                self.checker.process_tokens(_tokenize_str(code + "\n"))
+
+    def test_trailing_tool_pragma_still_catches_too_long_code(self) -> None:
+        """Code that is too long on its own is still reported, discounting the
+        pragma when computing the reported length.
+        """
+        self.checker.linter.config.max_line_length = 20
+        self.checker.linter.config.ignore_pattern_in_long_lines = None
+        cases = [
+            (
+                MessageTest("line-too-long", line=1, args=(26, 20)),
+                "x = '12345678901234567890'  # noqa",
+            ),
+            (
+                # A word that only looks like a pragma is left untouched.
+                MessageTest("line-too-long", line=1, args=(36, 20)),
+                "x = '12345'  # noqal is not a pragma",
+            ),
+        ]
+        for msg, code in cases:
+            with self.assertAddsMessages(msg):
+                self.checker.process_tokens(_tokenize_str(code + "\n"))

--- a/tests/checkers/unittest_format.py
+++ b/tests/checkers/unittest_format.py
@@ -227,9 +227,12 @@ class TestIgnoredToolPragmas(CheckerTestCase):
         cases = [
             "x = '12345'  # type: ignore",
             "x = '12345'  # type: ignore[assignment]",
+            "x = '12345'  # pyright: ignore",
+            "x = '12345'  # pyright: ignore[reportGeneralTypeIssues]",
             "x = '12345'  # noqa",
             "x = '12345'  # noqa: E501, RUF001",
             "x = '12345'  # pragma: no cover",
+            "x = '12345'  # pragma: no branch",
             "x = '123'  # noqa: E501  # pragma: no cover",
         ]
         with self.assertNoMessages():

--- a/tests/functional/l/line/line_too_long_ignored_pragmas.py
+++ b/tests/functional/l/line/line_too_long_ignored_pragmas.py
@@ -1,0 +1,24 @@
+"""Trailing tool pragmas must not count toward line length.
+
+See issue #10172 for the rationale behind this behaviour.
+"""
+# pylint: disable=invalid-name
+
+# The lines below only exceed the 60 character limit because
+# of a trailing tool pragma, so no message is expected here.
+a1 = "a compact but readable pragma sample"  # type: ignore
+a2 = "a compact but readable pragma sample"  # type: ignore[assignment]
+a3 = "a compact but readable pragma sample"  # noqa
+a4 = "a compact but readable pragma sample"  # noqa: E501, RUF001
+a5 = "a compact but readable pragma sample"  # pragma: no cover
+a6 = "a compact pragma sample"  # noqa: E501  # pragma: no cover
+
+# The code is still too long once the pragma is discounted,
+# so the message is still emitted, using the length of the
+# code without the pragma.
+# +1: [line-too-long]
+b1 = "this value is deliberately made long enough to exceed the limit"  # noqa
+
+# A word that only looks like a pragma is not stripped.
+# +1: [line-too-long]
+c1 = "this value is long enough to trip the limit on its own here"  # noqario

--- a/tests/functional/l/line/line_too_long_ignored_pragmas.py
+++ b/tests/functional/l/line/line_too_long_ignored_pragmas.py
@@ -8,10 +8,13 @@ See issue #10172 for the rationale behind this behaviour.
 # of a trailing tool pragma, so no message is expected here.
 a1 = "a compact but readable pragma sample"  # type: ignore
 a2 = "a compact but readable pragma sample"  # type: ignore[assignment]
-a3 = "a compact but readable pragma sample"  # noqa
-a4 = "a compact but readable pragma sample"  # noqa: E501, RUF001
-a5 = "a compact but readable pragma sample"  # pragma: no cover
-a6 = "a compact pragma sample"  # noqa: E501  # pragma: no cover
+a3 = "a compact but readable pragma sample"  # pyright: ignore
+a4 = "a compact but readable pragma sample"  # pyright: ignore[reportArgumentType]
+a5 = "a compact but readable pragma sample"  # noqa
+a6 = "a compact but readable pragma sample"  # noqa: E501, RUF001
+a7 = "a compact but readable pragma sample"  # pragma: no cover
+a8 = "a compact but readable pragma sample"  # pragma: no branch
+a9 = "a compact pragma sample"  # noqa: E501  # pragma: no cover
 
 # The code is still too long once the pragma is discounted,
 # so the message is still emitted, using the length of the

--- a/tests/functional/l/line/line_too_long_ignored_pragmas.rc
+++ b/tests/functional/l/line/line_too_long_ignored_pragmas.rc
@@ -1,0 +1,2 @@
+[Format]
+max-line-length=60

--- a/tests/functional/l/line/line_too_long_ignored_pragmas.txt
+++ b/tests/functional/l/line/line_too_long_ignored_pragmas.txt
@@ -1,2 +1,2 @@
-line-too-long:20:0:None:None::Line too long (70/60):UNDEFINED
-line-too-long:24:0:None:None::Line too long (77/60):UNDEFINED
+line-too-long:23:0:None:None::Line too long (70/60):UNDEFINED
+line-too-long:27:0:None:None::Line too long (77/60):UNDEFINED

--- a/tests/functional/l/line/line_too_long_ignored_pragmas.txt
+++ b/tests/functional/l/line/line_too_long_ignored_pragmas.txt
@@ -1,0 +1,2 @@
+line-too-long:20:0:None:None::Line too long (70/60):UNDEFINED
+line-too-long:24:0:None:None::Line too long (77/60):UNDEFINED


### PR DESCRIPTION
Extend the existing "ignore trailing pragmas when measuring line length" behaviour so that pragmas belonging to other common tooling no longer trip `line-too-long` on their own.

Today Pylint already discounts its own `# pylint: ...` pragmas when checking `line-too-long`, but a line pushed over the limit purely by a `# type: ignore`, `# noqa`, or `# pragma: no cover` still gets flagged, which forces people to add a `# pylint: disable=line-too-long` on top of the pragma they already have. This applies the same, unsurprising treatment to those three families of trailing pragmas.

The implementation mirrors what's already there: a small module-level regex strips a recognised trailing pragma from the text before the per-line length is computed, right next to where `remove_pylint_option_from_lines` and `ignore-pattern-in-long-lines` already run. It is deliberately conservative:

- Only the recognised pragma token is removed, so a genuine trailing comment before the pragma still counts, and code that is too long on its own is still reported (with the length measured without the pragma, matching the existing `ignore-pattern-in-long-lines` behaviour).
- Word-boundary anchoring means look-alikes such as `# noqario` are left untouched.
- Stacked pragmas (`# noqa: E501  # pragma: no cover`) are all handled.

Closes #10172 (and supersedes the narrower #8378).

### Testing

- Added `tests/functional/l/line/line_too_long_ignored_pragmas.py` (with a matching `.rc` setting a small `max-line-length`) covering the clean cases, the "still too long after discounting the pragma" case, and a pragma look-alike that must still be reported.
- Added `TestIgnoredToolPragmas` to `tests/checkers/unittest_format.py` for the same behaviour at the unit level.
- `tests/checkers/unittest_format.py` and the `line_too_long*` functional tests pass; `pylint pylint/checkers/format.py` stays at 10/10. (The pre-existing failures in the full functional run on my machine are unrelated — they reproduce identically on an unmodified checkout and are down to the local astroid/Python 3.13 versions.)

I made the behaviour default-on to match how `# pylint:` pragmas are already handled, but happy to gate it behind an option instead if you'd prefer.