### PR TITLE
Skip the PR primer when the branch does not contain the primed 'main'

### DIFF
--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -22,14 +22,46 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  primer-comment:
+  # The run skips itself when the branch does not contain the commit the 'main'
+  # output was produced from, and a skipped job still makes for a successful
+  # workflow, so there is nothing to comment on and no artifact to download.
+  check-output:
     # Skip job if the workflow failed
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has-output: ${{ steps.check.outputs.has-output }}
+    steps:
+      - name: Check the run produced an output to compare
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            const hasOutput = artifacts.data.artifacts.some((artifact) =>
+              artifact.name === 'pr_number'
+            );
+            if (!hasOutput) {
+              core.notice("The primer did not run, there is nothing to comment.")
+            }
+            core.setOutput("has-output", hasOutput)
+
+  primer-comment:
+    needs: check-output
+    if: needs.check-output.outputs.has-output == 'true'
     name: Run
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -35,6 +35,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       has-output: ${{ steps.check.outputs.has-output }}
+      skipped: ${{ steps.check.outputs.skipped }}
     steps:
       - name: Check the run produced an output to compare
         id: check
@@ -46,13 +47,84 @@ jobs:
                repo: context.repo.repo,
                run_id: ${{ github.event.workflow_run.id }},
             });
-            const hasOutput = artifacts.data.artifacts.some((artifact) =>
-              artifact.name === 'pr_number'
-            );
+            const names = artifacts.data.artifacts.map((artifact) => artifact.name);
+            const hasOutput = names.includes('pr_number');
+            const skipped = names.includes('primer_skipped');
             if (!hasOutput) {
-              core.notice("The primer did not run, there is nothing to comment.")
+              core.notice("The primer did not run, there is nothing to compare.")
             }
             core.setOutput("has-output", hasOutput)
+            core.setOutput("skipped", skipped)
+
+  # The primer skipped this branch because it does not contain the commit on
+  # 'main' its output would be compared against. Say so where the author will
+  # see it: they only need to press 'Update branch'.
+  suggest-update:
+    needs: check-output
+    if: needs.check-output.outputs.skipped == 'true'
+    name: Suggest an update
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download the reason for skipping
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            const [marker] = artifacts.data.artifacts.filter((artifact) =>
+              artifact.name === 'primer_skipped'
+            );
+            const downloaded = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: marker.id,
+               archive_format: "zip",
+            });
+            fs.writeFileSync('primer_skipped.zip', Buffer.from(downloaded.data));
+      - name: Unzip the reason for skipping
+        run: unzip primer_skipped.zip
+      - name: Ask for the branch to be updated
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const mainSha = fs.readFileSync('main_sha.txt', { encoding: 'utf8' }).trim();
+            const prNumber = parseInt(fs.readFileSync('pr_number.txt', { encoding: 'utf8' }));
+            // An invisible marker so the next run can recognize its own comment.
+            // Asking once is enough: only ask again if something was said since.
+            const marker = '<!-- primer-skipped -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const lastOwnComment = comments.filter((comment) =>
+              comment.user.login === 'github-actions[bot]'
+            ).pop();
+            if (lastOwnComment && lastOwnComment.body.includes(marker)) {
+              core.notice("The branch was already asked to be updated, not asking again.")
+              return
+            }
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${marker}\n🤖 **The primer did not run on this pull request.** 🤖\n\n` +
+                `It compares the branch against the output of the last successful run ` +
+                `on \`main\`, at ${mainSha}, and this branch does not contain that ` +
+                `commit yet — so the comparison would credit this pull request with ` +
+                `everything that landed on \`main\` in between.\n\n` +
+                `Press **Update branch** below (or rebase) and the primer will run on ` +
+                `the next push.`
+            });
 
   primer-comment:
     needs: check-output

--- a/.github/workflows/primer_comment.yaml
+++ b/.github/workflows/primer_comment.yaml
@@ -118,10 +118,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `${marker}\n🤖 **The primer did not run on this pull request.** 🤖\n\n` +
-                `It compares the branch against the output of the last successful run ` +
-                `on \`main\`, at ${mainSha}, and this branch does not contain that ` +
-                `commit yet — so the comparison would credit this pull request with ` +
-                `everything that landed on \`main\` in between.\n\n` +
+                `It compares this branch against the output of the last successful run ` +
+                `on \`main\`, at ${mainSha}, and the branch does not contain that ` +
+                `commit yet. Every message \`main\` gained in between would look ` +
+                `removed by this pull request, and every one it fixed would look added: ` +
+                `the comparison would read as a revert of \`main\`.\n\n` +
                 `Press **Update branch** below (or rebase) and the primer will run on ` +
                 `the next push.`
             });

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -34,8 +34,9 @@ permissions:
 jobs:
   # The primer compares this branch against the output of the last successful
   # run on 'main'. If the branch does not contain the commit that output was
-  # produced from, the comparison also shows everything that happened on 'main'
-  # in between, which is noise the author cannot act on. Rather than merge
+  # produced from, then it is missing what 'main' has: every message 'main'
+  # gained in between looks removed by the branch, every one it fixed looks
+  # added, and the comparison reads as a revert of 'main'. Rather than merge
   # 'main' in and prime a tree nobody wrote, skip the run and ask for a rebase.
   check-main-baseline:
     name: Check the branch contains the primed 'main'
@@ -80,7 +81,7 @@ jobs:
           then
             echo "up-to-date=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice ::Skipping the primer: this branch does not contain $MAIN_SHA, the commit the 'main' output it would be compared against was produced from. Merge or rebase on 'main' to get a run."
+            echo "::notice ::Skipping the primer: this branch does not contain $MAIN_SHA, the commit the 'main' output it would be compared against was produced from, so the comparison would read as a revert of 'main'. Merge or rebase on 'main' to get a run."
             echo "up-to-date=false" >> "$GITHUB_OUTPUT"
             echo "The primer did not run: this branch does not contain \`$MAIN_SHA\`, the commit on 'main' its output would have been compared against." >> "$GITHUB_STEP_SUMMARY"
             echo "$MAIN_SHA" > main_sha.txt

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -82,9 +82,23 @@ jobs:
           else
             echo "::notice ::Skipping the primer: this branch does not contain $MAIN_SHA, the commit the 'main' output it would be compared against was produced from. Merge or rebase on 'main' to get a run."
             echo "up-to-date=false" >> "$GITHUB_OUTPUT"
+            echo "The primer did not run: this branch does not contain \`$MAIN_SHA\`, the commit on 'main' its output would have been compared against." >> "$GITHUB_STEP_SUMMARY"
+            echo "$MAIN_SHA" > main_sha.txt
+            echo "$PR_NUMBER" > pr_number.txt
           fi
         env:
           MAIN_SHA: ${{ steps.main-run.outputs.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+      # The comment job needs to know which PR to nudge, and why. It cannot ask
+      # this job: 'workflow_run' only gives it the run, not the job outputs.
+      - name: Upload the reason for skipping
+        if: steps.compare.outputs.up-to-date != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: primer_skipped
+          path: |
+            main_sha.txt
+            pr_number.txt
 
   run-primer:
     name: Run / ${{ matrix.python-version }} / batch index ${{ matrix.batchIdx }}

--- a/.github/workflows/primer_run_pr.yaml
+++ b/.github/workflows/primer_run_pr.yaml
@@ -32,8 +32,64 @@ permissions:
   contents: read
 
 jobs:
+  # The primer compares this branch against the output of the last successful
+  # run on 'main'. If the branch does not contain the commit that output was
+  # produced from, the comparison also shows everything that happened on 'main'
+  # in between, which is noise the author cannot act on. Rather than merge
+  # 'main' in and prime a tree nobody wrote, skip the run and ask for a rebase.
+  check-main-baseline:
+    name: Check the branch contains the primed 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      up-to-date: ${{ steps.compare.outputs.up-to-date }}
+      main-run-id: ${{ steps.main-run.outputs.id }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Find the last successful run on 'main'
+        id: main-run
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: ".github/workflows/primer_run_main.yaml",
+              status: "success"
+            });
+            const lastRunMain = runs.data.workflow_runs.reduce(function(prev, current) {
+                return (prev.run_number > current.run_number) ? prev : current
+            })
+            console.log("Last run on main:")
+            console.log(lastRunMain.html_url)
+            core.setOutput("id", lastRunMain.id)
+            core.setOutput("sha", lastRunMain.head_sha)
+      - name: Compare the branch with the primed 'main'
+        id: compare
+        run: |
+          if ! git cat-file -e "${MAIN_SHA}^{commit}" 2> /dev/null
+          then
+            echo "::warning ::$MAIN_SHA is not in this repository (was 'main' force-pushed?), priming anyway"
+            echo "up-to-date=true" >> "$GITHUB_OUTPUT"
+          elif git merge-base --is-ancestor "$MAIN_SHA" HEAD
+          then
+            echo "up-to-date=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice ::Skipping the primer: this branch does not contain $MAIN_SHA, the commit the 'main' output it would be compared against was produced from. Merge or rebase on 'main' to get a run."
+            echo "up-to-date=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          MAIN_SHA: ${{ steps.main-run.outputs.sha }}
+
   run-primer:
     name: Run / ${{ matrix.python-version }} / batch index ${{ matrix.batchIdx }}
+    needs: check-main-baseline
+    if: needs.check-main-baseline.outputs.up-to-date == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -45,6 +101,9 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The default merge ref would prime the branch merged with the tip of
+          # 'main', which is not what the 'main' output was produced from.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
@@ -96,36 +155,21 @@ jobs:
 
       # Cache primer packages
       - name: Download last 'main' run info
-        id: download-main-run
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMIT_STRING_ARTIFACT: primer_commitstring_${{ matrix.python-version }}
+          MAIN_RUN_ID: ${{ needs.check-main-baseline.outputs.main-run-id }}
           OUTPUT_ARTIFACT:
             primer_output_main_${{ matrix.python-version }}_batch${{ matrix.batchIdx }}
         with:
-          # Return the commit as a bare string: the default JSON encoding would
-          # wrap it in double quotes, and those end up inside the ref name when
-          # the shell expands the environment variable holding it.
-          result-encoding: string
           script: |
-            const { COMMIT_STRING_ARTIFACT, OUTPUT_ARTIFACT } = process.env
+            const { COMMIT_STRING_ARTIFACT, MAIN_RUN_ID, OUTPUT_ARTIFACT } = process.env
             // Download 'main' pylint output
             const fs = require('fs');
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: ".github/workflows/primer_run_main.yaml",
-              status: "success"
-            });
-            const lastRunMain = runs.data.workflow_runs.reduce(function(prev, current) {
-                return (prev.run_number > current.run_number) ? prev : current
-            })
-            console.log("Last run on main:")
-            console.log(lastRunMain.html_url)
             const artifacts_main = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: lastRunMain.id,
+               run_id: Number(MAIN_RUN_ID),
             });
 
             // Get commitstring
@@ -149,7 +193,6 @@ jobs:
                archive_format: "zip",
             });
             fs.writeFileSync(`${OUTPUT_ARTIFACT}.zip`, Buffer.from(downloadWorkflowTwo.data));
-            return lastRunMain.head_sha;
       - name: Copy and unzip the commit string
         run: |
           unzip primer_commitstring_${{ matrix.python-version }}.zip
@@ -188,16 +231,6 @@ jobs:
         run: |
           . venv/bin/activate
           python tests/primer/__main__.py prepare --check
-
-      # Merge the 'main' commit of last successful run
-      - name: Pull 'main'
-        shell: bash
-        run: |
-          git config --global user.email "primer@example.com"
-          git config --global user.name "Pylint Primer"
-          git pull origin "${MAIN_RUN_REF}" --no-edit --no-commit --no-rebase
-        env:
-          MAIN_RUN_REF: ${{ steps.download-main-run.outputs.result }}
 
       # Run primer
       - name: Run pylint primer


### PR DESCRIPTION
## Type of Changes

|     | Type                 |
| --- | -------------------- |
| ✓   | :hammer: Refactoring |

## Description

The PR primer compares two trees that are not the same generation. It checks out
the *merge* of the branch with the current tip of `main` (the default ref for a
`pull_request` event), but downloads the output of the last successful run of
`Primer / Main`, which can be several commits older. Everything that landed on
`main` in between then shows up in the comparison as an effect of the pull
request.

On #11270 that was fourteen `assignment-from-no-return` entries under "Changed
messages", all of them #11210's better hints:

```diff
- Assigning result of a function call, where the function has no return
+ Assigning result of a function call, but 'add_column' returns None
```

Force the PR author to rebase / merge to get a primer run, where before we had one with extra noise in it.  My hope is that it's going to not be too much of a problem if we group merging together I think maintainer usually do that.

The second commit adds a nudge, so that a skipped run does not read like "the
primer found nothing": `Primer / Comment` says why it skipped, on the pull
request, one line above the **Update branch** button. It asks once — the comment
carries an invisible marker, and only asks again if something was said in
between.

Note the button itself only shows up for everyone once `allow_update_branch`
("Always suggest updating pull request branches", in Settings → General) is on
for the repository. It is off today.
