### PR TITLE
Fix false `unexpected-line-ending-format` when linting from stdin

### DIFF
--- a/doc/whatsnew/fragments/9054.false_positive
+++ b/doc/whatsnew/fragments/9054.false_positive
@@ -1,0 +1,6 @@
+Fix a false ``unexpected-line-ending-format`` when linting from stdin. Source
+piped with ``--from-stdin`` was read with universal newlines enabled, so every
+``CRLF`` and ``CR`` became ``LF`` before any checker saw it, and the check
+compared against text pylint had itself rewritten.
+
+Closes #9054

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -83,7 +83,9 @@ class GetAstProtocol(Protocol):
 def _read_stdin() -> str:
     # See https://github.com/python/typeshed/pull/5623 for rationale behind assertion
     assert isinstance(sys.stdin, TextIOWrapper)
-    sys.stdin = TextIOWrapper(sys.stdin.detach(), encoding="utf-8")
+    # newline="" disables universal newlines, which would otherwise rewrite
+    # every CRLF and CR in the piped source to LF before any checker sees it
+    sys.stdin = TextIOWrapper(sys.stdin.detach(), encoding="utf-8", newline="")
     return sys.stdin.read()
 
 

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -18,7 +18,7 @@ import textwrap
 import warnings
 from collections.abc import Iterator
 from copy import copy
-from io import BytesIO, StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 from os.path import abspath, dirname, join
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO
@@ -29,7 +29,7 @@ import pytest
 
 from pylint import extensions, modify_sys_path
 from pylint.constants import MAIN_CHECKER_NAME, MSG_TYPES_STATUS
-from pylint.lint.pylinter import PyLinter
+from pylint.lint.pylinter import PyLinter, _read_stdin
 from pylint.message import Message
 from pylint.reporters import BaseReporter
 from pylint.reporters.json_reporter import JSON2Reporter
@@ -631,6 +631,23 @@ class TestRunTC:
 
     def test_stdin_missing_modulename(self) -> None:
         self._runtest(["--from-stdin"], code=32)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [b"import os\r\nprint(os.name)\r\n", b"import os\rprint(os.name)\r"],
+        ids=["crlf", "cr"],
+    )
+    def test_stdin_preserves_line_endings(self, raw: bytes) -> None:
+        """Piped source must reach the checkers with its line endings intact.
+
+        _read_stdin() re-wraps the buffer to force utf-8 decoding. Leaving
+        newline at its default also enables universal newlines, which rewrites
+        every CRLF and CR to LF before any checker runs, so
+        unexpected-line-ending-format compares against the wrong text.
+        """
+        wrapper = TextIOWrapper(BytesIO(raw), encoding="utf-8")
+        with mock.patch.object(sys, "stdin", wrapper):
+            assert _read_stdin() == raw.decode("utf-8")
 
     @pytest.mark.parametrize("write_bpy_to_disk", [False, True])
     def test_relative_imports(self, write_bpy_to_disk: bool, tmp_path: Path) -> None:


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | 🐛 Bug fix |

## Description

Closes #9054

`--from-stdin` reported `unexpected-line-ending-format` on source whose line endings were already correct. The same bytes linted from a file were fine:

```console
$ printf 'import os\r\nprint(os.name)\r\n' > crlf_mod.py

$ pylint --disable=all --enable=unexpected-line-ending-format \
      --expected-line-ending-format=CRLF crlf_mod.py
Your code has been rated at 10.00/10

$ cat crlf_mod.py | pylint --disable=all --enable=unexpected-line-ending-format \
      --expected-line-ending-format=CRLF --from-stdin crlf_mod.py
crlf_mod.py:1:0: C0328: Unexpected line ending format. There is 'LF' while it should be 'CRLF'.
crlf_mod.py:2:0: C0328: Unexpected line ending format. There is 'LF' while it should be 'CRLF'.
```

### Cause

`_read_stdin()` re-wraps the detached buffer to force utf-8 decoding:

```python
sys.stdin = TextIOWrapper(sys.stdin.detach(), encoding="utf-8")
```

Leaving `newline` at its default does a second thing that is not wanted here: it enables universal newlines, so every `\r\n` and `\r` is rewritten to `\n` during the read.

```python
>>> TextIOWrapper(BytesIO(b"a\r\nb\r\n"), encoding="utf-8").read()
'a\nb\n'
>>> TextIOWrapper(BytesIO(b"a\r\nb\r\n"), encoding="utf-8", newline="").read()
'a\r\nb\r\n'
```

So the checker was comparing the expected ending against text pylint had itself rewritten. `newline=""` keeps the utf-8 decoding the line was added for and turns the translation off.

### Verified

All four combinations, on the same bytes through stdin:

| piped bytes | `--expected-line-ending-format` | before | after |
|---|---|---|---|
| CRLF | CRLF | 2 messages | none |
| LF | LF | none | none |
| LF | CRLF | 2 messages | 2 messages |
| CRLF | LF | 2 messages | 2 messages |

The two true positives still fire, so this narrows the check rather than weakening it.

## Tests

`test_stdin_preserves_line_endings`, parametrized over CRLF and CR, asserts `_read_stdin()` returns the bytes undisturbed.

It deliberately exercises the real function rather than mocking it. The existing stdin tests all patch `pylint.lint.pylinter._read_stdin` with a `return_value`, so none of them could ever have caught this: the bug lives inside the function they replace.

Reverting only `pylinter.py` and keeping the test fails both parameters. Full suite is 2118 passed / 289 skipped / 5 xfailed on this branch against 2116 / 289 / 5 on `main` on the same machine, with no failures either side, the difference being the two added cases.

I used an AI assistant while working on this. The reproduction, the `TextIOWrapper` comparison above and the decision to test `_read_stdin()` directly rather than through the mocked path are mine, and I ran every check reported here.

<!-- Note: @owillebo looked at this one in 2024 and stepped back. Reusing their reproduction as the starting point, credit to them for pinning down the stdin/file asymmetry. -->
