### PR TITLE
Report a changed parameter count in overridden special methods

### DIFF
--- a/custom_dict.txt
+++ b/custom_dict.txt
@@ -336,6 +336,7 @@ subparts
 subprocess
 subscriptable
 subscripted
+substitutability
 subtree
 supcls
 superclass

--- a/doc/whatsnew/fragments/11295.false_negative
+++ b/doc/whatsnew/fragments/11295.false_negative
@@ -1,0 +1,6 @@
+Emit ``arguments-differ`` when an overridden special method takes a different
+number of parameters. Only renamed parameters and removed variadics stay
+exempt, and the constructor family (``__new__``, ``__init__``,
+``__init_subclass__`` and ``__post_init__``) is still fully ignored.
+
+Closes #11295

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -50,6 +50,10 @@ _AccessNodes: TypeAlias = nodes.Attribute | nodes.AssignAttr
 
 INVALID_BASE_CLASSES = {"bool", "range", "slice", "memoryview"}
 BUILTIN_DECORATORS = {"builtins.property", "builtins.classmethod"}
+# Special methods that build or configure the class itself. A subclass routinely
+# takes different arguments there without breaking substitutability, because
+# callers name the concrete class instead of going through the base one.
+CONSTRUCTOR_METHODS = {"__new__", "__init__", "__init_subclass__", "__post_init__"}
 ASTROID_TYPE_COMPARATORS = {
     nodes.Const: lambda a, b: a.value == b.value,
     nodes.ClassDef: lambda a, b: a.qname == b.qname,
@@ -378,13 +382,18 @@ def _different_parameters(
     if kwarg_lost or vararg_lost:
         output_messages += ["Variadics removed in"]
 
-    if original.name in PYMETHODS:
-        # Ignore the difference for special methods. If the parameter
-        # numbers are different, then that is going to be caught by
-        # unexpected-special-method-signature.
-        # If the names are different, it doesn't matter, since they can't
-        # be used as keyword arguments anyway.
+    if original.name in CONSTRUCTOR_METHODS:
+        # Ignore every difference for the constructor family, overriding those
+        # with another signature is idiomatic.
         output_messages.clear()
+    elif original.name in PYMETHODS:
+        # For the other special methods, only keep the difference in the number
+        # of parameters. If the names are different, it doesn't matter, since
+        # they can't be used as keyword arguments anyway, and losing variadics
+        # is fine as long as the remaining parameters still match.
+        output_messages[:] = [
+            message for message in output_messages if "Number" in message
+        ]
 
     return output_messages
 

--- a/tests/functional/a/arguments_differ.py
+++ b/tests/functional/a/arguments_differ.py
@@ -368,3 +368,30 @@ class InitSubclassParent:
 class InitSubclassChild(InitSubclassParent):
     def __init_subclass__(cls, /, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
+
+
+# A special method called through the base class keeps the same
+# number of parameters:
+class CallParent:
+    def __call__(self, arg1, arg2):
+        ...
+
+class CallChild(CallParent):
+    def __call__(self, arg1, arg2, arg3):  # [arguments-differ]
+        ...
+
+
+# ... but widening it with variadics is fine, every base call still works:
+class CallChildWithVarargs(CallParent):
+    def __call__(self, *args):
+        ...
+
+
+# Exclude `__new__` from the check:
+class NewParent:
+    def __new__(cls, arg1):
+        return object.__new__(cls)
+
+class NewChild(NewParent):
+    def __new__(cls, arg1, arg2):
+        return object.__new__(cls)

--- a/tests/functional/a/arguments_differ.txt
+++ b/tests/functional/a/arguments_differ.txt
@@ -11,3 +11,4 @@ arguments-differ:313:4:313:16:Foo.kwonly_3:Number of parameters was 3 in 'Abstra
 arguments-differ:316:4:316:16:Foo.kwonly_4:Number of parameters was 3 in 'AbstractFoo.kwonly_4' and is now 3 in overriding 'Foo.kwonly_4' method:UNDEFINED
 arguments-differ:319:4:319:16:Foo.kwonly_5:Variadics removed in overriding 'Foo.kwonly_5' method:UNDEFINED
 arguments-differ:359:4:359:14:ClassWithNewNonDefaultKeywordOnly.method:Number of parameters was 2 in 'AClass.method' and is now 3 in overriding 'ClassWithNewNonDefaultKeywordOnly.method' method:UNDEFINED
+arguments-differ:380:4:380:16:CallChild.__call__:Number of parameters was 3 in 'CallParent.__call__' and is now 4 in overriding 'CallChild.__call__' method:UNDEFINED


### PR DESCRIPTION
## Type of Changes

<!-- Leave the corresponding lines for the applicable type of change: -->

|     | Type                   |
| --- | ---------------------- |
| ✓   | :sparkles: New feature |

## Description

``arguments-differ`` was exempting every special method since the fix for #1042, which was only about renamed parameters. The rationale was that ``unexpected-special-method-signature`` would catch a differing number of parameters, but that check only compares against the arity builtin special methods are expected to have, never against a user-defined base class. For the entries whose arity is variable -- ``__call__`` among them -- nothing was reported at all.

Renamed parameters and removed variadics stay exempt, and the constructor family is still ignored entirely: subclasses routinely build themselves from other arguments than their parent, and callers name the concrete class rather than going through the base one.

Closes #11295
