### PR TITLE
Fix false positive `unreachable` after instantiating `_sitebuiltins.Quitter`

### DIFF
--- a/doc/whatsnew/fragments/11310.false_positive
+++ b/doc/whatsnew/fragments/11310.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for :ref:`unreachable` on the statement following an
+instantiation of ``_sitebuiltins.Quitter`` (the class of the ``exit`` and
+``quit`` builtins). Only calling the instance terminates, not creating it.
+
+Closes #11310

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2223,6 +2223,10 @@ def is_terminating_func(node: nodes.Call) -> bool:
         return False
 
     for inferred in inferred_funcs:
+        if isinstance(inferred, nodes.ClassDef):
+            # Instantiating a class never terminates, even if the class is
+            # ``_sitebuiltins.Quitter`` (``exit``/``quit`` are instances of it).
+            continue
         if hasattr(inferred, "qname") and inferred.qname() in TERMINATING_FUNCS_QNAMES:
             return True
         match inferred:

--- a/tests/functional/u/unreachable.py
+++ b/tests/functional/u/unreachable.py
@@ -105,3 +105,13 @@ async def func15():
     coro = inner()
     print("reachable")
     await coro
+
+
+def func_quitter_instantiation():
+    """Instantiating ``_sitebuiltins.Quitter`` does not exit, only calling it does."""
+    import _sitebuiltins  # pylint: disable=import-outside-toplevel
+
+    quitter = _sitebuiltins.Quitter("exit", "")
+    print(quitter)
+    quitter()
+    print("unreachable")  # [unreachable]

--- a/tests/functional/u/unreachable.txt
+++ b/tests/functional/u/unreachable.txt
@@ -10,3 +10,4 @@ unreachable:75:4:75:15:func11:Unreachable code:INFERENCE
 unreachable:81:4:81:15:func12:Unreachable code:INFERENCE
 unreachable:90:4:90:24:func13:Unreachable code:INFERENCE
 unreachable:98:4:98:24:func14:Unreachable code:INFERENCE
+unreachable:117:4:117:24:func_quitter_instantiation:Unreachable code:INFERENCE


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | :bug: Bug fix |
| | :sparkles: New feature |
| | :hammer: Refactoring |
| | :scroll: Docs |

## Description

`utils.is_terminating_func` matched every callee whose qualified name is `_sitebuiltins.Quitter`. That is right for `exit()` / `quit()` (the builtins are instances of `Quitter`), but it also matched the `Quitter` class itself, so `_sitebuiltins.Quitter("exit", "")` was treated as if the program exited there and the next statement was reported as `unreachable` (three times in the stdlib's `_pyrepl/simple_interact.py`, once per entry of its `REPL_COMMANDS` dict).

Skip `ClassDef` results in `is_terminating_func`: instantiating a class does not terminate. Calling the resulting instance still does, which the new functional test covers.

Closes #11310