### PR TITLE
Flag assertEqual and assertNotEqual between two constants in W1503

### DIFF
--- a/doc/data/messages/r/redundant-unittest-assert/bad.py
+++ b/doc/data/messages/r/redundant-unittest-assert/bad.py
@@ -4,3 +4,4 @@ import unittest
 class DummyTestCase(unittest.TestCase):
     def test_dummy(self):
         self.assertTrue("foo")  # [redundant-unittest-assert]
+        self.assertEqual(5, 5)  # [redundant-unittest-assert]

--- a/doc/data/messages/r/redundant-unittest-assert/details.rst
+++ b/doc/data/messages/r/redundant-unittest-assert/details.rst
@@ -1,4 +1,5 @@
-Directly asserting a string literal will always pass. The solution is to
-test something that could fail, or not assert at all.
+Directly asserting a string literal will always pass, and comparing two
+literals has an outcome that is already fixed by the source. The solution
+is to test something that could fail, or not assert at all.
 
 For assertions using ``assert`` there are similar messages: :ref:`assert-on-string-literal` and :ref:`assert-on-tuple`.

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -1105,7 +1105,8 @@ Stdlib checker Messages
 :redundant-unittest-assert (W1503): *Redundant use of %s with constant value %r*
   The first argument of assertTrue and assertFalse is a condition. If a
   constant is passed as parameter, that condition will be always true. In this
-  case a warning should be emitted.
+  case a warning should be emitted. The same applies to assertEqual and
+  assertNotEqual when both compared values are constants.
 :bad-thread-instantiation (W1506): *threading.Thread needs the target function*
   The warning is emitted when a threading.Thread class is instantiated without
   the target function being passed as a kwarg or as a second argument. By

--- a/doc/whatsnew/fragments/11321.false_negative
+++ b/doc/whatsnew/fragments/11321.false_negative
@@ -1,0 +1,4 @@
+``redundant-unittest-assert`` now also flags ``assertEqual`` and ``assertNotEqual``
+when both compared values are constants, e.g. ``self.assertEqual(5, 5)``.
+
+Closes #11321

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -585,7 +585,8 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             "The first argument of assertTrue and assertFalse is "
             "a condition. If a constant is passed as parameter, that "
             "condition will be always true. In this case a warning "
-            "should be emitted.",
+            "should be emitted. The same applies to assertEqual and "
+            "assertNotEqual when both compared values are constants.",
         ),
         "W1506": (
             "threading.Thread needs the target function",
@@ -892,15 +893,27 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             )
 
     def _check_redundant_assert(self, node: nodes.Call, infer: InferenceResult) -> None:
+        if not isinstance(infer, astroid.BoundMethod):
+            return
         if (
-            isinstance(infer, astroid.BoundMethod)
-            and node.args
+            node.args
             and isinstance(node.args[0], nodes.Const)
             and infer.name in {"assertTrue", "assertFalse"}
         ):
             self.add_message(
                 "redundant-unittest-assert",
                 args=(infer.name, node.args[0].value),
+                node=node,
+            )
+        elif (
+            len(node.args) > 1
+            and isinstance(node.args[0], nodes.Const)
+            and isinstance(node.args[1], nodes.Const)
+            and infer.name in {"assertEqual", "assertNotEqual"}
+        ):
+            self.add_message(
+                "redundant-unittest-assert",
+                args=(infer.name, (node.args[0].value, node.args[1].value)),
                 node=node,
             )
 

--- a/tests/functional/r/redundant_unittest_assert.py
+++ b/tests/functional/r/redundant_unittest_assert.py
@@ -41,3 +41,40 @@ class RegressionWithArgs(unittest.TestCase):
 
     def test(self):
         self.run()
+
+
+@unittest.skip("don't run this")
+class ConstantComparisons(unittest.TestCase):
+    '''assertEqual and assertNotEqual have a fixed outcome when both operands are constants.'''
+
+    def test_constants(self):
+        # +1:[redundant-unittest-assert]
+        self.assertEqual(5, 5)
+        # +1:[redundant-unittest-assert]
+        self.assertEqual(5, 6)
+        # +1:[redundant-unittest-assert]
+        self.assertNotEqual('a', 'a', 'with a message')
+        # +1:[redundant-unittest-assert]
+        self.assertEqual(None, None)
+
+    def test_runtime_values(self):
+        some_var = 5
+        self.assertEqual(some_var, 5)
+        self.assertNotEqual(5, some_var)
+
+    def test_unsupported_operands(self):
+        self.assertEqual([1], [1])
+        self.assertEqual((1,), (1,))
+        self.assertEqual(1 + 1, 2)
+        self.assertIs(5, 5)
+        self.assertEqual(first=5, second=5)
+
+
+class NotATestCase:
+    '''Methods that only share a name with unittest assertions are left alone.'''
+
+    def assertEqual(self, first, second):  # pylint: disable=invalid-name
+        return first == second
+
+    def check(self):
+        self.assertEqual(5, 5)

--- a/tests/functional/r/redundant_unittest_assert.txt
+++ b/tests/functional/r/redundant_unittest_assert.txt
@@ -4,3 +4,7 @@ redundant-unittest-assert:26:8:26:39:Tests.test_something:Redundant use of asser
 redundant-unittest-assert:28:8:28:41:Tests.test_something:Redundant use of assertFalse with constant value False:UNDEFINED
 redundant-unittest-assert:30:8:30:40:Tests.test_something:Redundant use of assertFalse with constant value None:UNDEFINED
 redundant-unittest-assert:32:8:32:36:Tests.test_something:Redundant use of assertTrue with constant value 0:UNDEFINED
+redundant-unittest-assert:52:8:52:30:ConstantComparisons.test_constants:Redundant use of assertEqual with constant value (5, 5):UNDEFINED
+redundant-unittest-assert:54:8:54:30:ConstantComparisons.test_constants:Redundant use of assertEqual with constant value (5, 6):UNDEFINED
+redundant-unittest-assert:56:8:56:55:ConstantComparisons.test_constants:Redundant use of assertNotEqual with constant value ('a', 'a'):UNDEFINED
+redundant-unittest-assert:58:8:58:36:ConstantComparisons.test_constants:Redundant use of assertEqual with constant value (None, None):UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`redundant-unittest-assert` only looks at the first argument of `assertTrue` and
`assertFalse`, so `self.assertEqual(5, 5)` is never reported.

The check does not evaluate that argument today: `assertTrue(True)` and `assertTrue(0)`
are both flagged, and the functional test pins both. The rule is that the outcome is
fixed by the source, not that the assertion passes. `assertEqual` and `assertNotEqual`
now follow the same rule when both of the first two positional arguments are `Const`.

Requiring `Const` keeps the check syntactic and leaves the awkward cases out on its own:
containers are `List` / `Tuple` / `Set` / `Dict`, and `1 + 1`, `-1`, `f"a"` and
`float("nan")` are `BinOp` / `UnaryOp` / `JoinedStr` / `Call`. Nothing is evaluated, so
cross-type equality such as `1 == True` never has to be decided. `assertIs` stays out
because identity between equal literals is implementation defined. A custom
`addTypeEqualityFunc` could in principle make a constant comparison non-deterministic,
but the comparators unittest registers itself only change the failure message.

The message template is unchanged and the pair of values is passed to it, so the output
reads `Redundant use of assertEqual with constant value (5, 5)`. Reporting only the first
operand would be misleading for `assertEqual(5, 6)`, but I can reword it if you prefer.

Over CPython's own `Lib/test` this adds 58 messages, mostly in tests whose subject is the
compiler, such as `assertEqual(0x0, 0)` in `test_int_literal.py`. Those are correct, and
`comparison-of-constants` already takes the same position on `0xff == 255`, but that genre
is common there and rare elsewhere. `test_mmap.py` shows the other side: it uses
`self.assertEqual(0, 1)` as a hand-rolled `fail()`.

Tests cover the new positives, and negatives for runtime values, containers, folded
expressions, `assertIs`, the keyword form, and a non-`TestCase` class defining
`assertEqual`.

Closes #11321

## Tests

- `pytest "tests/test_functional.py::test_functional[redundant_unittest_assert]" doc/test_messages_documentation.py -q`
- `pytest tests/checkers -q`
- `pytest tests/ -q` (2167 passed; two pre-existing Windows-only failures excluded, they
  reproduce identically on an unmodified checkout)
- `pre-commit run --files <changed files>` (ruff, black, isort, pylint, mypy, rstcheck,
  codespell)
