### PR TITLE
Narrow superfluous-parens suppression to 'not' and pre-'in' contexts

### DIFF
--- a/doc/whatsnew/fragments/10084.bugfix
+++ b/doc/whatsnew/fragments/10084.bugfix
@@ -1,0 +1,3 @@
+False negative ``superfluous-parens`` when around two conditional and an ``and``
+
+Closes #10084

--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -364,7 +364,9 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
                     # The empty tuple () is always accepted.
                     if i == start + 2:
                         return
-                    if found_and_or:
+                    if found_and_or and (
+                        keyword_token == "not" or tokens[i + 1].string == "in"
+                    ):
                         return
                     if keyword_token == "in":
                         # Parentheses around a tuple after ``in`` are required, so


### PR DESCRIPTION
Closes #10084