### PR TITLE
Do not propose generators instead of async list comprehensions (#7271)

### DIFF
--- a/doc/whatsnew/fragments/7271.false_positive
+++ b/doc/whatsnew/fragments/7271.false_positive
@@ -1,1 +1,5 @@
-Fix a false positive for ``use-a-generator`` and ``consider-using-generator`` for async list comprenehensions.
+Fix a false positive for ``consider-using-generator`` and ``use-a-generator``
+with an asynchronous list comprehension. Turning it into a generator expression
+would create an asynchronous generator, which those functions cannot consume.
+
+Closes #7271

--- a/doc/whatsnew/fragments/7271.false_positive
+++ b/doc/whatsnew/fragments/7271.false_positive
@@ -1,0 +1,1 @@
+Fix a false positive for ``use-a-generator`` and ``consider-using-generator`` for async list comprenehensions.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1159,12 +1159,14 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 "use-a-generator",
                 node=node,
                 args=(call_name, inside_comp),
+                confidence=HIGH,
             )
         else:
             self.add_message(
                 "consider-using-generator",
                 node=node,
                 args=(call_name, inside_comp),
+                confidence=HIGH,
             )
 
     @utils.only_required_for_messages(

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1121,7 +1121,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         match node:
             case nodes.Call(
                 func=nodes.Name(name=call_name), args=[nodes.ListComp() as comp]
-            ) if (call_name in CALLS_THAT_SHOULD_USE_GENERATOR):
+            ) if call_name in CALLS_THAT_SHOULD_USE_GENERATOR and not any(
+                c.is_async for c in comp.generators
+            ):
                 # functions in checked_calls take exactly one positional argument
                 # check whether the argument is list comprehension
                 pass

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -211,6 +211,22 @@ def _is_part_of_assignment_target(node: nodes.NodeNG) -> bool:
     return False
 
 
+def _is_asynchronous_comprehension(comp: nodes.ListComp) -> bool:
+    """Check whether a comprehension would become an asynchronous generator.
+
+    That is the case when it uses ``async for``, or awaits anywhere but in its
+    outermost iterable, the only part evaluated outside of the generator.
+    """
+    if any(generator.is_async for generator in comp.generators):
+        return True
+
+    outermost_iterable = comp.generators[0].iter
+    return any(
+        node is not outermost_iterable and not outermost_iterable.parent_of(node)
+        for node in comp.nodes_of_class(nodes.Await)
+    )
+
+
 @dataclass
 class ConsiderUsingWithStack:
     """Stack for objects that may potentially trigger a R1732 message
@@ -1121,14 +1137,17 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         match node:
             case nodes.Call(
                 func=nodes.Name(name=call_name), args=[nodes.ListComp() as comp]
-            ) if call_name in CALLS_THAT_SHOULD_USE_GENERATOR and not any(
-                c.is_async for c in comp.generators
-            ):
+            ) if (call_name in CALLS_THAT_SHOULD_USE_GENERATOR):
                 # functions in checked_calls take exactly one positional argument
                 # check whether the argument is list comprehension
                 pass
             case _:
                 return
+
+        if _is_asynchronous_comprehension(comp):
+            # The generator expression would be an asynchronous generator,
+            # which none of these functions can consume.
+            return
 
         inside_comp = comp.as_string()[1:-1]  # remove square brackets '[]'
         if node.keywords:

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -1154,20 +1154,17 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             inside_comp = f"({inside_comp})"
             inside_comp += ", "
             inside_comp += ", ".join(kw.as_string() for kw in node.keywords)
-        if call_name in {"any", "all"}:
-            self.add_message(
-                "use-a-generator",
-                node=node,
-                args=(call_name, inside_comp),
-                confidence=HIGH,
-            )
-        else:
-            self.add_message(
-                "consider-using-generator",
-                node=node,
-                args=(call_name, inside_comp),
-                confidence=HIGH,
-            )
+        message_name = (
+            "use-a-generator"
+            if call_name in {"any", "all"}
+            else "consider-using-generator"
+        )
+        self.add_message(
+            message_name,
+            node=node,
+            args=(call_name, inside_comp),
+            confidence=HIGH,
+        )
 
     @utils.only_required_for_messages(
         "stop-iteration-return",

--- a/tests/functional/c/consider/consider_using_generator.py
+++ b/tests/functional/c/consider/consider_using_generator.py
@@ -3,13 +3,6 @@
 
 import asyncio
 
-
-async def arange(n: int):
-    for i in range(n):
-        await asyncio.sleep(0.0)
-        yield i
-
-
 list([])
 tuple([])
 sum([])
@@ -22,80 +15,49 @@ sum([x*x for x in range(10)])  # [consider-using-generator]
 min([x*x for x in range(10)])  # [consider-using-generator]
 max([x*x for x in range(10)])  # [consider-using-generator]
 
-list([0 async for y in arange(10)])
-tuple([0 async for y in arange(10)])
-sum([x*x async for x in arange(10)])
-min([x*x async for x in arange(10)])
-max([x*x async for x in arange(10)])
-
-list([0 for z in list(range(10)) for z in list(range(10))])  # [consider-using-generator]
-tuple([0 for z in list(range(10)) for z in list(range(10))])  # [consider-using-generator]
-sum([x*y for x in range(10) for y in range(10)])  # [consider-using-generator]
-min([x*y for x in range(10) for y in range(10)])  # [consider-using-generator]
-max([x*y for x in range(10) for y in range(10)])  # [consider-using-generator]
-
-list([0 async for z in arange(10) for z in range(10)])
-tuple([0 async for z in arange(10) for z in range(10)])
-sum([x*x async for x in arange(10) for y in range(10)])
-min([x*x async for x in arange(10) for y in range(10)])
-max([x*x async for x in arange(10) for y in range(10)])
-
-list([0 for z in range(10) async for z in arange(10)])
-tuple([0 for z in range(10) async for z in arange(10)])
-sum([x*x for x in range(10) async for y in arange(10)])
-min([x*x for x in range(10) async for y in arange(10)])
-max([x*x for x in range(10) async for y in arange(10)])
-
-list([0 async for z in arange(10) async for z in arange(10)])
-tuple([0 async for z in arange(10) async for z in arange(10)])
-sum([x*x async for x in arange(10) async for y in arange(10)])
-min([x*x async for x in arange(10) async for y in arange(10)])
-max([x*x async for x in arange(10) async for y in arange(10)])
-
 list(0 for y in list(range(10)))
 tuple(0 for y in list(range(10)))
 sum(x*x for x in range(10))
 min(x*x for x in range(10))
 max(x*x for x in range(10))
 
-list(0 async for y in arange(10))
-tuple(0 async for y in arange(10))
-sum(x*x async for x in arange(10))
-min(x*x async for x in arange(10))
-max(x*x async for x in arange(10))
-
-list(0 for z in list(range(10)) for z in list(range(10)))
-tuple(0 for z in list(range(10)) for z in list(range(10)))
-sum(x*y for x in range(10) for y in range(10))
-min(x*y for x in range(10) for y in range(10))
-max(x*y for x in range(10) for y in range(10))
-
-list(0 async for z in arange(10) for z in range(10))
-tuple(0 async for z in arange(10) for z in range(10))
-sum(x*y async for x in arange(10) for y in range(10))
-min(x*y async for x in arange(10) for y in range(10))
-max(x*y async for x in arange(10) for y in range(10))
-
-list(0 for z in range(10) async for z in arange(10))
-tuple(0 for z in range(10) async for z in arange(10))
-sum(x*y for x in range(10) async for y in arange(10))
-min(x*y for x in range(10) async for y in arange(10))
-max(x*y for x in range(10) async for y in arange(10))
-
-list(0 async for z in arange(10) async for z in arange(10))
-tuple(0 async for z in arange(10) async for z in arange(10))
-sum(x*y async for x in arange(10) async for y in arange(10))
-min(x*y async for x in arange(10) async for y in arange(10))
-max(x*y async for x in arange(10) async for y in arange(10))
-
 # Keyword arguments
 # https://github.com/pylint-dev/pylint/issues/8563
 min([x*x for x in range(10)], default=42)  # [consider-using-generator]
-min([x*x async for x in arange(10)], default=42)
 min((x*x for x in range(10)), default=42)
 
-min([x*y for x in range(10) for y in range(10)], default=42)  # [consider-using-generator]
-min([x*y async for x in arange(10) for y in range(10)], default=42)
-min([x*y for x in range(10) async for y in arange(10)], default=42)
-min([x*y async for x in arange(10) async for y in arange(10)], default=42)
-min((x*y for x in range(10) for y in range(10)), default=42)
+
+# https://github.com/pylint-dev/pylint/issues/7271
+# An asynchronous comprehension would become an asynchronous generator,
+# which none of these functions can consume.
+async def apples():
+    for apple in range(10):
+        await asyncio.sleep(0)
+        yield apple
+
+
+async def weigh(apple):
+    await asyncio.sleep(0)
+    return apple * 2
+
+
+async def basket():
+    await asyncio.sleep(0)
+    return list(range(10))
+
+
+async def main():
+    list([apple async for apple in apples()])
+    tuple([apple async for apple in apples()])
+    sum([apple async for apple in apples()])
+    min([apple async for apple in apples()])
+    max([apple async for apple in apples()])
+    min([apple async for apple in apples()], default=42)
+    # Any of the generators can be the asynchronous one.
+    sum([apple for apple in range(10) async for _ in apples()])
+    # An await has the same effect as an 'async for'.
+    sum([await weigh(apple) for apple in range(10)])
+    sum([apple for apple in range(10) if await weigh(apple)])
+    # The outermost iterable is evaluated outside of the generator, so awaiting
+    # there is fine.
+    sum([apple * 2 for apple in await basket()])  # [consider-using-generator]

--- a/tests/functional/c/consider/consider_using_generator.py
+++ b/tests/functional/c/consider/consider_using_generator.py
@@ -1,6 +1,15 @@
 # pylint: disable=missing-docstring, invalid-name
 # https://github.com/pylint-dev/pylint/issues/3165
 
+import asyncio
+
+
+async def arange(n: int):
+    for i in range(n):
+        await asyncio.sleep(0.0)
+        yield i
+
+
 list([])
 tuple([])
 sum([])
@@ -13,13 +22,80 @@ sum([x*x for x in range(10)])  # [consider-using-generator]
 min([x*x for x in range(10)])  # [consider-using-generator]
 max([x*x for x in range(10)])  # [consider-using-generator]
 
+list([0 async for y in arange(10)])
+tuple([0 async for y in arange(10)])
+sum([x*x async for x in arange(10)])
+min([x*x async for x in arange(10)])
+max([x*x async for x in arange(10)])
+
+list([0 for z in list(range(10)) for z in list(range(10))])  # [consider-using-generator]
+tuple([0 for z in list(range(10)) for z in list(range(10))])  # [consider-using-generator]
+sum([x*y for x in range(10) for y in range(10)])  # [consider-using-generator]
+min([x*y for x in range(10) for y in range(10)])  # [consider-using-generator]
+max([x*y for x in range(10) for y in range(10)])  # [consider-using-generator]
+
+list([0 async for z in arange(10) for z in range(10)])
+tuple([0 async for z in arange(10) for z in range(10)])
+sum([x*x async for x in arange(10) for y in range(10)])
+min([x*x async for x in arange(10) for y in range(10)])
+max([x*x async for x in arange(10) for y in range(10)])
+
+list([0 for z in range(10) async for z in arange(10)])
+tuple([0 for z in range(10) async for z in arange(10)])
+sum([x*x for x in range(10) async for y in arange(10)])
+min([x*x for x in range(10) async for y in arange(10)])
+max([x*x for x in range(10) async for y in arange(10)])
+
+list([0 async for z in arange(10) async for z in arange(10)])
+tuple([0 async for z in arange(10) async for z in arange(10)])
+sum([x*x async for x in arange(10) async for y in arange(10)])
+min([x*x async for x in arange(10) async for y in arange(10)])
+max([x*x async for x in arange(10) async for y in arange(10)])
+
 list(0 for y in list(range(10)))
 tuple(0 for y in list(range(10)))
 sum(x*x for x in range(10))
 min(x*x for x in range(10))
 max(x*x for x in range(10))
 
+list(0 async for y in arange(10))
+tuple(0 async for y in arange(10))
+sum(x*x async for x in arange(10))
+min(x*x async for x in arange(10))
+max(x*x async for x in arange(10))
+
+list(0 for z in list(range(10)) for z in list(range(10)))
+tuple(0 for z in list(range(10)) for z in list(range(10)))
+sum(x*y for x in range(10) for y in range(10))
+min(x*y for x in range(10) for y in range(10))
+max(x*y for x in range(10) for y in range(10))
+
+list(0 async for z in arange(10) for z in range(10))
+tuple(0 async for z in arange(10) for z in range(10))
+sum(x*y async for x in arange(10) for y in range(10))
+min(x*y async for x in arange(10) for y in range(10))
+max(x*y async for x in arange(10) for y in range(10))
+
+list(0 for z in range(10) async for z in arange(10))
+tuple(0 for z in range(10) async for z in arange(10))
+sum(x*y for x in range(10) async for y in arange(10))
+min(x*y for x in range(10) async for y in arange(10))
+max(x*y for x in range(10) async for y in arange(10))
+
+list(0 async for z in arange(10) async for z in arange(10))
+tuple(0 async for z in arange(10) async for z in arange(10))
+sum(x*y async for x in arange(10) async for y in arange(10))
+min(x*y async for x in arange(10) async for y in arange(10))
+max(x*y async for x in arange(10) async for y in arange(10))
+
 # Keyword arguments
 # https://github.com/pylint-dev/pylint/issues/8563
 min([x*x for x in range(10)], default=42)  # [consider-using-generator]
+min([x*x async for x in arange(10)], default=42)
 min((x*x for x in range(10)), default=42)
+
+min([x*y for x in range(10) for y in range(10)], default=42)  # [consider-using-generator]
+min([x*y async for x in arange(10) for y in range(10)], default=42)
+min([x*y for x in range(10) async for y in arange(10)], default=42)
+min([x*y async for x in arange(10) async for y in arange(10)], default=42)
+min((x*y for x in range(10) for y in range(10)), default=42)

--- a/tests/functional/c/consider/consider_using_generator.py
+++ b/tests/functional/c/consider/consider_using_generator.py
@@ -30,34 +30,38 @@ min((x*x for x in range(10)), default=42)
 # https://github.com/pylint-dev/pylint/issues/7271
 # An asynchronous comprehension would become an asynchronous generator,
 # which none of these functions can consume.
-async def apples():
+async def grow_apples():
     for apple in range(10):
         await asyncio.sleep(0)
         yield apple
 
 
-async def weigh(apple):
-    await asyncio.sleep(0)
-    return apple * 2
-
-
-async def basket():
+async def pick_apples():
     await asyncio.sleep(0)
     return list(range(10))
 
 
+async def weigh(apple):
+    await asyncio.sleep(0)
+    return apple * 100
+
+
+def is_red(apple):
+    return apple % 2 == 0
+
+
 async def main():
-    list([apple async for apple in apples()])
-    tuple([apple async for apple in apples()])
-    sum([apple async for apple in apples()])
-    min([apple async for apple in apples()])
-    max([apple async for apple in apples()])
-    min([apple async for apple in apples()], default=42)
+    list([apple async for apple in grow_apples()])
+    tuple([apple async for apple in grow_apples()])
+    sum([apple async for apple in grow_apples()])
+    min([apple async for apple in grow_apples()])
+    max([apple async for apple in grow_apples()])
+    min([apple async for apple in grow_apples()], default=42)
     # Any of the generators can be the asynchronous one.
-    sum([apple for apple in range(10) async for _ in apples()])
+    sum([apple for apple in range(10) async for _ in grow_apples()])
     # An await has the same effect as an 'async for'.
     sum([await weigh(apple) for apple in range(10)])
     sum([apple for apple in range(10) if await weigh(apple)])
     # The outermost iterable is evaluated outside of the generator, so awaiting
     # there is fine.
-    sum([apple * 2 for apple in await basket()])  # [consider-using-generator]
+    sum([apple for apple in await pick_apples() if is_red(apple)])  # [consider-using-generator]

--- a/tests/functional/c/consider/consider_using_generator.txt
+++ b/tests/functional/c/consider/consider_using_generator.txt
@@ -1,6 +1,12 @@
-consider-using-generator:10:0:10:34::Consider using a generator instead 'list(0 for y in list(range(10)))':UNDEFINED
-consider-using-generator:11:0:11:35::Consider using a generator instead 'tuple(0 for y in list(range(10)))':UNDEFINED
-consider-using-generator:12:0:12:29::Consider using a generator instead 'sum(x * x for x in range(10))':UNDEFINED
-consider-using-generator:13:0:13:29::Consider using a generator instead 'min(x * x for x in range(10))':UNDEFINED
-consider-using-generator:14:0:14:29::Consider using a generator instead 'max(x * x for x in range(10))':UNDEFINED
-consider-using-generator:24:0:24:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':UNDEFINED
+consider-using-generator:19:0:19:34::Consider using a generator instead 'list(0 for y in list(range(10)))':UNDEFINED
+consider-using-generator:20:0:20:35::Consider using a generator instead 'tuple(0 for y in list(range(10)))':UNDEFINED
+consider-using-generator:21:0:21:29::Consider using a generator instead 'sum(x * x for x in range(10))':UNDEFINED
+consider-using-generator:22:0:22:29::Consider using a generator instead 'min(x * x for x in range(10))':UNDEFINED
+consider-using-generator:23:0:23:29::Consider using a generator instead 'max(x * x for x in range(10))':UNDEFINED
+consider-using-generator:31:0:31:59::Consider using a generator instead 'list(0 for z in list(range(10)) for z in list(range(10)))':UNDEFINED
+consider-using-generator:32:0:32:60::Consider using a generator instead 'tuple(0 for z in list(range(10)) for z in list(range(10)))':UNDEFINED
+consider-using-generator:33:0:33:48::Consider using a generator instead 'sum(x * y for x in range(10) for y in range(10))':UNDEFINED
+consider-using-generator:34:0:34:48::Consider using a generator instead 'min(x * y for x in range(10) for y in range(10))':UNDEFINED
+consider-using-generator:35:0:35:48::Consider using a generator instead 'max(x * y for x in range(10) for y in range(10))':UNDEFINED
+consider-using-generator:93:0:93:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':UNDEFINED
+consider-using-generator:97:0:97:60::Consider using a generator instead 'min((x * y for x in range(10) for y in range(10)), default=42)':UNDEFINED

--- a/tests/functional/c/consider/consider_using_generator.txt
+++ b/tests/functional/c/consider/consider_using_generator.txt
@@ -1,7 +1,7 @@
-consider-using-generator:12:0:12:34::Consider using a generator instead 'list(0 for y in list(range(10)))':UNDEFINED
-consider-using-generator:13:0:13:35::Consider using a generator instead 'tuple(0 for y in list(range(10)))':UNDEFINED
-consider-using-generator:14:0:14:29::Consider using a generator instead 'sum(x * x for x in range(10))':UNDEFINED
-consider-using-generator:15:0:15:29::Consider using a generator instead 'min(x * x for x in range(10))':UNDEFINED
-consider-using-generator:16:0:16:29::Consider using a generator instead 'max(x * x for x in range(10))':UNDEFINED
-consider-using-generator:26:0:26:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':UNDEFINED
-consider-using-generator:67:4:67:66:main:Consider using a generator instead 'sum(apple for apple in await pick_apples() if is_red(apple))':UNDEFINED
+consider-using-generator:12:0:12:34::Consider using a generator instead 'list(0 for y in list(range(10)))':HIGH
+consider-using-generator:13:0:13:35::Consider using a generator instead 'tuple(0 for y in list(range(10)))':HIGH
+consider-using-generator:14:0:14:29::Consider using a generator instead 'sum(x * x for x in range(10))':HIGH
+consider-using-generator:15:0:15:29::Consider using a generator instead 'min(x * x for x in range(10))':HIGH
+consider-using-generator:16:0:16:29::Consider using a generator instead 'max(x * x for x in range(10))':HIGH
+consider-using-generator:26:0:26:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':HIGH
+consider-using-generator:67:4:67:66:main:Consider using a generator instead 'sum(apple for apple in await pick_apples() if is_red(apple))':HIGH

--- a/tests/functional/c/consider/consider_using_generator.txt
+++ b/tests/functional/c/consider/consider_using_generator.txt
@@ -4,4 +4,4 @@ consider-using-generator:14:0:14:29::Consider using a generator instead 'sum(x *
 consider-using-generator:15:0:15:29::Consider using a generator instead 'min(x * x for x in range(10))':UNDEFINED
 consider-using-generator:16:0:16:29::Consider using a generator instead 'max(x * x for x in range(10))':UNDEFINED
 consider-using-generator:26:0:26:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':UNDEFINED
-consider-using-generator:63:4:63:48:main:Consider using a generator instead 'sum(apple * 2 for apple in await basket())':UNDEFINED
+consider-using-generator:67:4:67:66:main:Consider using a generator instead 'sum(apple for apple in await pick_apples() if is_red(apple))':UNDEFINED

--- a/tests/functional/c/consider/consider_using_generator.txt
+++ b/tests/functional/c/consider/consider_using_generator.txt
@@ -1,12 +1,7 @@
-consider-using-generator:19:0:19:34::Consider using a generator instead 'list(0 for y in list(range(10)))':UNDEFINED
-consider-using-generator:20:0:20:35::Consider using a generator instead 'tuple(0 for y in list(range(10)))':UNDEFINED
-consider-using-generator:21:0:21:29::Consider using a generator instead 'sum(x * x for x in range(10))':UNDEFINED
-consider-using-generator:22:0:22:29::Consider using a generator instead 'min(x * x for x in range(10))':UNDEFINED
-consider-using-generator:23:0:23:29::Consider using a generator instead 'max(x * x for x in range(10))':UNDEFINED
-consider-using-generator:31:0:31:59::Consider using a generator instead 'list(0 for z in list(range(10)) for z in list(range(10)))':UNDEFINED
-consider-using-generator:32:0:32:60::Consider using a generator instead 'tuple(0 for z in list(range(10)) for z in list(range(10)))':UNDEFINED
-consider-using-generator:33:0:33:48::Consider using a generator instead 'sum(x * y for x in range(10) for y in range(10))':UNDEFINED
-consider-using-generator:34:0:34:48::Consider using a generator instead 'min(x * y for x in range(10) for y in range(10))':UNDEFINED
-consider-using-generator:35:0:35:48::Consider using a generator instead 'max(x * y for x in range(10) for y in range(10))':UNDEFINED
-consider-using-generator:93:0:93:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':UNDEFINED
-consider-using-generator:97:0:97:60::Consider using a generator instead 'min((x * y for x in range(10) for y in range(10)), default=42)':UNDEFINED
+consider-using-generator:12:0:12:34::Consider using a generator instead 'list(0 for y in list(range(10)))':UNDEFINED
+consider-using-generator:13:0:13:35::Consider using a generator instead 'tuple(0 for y in list(range(10)))':UNDEFINED
+consider-using-generator:14:0:14:29::Consider using a generator instead 'sum(x * x for x in range(10))':UNDEFINED
+consider-using-generator:15:0:15:29::Consider using a generator instead 'min(x * x for x in range(10))':UNDEFINED
+consider-using-generator:16:0:16:29::Consider using a generator instead 'max(x * x for x in range(10))':UNDEFINED
+consider-using-generator:26:0:26:41::Consider using a generator instead 'min((x * x for x in range(10)), default=42)':UNDEFINED
+consider-using-generator:63:4:63:48:main:Consider using a generator instead 'sum(apple * 2 for apple in await basket())':UNDEFINED

--- a/tests/functional/c/consider/consider_using_generator_py315.txt
+++ b/tests/functional/c/consider/consider_using_generator_py315.txt
@@ -1,2 +1,2 @@
-consider-using-generator:3:8:3:33::Consider using a generator instead 'sum(*x for x in NESTED)':UNDEFINED
-consider-using-generator:4:11:4:38::Consider using a generator instead 'tuple(*x for x in NESTED)':UNDEFINED
+consider-using-generator:3:8:3:33::Consider using a generator instead 'sum(*x for x in NESTED)':HIGH
+consider-using-generator:4:11:4:38::Consider using a generator instead 'tuple(*x for x in NESTED)':HIGH

--- a/tests/functional/n/nested_min_max_py315.txt
+++ b/tests/functional/n/nested_min_max_py315.txt
@@ -1,2 +1,2 @@
-consider-using-generator:3:18:3:43::Consider using a generator instead 'min(*x for x in NESTED)':UNDEFINED
+consider-using-generator:3:18:3:43::Consider using a generator instead 'min(*x for x in NESTED)':HIGH
 nested-min-max:3:11:3:44::Do not use nested call of 'min'; it's possible to do 'min(1, *[*x for x in NESTED])' instead:INFERENCE

--- a/tests/functional/u/use/use_a_generator.py
+++ b/tests/functional/u/use/use_a_generator.py
@@ -1,11 +1,50 @@
 # pylint: disable=missing-docstring, invalid-name
 # https://github.com/pylint-dev/pylint/issues/3165
 
+import asyncio
+
+
+async def arange(n: int):
+    for i in range(n):
+        await asyncio.sleep(0.0)
+        yield i
+
+
 any([])
 all([])
 
 any([0 for x in list(range(10))]) # [use-a-generator]
 all([0 for y in list(range(10))]) # [use-a-generator]
 
+any([0 async for x in arange(10)])
+all([0 async for y in arange(10)])
+
+any([0 for x in list(range(10)) for y in list(range(10))]) # [use-a-generator]
+all([0 for y in list(range(10)) for x in list(range(10))]) # [use-a-generator]
+
+any([0 async for x in arange(10) for y in range(10)])
+all([0 async for y in arange(10) for x in range(10)])
+
+any([0 for x in range(10) async for y in arange(10)])
+all([0 for y in range(10) async for x in arange(10)])
+
+any([0 async for x in arange(10) async for y in arange(10)])
+all([0 async for y in arange(10) async for x in arange(10)])
+
 any(0 for x in list(range(10)))
 all(0 for y in list(range(10)))
+
+any(0 async for x in arange(10))
+all(0 async for y in arange(10))
+
+any(0 for x in list(range(10)) for y in list(range(10)))
+all(0 for y in list(range(10)) for x in list(range(10)))
+
+any(0 async for x in arange(10) for y in range(10))
+all(0 async for y in arange(10) for x in range(10))
+
+any(0 for x in range(10) async for y in arange(10))
+all(0 for y in range(10) async for x in arange(10))
+
+any(0 async for x in arange(10) async for y in arange(10))
+all(0 async for y in arange(10) async for x in arange(10))

--- a/tests/functional/u/use/use_a_generator.py
+++ b/tests/functional/u/use/use_a_generator.py
@@ -3,48 +3,45 @@
 
 import asyncio
 
-
-async def arange(n: int):
-    for i in range(n):
-        await asyncio.sleep(0.0)
-        yield i
-
-
 any([])
 all([])
 
 any([0 for x in list(range(10))]) # [use-a-generator]
 all([0 for y in list(range(10))]) # [use-a-generator]
 
-any([0 async for x in arange(10)])
-all([0 async for y in arange(10)])
-
-any([0 for x in list(range(10)) for y in list(range(10))]) # [use-a-generator]
-all([0 for y in list(range(10)) for x in list(range(10))]) # [use-a-generator]
-
-any([0 async for x in arange(10) for y in range(10)])
-all([0 async for y in arange(10) for x in range(10)])
-
-any([0 for x in range(10) async for y in arange(10)])
-all([0 for y in range(10) async for x in arange(10)])
-
-any([0 async for x in arange(10) async for y in arange(10)])
-all([0 async for y in arange(10) async for x in arange(10)])
-
 any(0 for x in list(range(10)))
 all(0 for y in list(range(10)))
 
-any(0 async for x in arange(10))
-all(0 async for y in arange(10))
 
-any(0 for x in list(range(10)) for y in list(range(10)))
-all(0 for y in list(range(10)) for x in list(range(10)))
+# https://github.com/pylint-dev/pylint/issues/7271
+# An asynchronous comprehension would become an asynchronous generator,
+# which any() and all() cannot consume.
+async def apples():
+    for apple in range(10):
+        await asyncio.sleep(0)
+        yield apple
 
-any(0 async for x in arange(10) for y in range(10))
-all(0 async for y in arange(10) for x in range(10))
 
-any(0 for x in range(10) async for y in arange(10))
-all(0 for y in range(10) async for x in arange(10))
+async def is_ripe(apple):
+    await asyncio.sleep(0)
+    return apple % 2
 
-any(0 async for x in arange(10) async for y in arange(10))
-all(0 async for y in arange(10) async for x in arange(10))
+
+async def basket():
+    await asyncio.sleep(0)
+    return list(range(10))
+
+
+async def main():
+    any([apple async for apple in apples()])
+    all([apple async for apple in apples()])
+    # Any of the generators can be the asynchronous one.
+    any([apple for apple in range(10) async for _ in apples()])
+    all([apple for apple in range(10) async for _ in apples()])
+    # An await has the same effect as an 'async for'.
+    any([await is_ripe(apple) for apple in range(10)])
+    all([apple for apple in range(10) if await is_ripe(apple)])
+    # The outermost iterable is evaluated outside of the generator, so awaiting
+    # there is fine.
+    any([apple > 1 for apple in await basket()]) # [use-a-generator]
+    all([apple > 1 for apple in await basket()]) # [use-a-generator]

--- a/tests/functional/u/use/use_a_generator.py
+++ b/tests/functional/u/use/use_a_generator.py
@@ -16,10 +16,15 @@ all(0 for y in list(range(10)))
 # https://github.com/pylint-dev/pylint/issues/7271
 # An asynchronous comprehension would become an asynchronous generator,
 # which any() and all() cannot consume.
-async def apples():
+async def grow_apples():
     for apple in range(10):
         await asyncio.sleep(0)
         yield apple
+
+
+async def pick_apples():
+    await asyncio.sleep(0)
+    return list(range(10))
 
 
 async def is_ripe(apple):
@@ -27,21 +32,20 @@ async def is_ripe(apple):
     return apple % 2
 
 
-async def basket():
-    await asyncio.sleep(0)
-    return list(range(10))
+def is_red(apple):
+    return apple % 2 == 0
 
 
 async def main():
-    any([apple async for apple in apples()])
-    all([apple async for apple in apples()])
+    any([apple async for apple in grow_apples()])
+    all([apple async for apple in grow_apples()])
     # Any of the generators can be the asynchronous one.
-    any([apple for apple in range(10) async for _ in apples()])
-    all([apple for apple in range(10) async for _ in apples()])
+    any([apple for apple in range(10) async for _ in grow_apples()])
+    all([apple for apple in range(10) async for _ in grow_apples()])
     # An await has the same effect as an 'async for'.
     any([await is_ripe(apple) for apple in range(10)])
     all([apple for apple in range(10) if await is_ripe(apple)])
     # The outermost iterable is evaluated outside of the generator, so awaiting
     # there is fine.
-    any([apple > 1 for apple in await basket()]) # [use-a-generator]
-    all([apple > 1 for apple in await basket()]) # [use-a-generator]
+    any([is_red(apple) for apple in await pick_apples()]) # [use-a-generator]
+    all([is_red(apple) for apple in await pick_apples()]) # [use-a-generator]

--- a/tests/functional/u/use/use_a_generator.txt
+++ b/tests/functional/u/use/use_a_generator.txt
@@ -1,4 +1,4 @@
 use-a-generator:9:0:9:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
 use-a-generator:10:0:10:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
-use-a-generator:46:4:46:48:main:Use a generator instead 'any(apple > 1 for apple in await basket())':UNDEFINED
-use-a-generator:47:4:47:48:main:Use a generator instead 'all(apple > 1 for apple in await basket())':UNDEFINED
+use-a-generator:50:4:50:57:main:Use a generator instead 'any(is_red(apple) for apple in await pick_apples())':UNDEFINED
+use-a-generator:51:4:51:57:main:Use a generator instead 'all(is_red(apple) for apple in await pick_apples())':UNDEFINED

--- a/tests/functional/u/use/use_a_generator.txt
+++ b/tests/functional/u/use/use_a_generator.txt
@@ -1,4 +1,4 @@
-use-a-generator:16:0:16:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
-use-a-generator:17:0:17:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
-use-a-generator:22:0:22:58::Use a generator instead 'any(0 for x in list(range(10)) for y in list(range(10)))':UNDEFINED
-use-a-generator:23:0:23:58::Use a generator instead 'all(0 for y in list(range(10)) for x in list(range(10)))':UNDEFINED
+use-a-generator:9:0:9:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
+use-a-generator:10:0:10:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
+use-a-generator:46:4:46:48:main:Use a generator instead 'any(apple > 1 for apple in await basket())':UNDEFINED
+use-a-generator:47:4:47:48:main:Use a generator instead 'all(apple > 1 for apple in await basket())':UNDEFINED

--- a/tests/functional/u/use/use_a_generator.txt
+++ b/tests/functional/u/use/use_a_generator.txt
@@ -1,2 +1,4 @@
-use-a-generator:7:0:7:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
-use-a-generator:8:0:8:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
+use-a-generator:16:0:16:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
+use-a-generator:17:0:17:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
+use-a-generator:22:0:22:58::Use a generator instead 'any(0 for x in list(range(10)) for y in list(range(10)))':UNDEFINED
+use-a-generator:23:0:23:58::Use a generator instead 'all(0 for y in list(range(10)) for x in list(range(10)))':UNDEFINED

--- a/tests/functional/u/use/use_a_generator.txt
+++ b/tests/functional/u/use/use_a_generator.txt
@@ -1,4 +1,4 @@
-use-a-generator:9:0:9:33::Use a generator instead 'any(0 for x in list(range(10)))':UNDEFINED
-use-a-generator:10:0:10:33::Use a generator instead 'all(0 for y in list(range(10)))':UNDEFINED
-use-a-generator:50:4:50:57:main:Use a generator instead 'any(is_red(apple) for apple in await pick_apples())':UNDEFINED
-use-a-generator:51:4:51:57:main:Use a generator instead 'all(is_red(apple) for apple in await pick_apples())':UNDEFINED
+use-a-generator:9:0:9:33::Use a generator instead 'any(0 for x in list(range(10)))':HIGH
+use-a-generator:10:0:10:33::Use a generator instead 'all(0 for y in list(range(10)))':HIGH
+use-a-generator:50:4:50:57:main:Use a generator instead 'any(is_red(apple) for apple in await pick_apples())':HIGH
+use-a-generator:51:4:51:57:main:Use a generator instead 'all(is_red(apple) for apple in await pick_apples())':HIGH

--- a/tests/functional/u/use/use_a_generator_py315.txt
+++ b/tests/functional/u/use/use_a_generator_py315.txt
@@ -1,2 +1,2 @@
-use-a-generator:3:6:3:31::Use a generator instead 'any(*x for x in NESTED)':UNDEFINED
-use-a-generator:4:6:4:31::Use a generator instead 'all(*x for x in NESTED)':UNDEFINED
+use-a-generator:3:6:3:31::Use a generator instead 'any(*x for x in NESTED)':HIGH
+use-a-generator:4:6:4:31::Use a generator instead 'all(*x for x in NESTED)':HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

R1728 and R1729 propose to replace unnecessary list comprehensions with pure generator argument in functions like `any`/`all`/`min`/`max`/`sum`/`tuple`/`list`. The functions only works with sync generators though. So the change make exception for async list comprehensions.

Closes #7271