### PR TITLE
Ignore trailing tool pragmas in line-too-long

### DIFF
--- a/doc/whatsnew/fragments/10172.false_positive
+++ b/doc/whatsnew/fragments/10172.false_positive
@@ -1,0 +1,6 @@
+``line-too-long`` no longer counts a trailing tooling pragma towards the line
+length. Like pylint's own ``# pylint: ...`` pragmas, comments such as
+``# type: ignore``, ``# pyright: ignore``, ``# noqa`` and ``# pragma: no cover``
+are now ignored when they are the only thing pushing a line past the limit.
+
+Closes #10172

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -55,7 +55,7 @@ _JUNK_TOKENS = {tokenize.COMMENT, tokenize.NL}
 # ruff, coverage). Like pylint's own inline pragmas, these should not count
 # towards ``line-too-long`` when they are the only thing pushing a line past the
 # limit. Matched on raw source text and anchored to the end of the line, so a
-# chain such as "# noqa: E501  # pragma: no cover" is handled too.
+# chain such as "# pragma: no cover" is handled too.
 _TRAILING_TOOL_PRAGMA_RGX = re.compile(
     r"(?:\s*#\s*(?:"
     r"type:\s*ignore(?:\[[^\]]*\])?"

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -13,6 +13,7 @@ Some parts of the process_token method is based from The Tab Nanny std module.
 
 from __future__ import annotations
 
+import re
 import tokenize
 from functools import reduce
 from re import Match
@@ -49,6 +50,20 @@ _KEYWORD_TOKENS = {
     ":=",
 }
 _JUNK_TOKENS = {tokenize.COMMENT, tokenize.NL}
+
+# Trailing pragma comments understood by other tooling (type checkers, flake8 /
+# ruff, coverage). Like pylint's own inline pragmas, these should not count
+# towards ``line-too-long`` when they are the only thing pushing a line past the
+# limit. Matched on raw source text and anchored to the end of the line, so a
+# chain such as "# noqa: E501  # pragma: no cover" is handled too.
+_TRAILING_TOOL_PRAGMA_RGX = re.compile(
+    r"(?:\s*#\s*(?:"
+    r"type:\s*ignore(?:\[[^\]]*\])?"
+    r"|pyright:\s*ignore(?:\[[^\]]*\])?"
+    r"|noqa(?::\s*[A-Z]+[0-9]+(?:\s*,\s*[A-Z]+[0-9]+)*)?"
+    r"|pragma:\s*no\s+(?:cover|branch)"
+    r"))+\s*$"
+)
 
 
 MSGS: dict[str, MessageDefinitionTuple] = {
@@ -613,6 +628,10 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
         max_chars = self.linter.config.max_line_length
         ignore_long_line = self.linter.config.ignore_long_lines
         line = line.rstrip()
+        if len(line) > max_chars:
+            # A trailing tooling pragma (``type: ignore``, ``noqa``, ...) should
+            # not, on its own, make a line count as too long.
+            line = _TRAILING_TOOL_PRAGMA_RGX.sub("", line).rstrip()
         if len(line) > max_chars and not ignore_long_line.search(line):
             if checker_off:
                 self.linter.add_ignored_message("line-too-long", i)

--- a/tests/checkers/unittest_format.py
+++ b/tests/checkers/unittest_format.py
@@ -215,3 +215,43 @@ class TestIgnorePatternInLongLines(CheckerTestCase):
         for msg, code in cases:
             with self.assertAddsMessages(msg):
                 self.checker.process_tokens(_tokenize_str(code + "\n"))
+
+
+class TestTrailingToolPragmaInLongLines(CheckerTestCase):
+    CHECKER_CLASS = FormatChecker
+
+    def test_trailing_tool_pragma_not_counted(self) -> None:
+        self.checker.linter.config.max_line_length = 20
+        cases = [
+            "x = '12345'            # type: ignore",
+            "x = '12345678901234'   # type: ignore[assignment]",
+            "x = '12345678901234'   # pyright: ignore[reportAny]",
+            "x = '12345678901234'   # noqa",
+            "x = '12345678901234'   # noqa: E501, RUF001",
+            "x = '12345678901234'   # pragma: no cover",
+            "x = '12345'  # noqa: E501  # pragma: no cover  # type: ignore",
+        ]
+        with self.assertNoMessages():
+            for code in cases:
+                self.checker.process_tokens(_tokenize_str(code + "\n"))
+
+    def test_trailing_tool_pragma_still_catches_too_long_code(self) -> None:
+        self.checker.linter.config.max_line_length = 20
+        cases = [
+            (
+                MessageTest("line-too-long", line=1, args=(26, 20)),
+                "x = '12345678901234567890'  # type: ignore",
+            ),
+            (
+                MessageTest("line-too-long", line=1, args=(26, 20)),
+                "x = '12345678901234567890'  # noqa: E501",
+            ),
+            (
+                # An unrecognised pragma is left alone and counted as usual.
+                MessageTest("line-too-long", line=1, args=(38, 20)),
+                "x = '12345'            # other: ignore",
+            ),
+        ]
+        for msg, code in cases:
+            with self.assertAddsMessages(msg):
+                self.checker.process_tokens(_tokenize_str(code + "\n"))

--- a/tests/functional/l/line/line_too_long.py
+++ b/tests/functional/l/line/line_too_long.py
@@ -75,3 +75,11 @@ VAR = """A very very long, maybe too much, constant. Just here to trigger messag
 # +1: [line-too-long]
 VAR_BIS = """A very very long, maybe too much, constant. Just here to trigger message emission and check everything is fine and nice"""
 """But it is however too long, isn't it? I don't know what to say more here. I got a lack of imagination, just listening to music..."""#pylint: disable=line-too-long
+
+
+# Trailing tool pragmas (type checkers, flake8/ruff, coverage) should not, on
+# their own, make a line count as too long. See issue #10172.
+GOOD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # type: ignore
+GOOD_BIS = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"  # noqa: E501, RUF001  # pragma: no cover
+# +1: [line-too-long]
+TOO_LONG = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"  # type: ignore

--- a/tests/functional/l/line/line_too_long.txt
+++ b/tests/functional/l/line/line_too_long.txt
@@ -9,3 +9,4 @@ line-too-long:64:0:None:None::Line too long (122/100):UNDEFINED
 line-too-long:71:0:None:None::Line too long (131/100):UNDEFINED
 line-too-long:72:0:None:None::Line too long (135/100):UNDEFINED
 line-too-long:76:0:None:None::Line too long (135/100):UNDEFINED
+line-too-long:85:0:None:None::Line too long (113/100):UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

A line whose only overflow past `max-line-length` is a trailing tooling pragma no longer triggers `line-too-long`.

Pylint already strips its own `# pylint: ...` pragmas out of the text before measuring line length (`remove_pylint_option_from_lines`), so `x = ...  # pylint: disable=invalid-name` isn't penalised for the length of the disable comment. The equivalent comments from other tools don't get that treatment, so a `# type: ignore` required by mypy, a `# noqa: E501` for flake8/ruff, or a `# pragma: no cover` for coverage forces the user to tack on a redundant `# pylint: disable=line-too-long` as well. This is exactly the annoyance described in #10172 (and its predecessor #8378, where the suggested direction was to "alter the string search to look for additional pragma statements").

This PR does that: a single anchored regex recognises a trailing run of the common tooling pragmas (`type: ignore`, `pyright: ignore`, `noqa`, `pragma: no cover` / `no branch`, including chains like `# noqa: E501  # pragma: no cover`) and strips them before the length is measured in `check_line_length`. The strip only runs when a line is already over the limit, so there's no cost on clean lines. A line that is still too long after the pragmas are removed is reported as before, using its pragma-stripped length — the same behaviour the existing `ignore-pattern-in-long-lines` option already has. Unrecognised comments are left untouched.

### Tests

- Added unit tests `TestTrailingToolPragmaInLongLines` in `tests/checkers/unittest_format.py` covering each recognised pragma, chained pragmas, the "still too long even without the pragma" case, and an unrecognised pragma (left alone).
- Extended the `line_too_long` functional test with pragma-only-overflow lines (no message) and an over-limit line carrying a `# type: ignore` (still flagged).
- Added a `false_positive` news fragment.

`tests/checkers/unittest_format.py` and the `line_too_long` functional test pass; `format.py` self-lints at 10/10 and is clean under `black`/`isort`.

Closes #10172
