### PR TITLE
Fix false positive `bad-string-format-type` for subclasses of the builtin types

### DIFF
--- a/doc/whatsnew/fragments/11315.false_positive
+++ b/doc/whatsnew/fragments/11315.false_positive
@@ -1,0 +1,5 @@
+Fix false positives for :ref:`bad-string-format-type` when the argument is an
+instance of a subclass of ``int``, ``float`` or ``str``, such as ``bool`` or an
+``IntEnum`` member formatted with ``%d``.
+
+Closes #11315

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -227,15 +227,16 @@ def arg_matches_format_type(
         # All types can be printed with %s, %r and %a
         return True
     if isinstance(arg_type, astroid.Instance):
-        match arg_type.pytype():
-            case "builtins.str":
-                return format_type == "c"
-            case "builtins.float":
-                # ``i`` and ``u`` accept a float at runtime (truncated like ``d``)
-                return format_type in "diueEfFgGn%"
-            case "builtins.int":
-                # Integers allow all types
-                return True
+        # Subclasses behave like their builtin base: ``bool`` and ``IntEnum``
+        # members format like ``int``, a ``float`` subclass like ``float``.
+        if arg_type.is_subtype_of("builtins.str"):
+            return format_type == "c"
+        if arg_type.is_subtype_of("builtins.int"):
+            # Integers allow all types
+            return True
+        if arg_type.is_subtype_of("builtins.float"):
+            # ``i`` and ``u`` accept a float at runtime (truncated like ``d``)
+            return format_type in "diueEfFgGn%"
         return False
     return True
 

--- a/tests/functional/b/bad_string_format_type.py
+++ b/tests/functional/b/bad_string_format_type.py
@@ -54,3 +54,22 @@ def test_format(my_input_value, my_other_input_value):
     print("%d %s" % (my_input_value, my_other_input_value))
     to_be_formatted = (my_input_value, my_other_input_value)
     print("%d %s" % to_be_formatted)
+
+
+# Subclasses of the builtin types format like their base type
+# pylint: disable=wrong-import-position, missing-class-docstring, expression-not-assigned
+import enum
+
+
+class Color(enum.IntEnum):
+    RED = 1
+
+
+class MyFloat(float):
+    pass
+
+
+"%i" % True
+"%d %x" % (Color.RED, Color.RED)
+"%f %d" % (MyFloat(1.5), MyFloat(1.5))
+"%x %s" % (MyFloat(1.5), "a")  # [bad-string-format-type]

--- a/tests/functional/b/bad_string_format_type.txt
+++ b/tests/functional/b/bad_string_format_type.txt
@@ -8,3 +8,4 @@ bad-string-format-type:38:0:38:23::Argument 'builtins.list' does not match forma
 bad-string-format-type:41:0:41:11::Argument 'builtins.str' does not match format type 'd':UNDEFINED
 bad-string-format-type:42:0:42:22::Argument 'builtins.str' does not match format type 'd':UNDEFINED
 bad-string-format-type:46:0:46:29::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:75:0:75:29::Argument 'functional.b.bad_string_format_type.MyFloat' does not match format type 'x':UNDEFINED


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | :bug: Bug fix |
| | :sparkles: New feature |
| | :hammer: Refactoring |
| | :scroll: Docs |

## Description

`arg_matches_format_type` compared `arg_type.pytype()` exactly with `builtins.int` / `builtins.float` / `builtins.str`, so instances of subclasses never matched: `bool`, `IntEnum` members and user subclasses of `float`/`int` were reported for `%d`, `%i`, `%x`, `%f`, ... although they format fine at runtime (the stdlib's `curses/has_key.py` formats two bools with `%i`).

Use `is_subtype_of` so a subclass behaves like its builtin base. The order of the checks is str, int, float (`bool` is an `int`, nothing is both). Real mismatches keep being reported, including for subclass instances (`"%x %s" % (MyFloat(1.5), "a")` in the functional test).

This is the remaining part of #11147, whose `%i`/`%u`/`%a` half was fixed in #11150.

Closes #11315