### PR TITLE
fix(refactoring): handle non-AssignName targets in use-yield-from (#11286)

### DIFF
--- a/doc/whatsnew/fragments/11286.bugfix
+++ b/doc/whatsnew/fragments/11286.bugfix
@@ -1,0 +1,3 @@
+Fix a crash in the ``use-yield-from`` checker (``AttributeError: 'Subscript' object has no attribute 'name'``) when a loop target is a subscript, attribute, or tuple.
+
+Closes #11286

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1179,7 +1179,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                         body=[_],
                     ) as loop_node
                 ),
-            ) if not isinstance(loop_node, nodes.AsyncFor) and target_name == name:
+            ) if (
+                not isinstance(loop_node, nodes.AsyncFor) and target_name == name
+            ):
                 pass
             case _:
                 # Avoid a false positive if the return value from `yield` is used,

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1173,16 +1173,18 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         match node:
             case nodes.Yield(
                 value=nodes.Name(name=name),
-                parent=nodes.Expr(parent=nodes.For(body=[_]) as loop_node),
-            ) if not isinstance(loop_node, nodes.AsyncFor):
+                parent=nodes.Expr(
+                    parent=nodes.For(
+                        target=nodes.AssignName(name=target_name),
+                        body=[_],
+                    ) as loop_node
+                ),
+            ) if not isinstance(loop_node, nodes.AsyncFor) and target_name == name:
                 pass
             case _:
                 # Avoid a false positive if the return value from `yield` is used,
                 # (such as via Assign, AugAssign, etc).
                 return
-
-        if loop_node.target.name != name:
-            return
 
         if isinstance(node.frame(), nodes.AsyncFunctionDef):
             return

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -67,3 +67,12 @@ def yield_use_send():
     total = 0
     for item in (1, 2, 3):
         total += yield item
+
+
+def yield_non_assignname_targets(a, i, x):
+    for a[i] in []:
+        yield x
+    for a.b in []:
+        yield x
+    for _, _ in []:
+        yield x


### PR DESCRIPTION
Closes #11286

### Problem
In the `use-yield-from` refactoring checker (`visit_yield`), `loop_node.target.name` assumed the loop target was always an `AssignName`. When looping over complex targets like subscripts (`for a[i] in []: yield x`), attributes, or tuples, `loop_node.target` does not define a `name` attribute, raising an `AttributeError`.

### Solution
- Updated the AST pattern match in `visit_yield` to directly match `target=nodes.AssignName(name=target_name)` and verify `target_name == name`.
- Added test cases in `tests/functional/u/use/use_yield_from.py` covering subscript, attribute, and tuple loop targets.
- Added changelog fragment `doc/whatsnew/fragments/11286.bugfix`.