### PR TITLE
fix(docparams): guard decorated_with_property against non-function nodes (#11287)

### DIFF
--- a/doc/whatsnew/fragments/11287.bugfix
+++ b/doc/whatsnew/fragments/11287.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the ``docparams`` extension (``AttributeError: 'AssignName' object has no attribute 'decorators'``) when a class has non-function attributes sharing the name of a property setter.
+
+Closes #11287

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -804,8 +804,10 @@ def error_of_type(
     return handler.catch(expected_errors)  # type: ignore[no-any-return]
 
 
-def decorated_with_property(node: nodes.FunctionDef) -> bool:
+def decorated_with_property(node: nodes.NodeNG) -> bool:
     """Detect if the given function node is decorated with a property."""
+    if not isinstance(node, (nodes.FunctionDef, nodes.AsyncFunctionDef)):
+        return False
     if not node.decorators:
         return False
     for decorator in node.decorators.nodes:

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -806,7 +806,7 @@ def error_of_type(
 
 def decorated_with_property(node: nodes.NodeNG) -> bool:
     """Detect if the given function node is decorated with a property."""
-    if not isinstance(node, (nodes.FunctionDef, nodes.AsyncFunctionDef)):
+    if not isinstance(node, nodes.FunctionDef):
         return False
     if not node.decorators:
         return False

--- a/tests/extensions/test_check_docs_utils.py
+++ b/tests/extensions/test_check_docs_utils.py
@@ -196,4 +196,3 @@ def test_get_setters_property_with_non_function_attr() -> None:
             raise Exception
     """)
     assert utils.get_setters_property(node) is None
-

--- a/tests/extensions/test_check_docs_utils.py
+++ b/tests/extensions/test_check_docs_utils.py
@@ -183,3 +183,17 @@ def test_possible_exc_types_instance() -> None:
     assert {ancestor.name for node in found_nodes for ancestor in node.ancestors()} >= {
         "Exception"
     }
+
+
+def test_get_setters_property_with_non_function_attr() -> None:
+    """Test get_setters_property when a class attribute sharing property name is not a function (#11287)."""
+    node = astroid.extract_node("""
+    class C:
+        prop = None
+
+        @prop.setter
+        def prop(self, value): #@
+            raise Exception
+    """)
+    assert utils.get_setters_property(node) is None
+


### PR DESCRIPTION
Closes #11287

### Problem
When `docparams` analyzes a class containing an attribute with the same name as a property setter (such as `prop = None` alongside `@prop.setter def prop(...)`), `get_setters_property` fetches all class attributes named `prop`. Passing non-function attributes (`AssignName`) into `utils.decorated_with_property` causes an `AttributeError` because `AssignName` does not define `.decorators`.

### Solution
- Added a type guard in `decorated_with_property` to return `False` when `node` is not a `FunctionDef` or `AsyncFunctionDef`.
- Added a regression test in `tests/extensions/test_check_docs_utils.py`.
- Added changelog fragment `doc/whatsnew/fragments/11287.bugfix`.