### PR TITLE
Fix false positive `invalid-*-returned` for instances of builtin subclasses

### DIFF
--- a/doc/whatsnew/fragments/11306.false_positive
+++ b/doc/whatsnew/fragments/11306.false_positive
@@ -1,0 +1,9 @@
+Fix false positives for :ref:`invalid-str-returned`, :ref:`invalid-repr-returned`,
+:ref:`invalid-format-returned`, :ref:`invalid-bytes-returned`, :ref:`invalid-hash-returned`,
+:ref:`invalid-index-returned`, :ref:`invalid-length-returned`,
+:ref:`invalid-length-hint-returned`, :ref:`invalid-getnewargs-returned` and
+:ref:`invalid-getnewargs-ex-returned` when the returned value is an instance of a
+subclass of the expected builtin type, such as ``self`` in a ``str`` subclass or a
+``namedtuple``.
+
+Closes #11306

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -246,10 +246,16 @@ class SpecialMethodsChecker(BaseChecker):
 
     @staticmethod
     def _is_wrapped_type(node: InferenceResult, type_: str) -> bool:
+        """Check whether ``node`` is an instance of the builtin ``type_``.
+
+        Instances of subclasses of the builtin type are accepted too: returning
+        ``self`` from the ``__str__`` of a ``str`` subclass or a ``namedtuple``
+        from ``__getnewargs__`` is valid.
+        """
         return (
             isinstance(node, bases.Instance)
-            and node.name == type_
             and not isinstance(node, nodes.Const)
+            and node.is_subtype_of(f"builtins.{type_}")
         )
 
     @staticmethod

--- a/tests/functional/i/invalid/invalid_returned_subclass.py
+++ b/tests/functional/i/invalid/invalid_returned_subclass.py
@@ -1,0 +1,105 @@
+"""Special methods may return an instance of a subclass of the expected builtin type."""
+
+# pylint: disable=too-few-public-methods,missing-docstring,unnecessary-pass
+
+from collections import namedtuple
+
+
+class MyStr(str):
+    """A str subclass; ``self`` is a valid str."""
+
+    def __repr__(self):
+        return self
+
+    def __str__(self):
+        return self
+
+    def __format__(self, format_spec):
+        return self
+
+
+class MyInt(int):
+    """An int subclass; ``self`` is a valid int."""
+
+    def __hash__(self):
+        return self
+
+    def __index__(self):
+        return self
+
+    def __len__(self):
+        return self
+
+    def __length_hint__(self):
+        return self
+
+
+class MyBytes(bytes):
+    def __bytes__(self):
+        return self
+
+
+class MyTuple(tuple):
+    def __getnewargs__(self):
+        return self
+
+
+Args = namedtuple("Args", ["first", "second"])
+
+
+class ReturnsSubclassInstances:
+    """The subclass instance is returned from an unrelated class."""
+
+    def __init__(self):
+        self.text = MyStr("text")
+        self.number = MyInt(1)
+
+    def __repr__(self):
+        return self.text
+
+    def __str__(self):
+        return self.text
+
+    def __format__(self, format_spec):
+        return MyStr(format_spec)
+
+    def __bytes__(self):
+        return MyBytes(b"bytes")
+
+    def __hash__(self):
+        return self.number
+
+    def __index__(self):
+        return self.number
+
+    def __len__(self):
+        return self.number
+
+    def __length_hint__(self):
+        return MyInt(2)
+
+    def __getnewargs__(self):
+        return Args(1, 2)
+
+    def __getnewargs_ex__(self):
+        return MyTuple((Args(1, 2), {}))
+
+
+class NotStr:
+    pass
+
+
+class ReturnsUnrelatedSubclass:
+    """Being a subclass of some other builtin is still an error."""
+
+    def __repr__(self):  # [invalid-repr-returned]
+        return MyInt(1)
+
+    def __str__(self):  # [invalid-str-returned]
+        return NotStr()
+
+    def __index__(self):  # [invalid-index-returned]
+        return MyStr("1")
+
+    def __bytes__(self):  # [invalid-bytes-returned]
+        return MyStr("1")

--- a/tests/functional/i/invalid/invalid_returned_subclass.txt
+++ b/tests/functional/i/invalid/invalid_returned_subclass.txt
@@ -1,0 +1,4 @@
+invalid-repr-returned:95:4:95:16:ReturnsUnrelatedSubclass.__repr__:__repr__ does not return str:UNDEFINED
+invalid-str-returned:98:4:98:15:ReturnsUnrelatedSubclass.__str__:__str__ does not return str:UNDEFINED
+invalid-index-returned:101:4:101:17:ReturnsUnrelatedSubclass.__index__:__index__ does not return int:UNDEFINED
+invalid-bytes-returned:104:4:104:17:ReturnsUnrelatedSubclass.__bytes__:__bytes__ does not return bytes:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`SpecialMethodsChecker._is_wrapped_type` decides whether an inferred value is a `str`/`int`/`bytes`/`tuple`/`dict` by comparing the instance's class *name* with the builtin's name:

```python
isinstance(node, bases.Instance) and node.name == type_ and not isinstance(node, nodes.Const)
```

That rejects any instance of a *subclass* of the builtin, so every `invalid-*-returned` check that goes through it reports valid code. The stdlib has an example: `pdb._rstr` is a `str` subclass whose `__repr__` does `return self`, and pylint reports `invalid-repr-returned` on it. The same happens for `__str__`, `__format__`, `__bytes__`, `__hash__`, `__index__`, `__len__`, `__length_hint__`, `__getnewargs__` (returning a `namedtuple`) and `__getnewargs_ex__` — ten messages in total — whether the subclass instance is `self` or is returned from an unrelated class.

The fix checks the class hierarchy with `is_subtype_of(f"builtins.{type_}")` instead of the bare name. Two consequences:

- Subclass instances are accepted. CPython accepts them everywhere these protocols are consumed (`str()`, `repr()`, `format()`, `hash()`, `len()`, `bytes()`, `operator.length_hint()`, pickling), so this removes false positives only.
- A user-defined class that happens to be *named* `str`/`int`/... but is unrelated to the builtin no longer passes. The old name comparison let it through; it now has to actually derive from the builtin. I do not think anyone relied on that, but mentioning it in case.

The only caveat I know of: CPython emits a `DeprecationWarning` when `__index__` returns a *strict* subclass of `int` (it still works). I kept `__index__` consistent with the rest rather than special-casing it, since "does not return int" would be the wrong message for that situation anyway and pylint already accepts `bool` there. Happy to tighten `__index__` back if you would rather keep the warning.

### Tests

- New functional test `invalid_returned_subclass.py` covers each affected message with `return self` from a subclass and with the subclass instance returned from an unrelated class. It fails on `main` with 13 unexpected messages and passes with the fix.
- It also keeps four "still reported" cases (a `str` subclass from `__index__`/`__bytes__`, an `int` subclass from `__repr__`, an unrelated class from `__str__`) so the check is shown to still distinguish *which* builtin the value derives from.
- The existing `invalid_*_returned` functional tests are unchanged and pass.

Closes #11306
