### PR TITLE
Count properties and descriptors as public methods in too-few-public-methods

### DIFF
--- a/doc/whatsnew/fragments/10348.bugfix
+++ b/doc/whatsnew/fragments/10348.bugfix
@@ -1,0 +1,3 @@
+False positive ``too-few-public-methods`` on property function calls and descriptors
+
+Closes #10348

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -13,8 +13,9 @@ from typing import TYPE_CHECKING
 
 from astroid import nodes
 
+from astroid import nodes, objects
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import is_enum, only_required_for_messages
+from pylint.checkers.utils import is_enum, only_required_for_messages, safe_infer
 from pylint.interfaces import HIGH
 from pylint.typing import MessageDefinitionTuple
 
@@ -240,6 +241,21 @@ def _count_methods_in_class(node: nodes.ClassDef) -> int:
     for method in node.mymethods():
         if SPECIAL_OBJ.search(method.name) and method.name != "__init__":
             all_methods += 1
+
+    # Count public attributes that are properties or descriptors
+    for item in node.body:
+        if isinstance(item, nodes.Assign) and len(item.targets) == 1:
+            target = item.targets[0]
+            if isinstance(target, nodes.AssignName) and not target.name.startswith("_"):
+                inferred = safe_infer(item.value)
+                if isinstance(inferred, objects.Property):
+                    all_methods += 1
+                elif inferred:
+                    try:
+                        if inferred.getattr("__get__"):
+                            all_methods += 1
+                    except Exception:
+                        pass
     return all_methods
 
 

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -11,9 +11,8 @@ from collections import defaultdict
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
-from astroid import nodes
-
 from astroid import nodes, objects
+
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import is_enum, only_required_for_messages, safe_infer
 from pylint.interfaces import HIGH

--- a/tests/functional/t/too/too_few_public_methods.py
+++ b/tests/functional/t/too/too_few_public_methods.py
@@ -47,3 +47,34 @@ class DumbList:
 
     def __getitem__(self, index):
         return self._list[index]
+
+
+class PropertyCalls:
+    """Properties built via a direct ``property(...)`` call still count."""
+    id = property(lambda self: None)
+    name = property(lambda self: None)
+
+
+def make_property():
+    def getter(_self):
+        pass
+
+    return property(getter)
+
+
+class PropertyFactory:
+    """Properties returned from a helper function still count."""
+    id = make_property()
+    name = make_property()
+
+
+class Descriptor: # [too-few-public-methods]
+    """A data descriptor with a single dunder method: still too few."""
+    def __get__(self, instance, owner=None):
+        pass
+
+
+class Descriptors:
+    """Descriptor instances used as class attributes still count."""
+    id = Descriptor()
+    name = Descriptor()

--- a/tests/functional/t/too/too_few_public_methods.txt
+++ b/tests/functional/t/too/too_few_public_methods.txt
@@ -1,1 +1,2 @@
 too-few-public-methods:7:0:7:10:Aaaa:Too few public methods (1/2):UNDEFINED
+too-few-public-methods:71:0:71:16:Descriptor:Too few public methods (1/2):UNDEFINED


### PR DESCRIPTION
Closes #10348