### PR TITLE
Fix false positive \invalid-name\ for variables in \__main__\ blocks (#10766)

### DIFF
--- a/doc/whatsnew/fragments/10766.false_positive
+++ b/doc/whatsnew/fragments/10766.false_positive
@@ -1,0 +1,3 @@
+Fix false positive ``invalid-name`` (constant naming style) for variables defined inside ``if __name__ == '__main__':`` blocks.
+
+Closes #10766

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -114,6 +114,34 @@ def _redefines_import(node: nodes.AssignName) -> bool:
     return False
 
 
+def _is_in_main_block(node: nodes.NodeNG) -> bool:
+    """Detect if the given node is inside an `if __name__ == '__main__':` block."""
+    current: nodes.NodeNG | None = node
+    while current and not isinstance(current, nodes.Module):
+        if isinstance(current, (nodes.FunctionDef, nodes.ClassDef)):
+            return False
+        if isinstance(current.parent, nodes.If) and current is not current.parent.test:
+            test = current.parent.test
+            if isinstance(test, nodes.Compare):
+                left = test.left
+                for op, right in test.ops:
+                    if op in ("==", "is"):
+                        if (
+                            isinstance(left, nodes.Name)
+                            and left.name == "__name__"
+                            and isinstance(right, nodes.Const)
+                            and right.value == "__main__"
+                        ) or (
+                            isinstance(right, nodes.Name)
+                            and right.name == "__name__"
+                            and isinstance(left, nodes.Const)
+                            and left.value == "__main__"
+                        ):
+                            return True
+        current = current.parent
+    return False
+
+
 def _determine_function_name_type(
     node: nodes.FunctionDef, config: argparse.Namespace
 ) -> str:
@@ -509,6 +537,7 @@ class NameChecker(_BasicChecker):
                     and not utils.get_node_first_ancestor_of_type(
                         node, (nodes.For, nodes.While)
                     )
+                    and not _is_in_main_block(node)
                 ):
                     if not self._meets_exception_for_non_consts(
                         inferred_assign_type, node.name
@@ -525,9 +554,13 @@ class NameChecker(_BasicChecker):
                     # Do the exclusive assignment analysis on attrs, not iattrs.
                     # iattrs locations could be anywhere (inference result).
                     attrs = tuple(node.frame().getattr(node.name))
-                    if len(attrs) > 1 and all(
-                        astroid.are_exclusive(*combo)
-                        for combo in itertools.combinations(attrs, 2)
+                    if (
+                        not _is_in_main_block(node)
+                        and len(attrs) > 1
+                        and all(
+                            astroid.are_exclusive(*combo)
+                            for combo in itertools.combinations(attrs, 2)
+                        )
                     ):
                         node_type = "const"
                     if not self._meets_exception_for_non_consts(

--- a/tests/checkers/base/unittest_multi_naming_style.py
+++ b/tests/checkers/base/unittest_multi_naming_style.py
@@ -213,4 +213,3 @@ class TestMultiNamingStyle(CheckerTestCase):
         )
         with self.assertAddsMessages(message):
             self.walk(module)
-

--- a/tests/checkers/base/unittest_multi_naming_style.py
+++ b/tests/checkers/base/unittest_multi_naming_style.py
@@ -168,3 +168,49 @@ class TestMultiNamingStyle(CheckerTestCase):
                 self.checker.visit_functiondef(func)
             if func:
                 self.checker.leave_module(func.root)
+
+    def test_main_block_variable_does_not_require_const(self) -> None:
+        module = astroid.parse(
+            """
+        def main() -> int:
+            return 0
+
+        if __name__ == '__main__':
+            exit_code = main()
+            raise SystemExit(exit_code)
+        """,
+            "test_module",
+        )
+        with self.assertNoMessages():
+            self.walk(module)
+
+    def test_main_block_variable_invalid_name_raises_variable_warning(self) -> None:
+        module = astroid.parse(
+            """
+        def main() -> int:
+            return 0
+
+        if __name__ == '__main__':
+            exitCode = main()
+            raise SystemExit(exitCode)
+        """,
+            "test_module",
+        )
+        assign_name = module.body[1].body[0].targets[0]
+        message = MessageTest(
+            "invalid-name",
+            node=assign_name,
+            args=(
+                "Variable",
+                "exitCode",
+                "snake_case naming style",
+            ),
+            confidence=HIGH,
+            line=6,
+            col_offset=4,
+            end_line=6,
+            end_col_offset=12,
+        )
+        with self.assertAddsMessages(message):
+            self.walk(module)
+


### PR DESCRIPTION
Fixes #10766

## What & Why
Variables assigned inside an `if __name__ == '__main__':` block were previously classified as module-level constants because `node.frame()` resolves to `nodes.Module`. This caused Pylint to emit `C0103: Constant name "exit_code" doesn't conform to UPPER_CASE naming style (invalid-name)` on local runtime variables that are not intended to be constants.

## Fix
- Added `_is_in_main_block(node)` helper in `pylint/checkers/base/name_checker/checker.py` to identify assignments located inside `if __name__ == '__main__':` (or `__main__ == __name__`) guards.
- Excluded nodes inside `__main__` guards from constant naming checks in `visit_assignname()`, allowing them to be evaluated against standard variable naming style (`variable-rgx` / snake_case).
- Added newsfragment in `doc/whatsnew/fragments/10766.false_positive`.

## How This Was Tested

| Test Suite | Command | Outcome |
| :--- | :--- | :--- |
| Main block snake_case (valid) | `pytest tests/checkers/base/unittest_multi_naming_style.py` | Pass (no messages) |
| Main block CamelCase (invalid) | `pytest tests/checkers/base/unittest_multi_naming_style.py` | Pass (raises `Variable` invalid-name) |
| Full name checker suite | `pytest tests/checkers/base/unittest_name_preset.py tests/checkers/base/unittest_multi_naming_style.py` | Pass (100%) |

## Scope & Risks
- **Scope**: Only applies to module-level assignments guarded by `__name__ == '__main__'`. Standard top-level module constants outside main blocks remain subject to constant naming rules.
