### PR TITLE
Fix unnecessary-direct-lambda-call when the lambda supplies a class-body scope

### DIFF
--- a/doc/whatsnew/fragments/9294.false_positive
+++ b/doc/whatsnew/fragments/9294.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``unnecessary-direct-lambda-call`` when a directly called
+lambda in a class body wraps a comprehension containing an assignment expression.
+PEP 572 makes that a ``SyntaxError`` without the lambda's scope, so following the
+message produced code that would not compile.
+
+Closes #9294

--- a/pylint/checkers/lambda_expressions.py
+++ b/pylint/checkers/lambda_expressions.py
@@ -100,7 +100,7 @@ class LambdaExpressionChecker(BaseChecker):
 
 
 def _lambda_scope_is_required(node: nodes.Call) -> bool:
-    """Whether inlining this directly called lambda would not compile.
+    """Whether removing this directly called lambda would not compile.
 
     A comprehension carrying an assignment expression is a SyntaxError when its
     containing scope is a class body (PEP 572). The lambda supplies a function
@@ -109,7 +109,7 @@ def _lambda_scope_is_required(node: nodes.Call) -> bool:
 
     Only a comprehension that would land in the class body itself counts. One
     nested inside a further lambda or function keeps a scope of its own after
-    the inlining, so the call around it is still reported.
+    the removal, so the call around it is still reported.
     """
     if not isinstance(node.frame(), nodes.ClassDef):
         return False

--- a/pylint/checkers/lambda_expressions.py
+++ b/pylint/checkers/lambda_expressions.py
@@ -12,6 +12,15 @@ from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.interfaces import HIGH
 
+# PEP 572 forbids an assignment expression inside a comprehension whose
+# containing scope is a class body, and every comprehension form is covered.
+COMPREHENSION_NODES = (
+    nodes.DictComp,
+    nodes.GeneratorExp,
+    nodes.ListComp,
+    nodes.SetComp,
+)
+
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
@@ -82,12 +91,39 @@ class LambdaExpressionChecker(BaseChecker):
 
     def visit_call(self, node: nodes.Call) -> None:
         """Check if lambda expression is called directly."""
-        if isinstance(node.func, nodes.Lambda):
+        if isinstance(node.func, nodes.Lambda) and not _lambda_scope_is_required(node):
             self.add_message(
                 "unnecessary-direct-lambda-call",
                 node=node,
                 confidence=HIGH,
             )
+
+
+def _lambda_scope_is_required(node: nodes.Call) -> bool:
+    """Whether inlining this directly called lambda would not compile.
+
+    A comprehension carrying an assignment expression is a SyntaxError when its
+    containing scope is a class body (PEP 572). The lambda supplies a function
+    scope in between, so removing it, which is exactly what the message advises,
+    turns working code into code that does not parse.
+
+    Only a comprehension that would land in the class body itself counts. One
+    nested inside a further lambda or function keeps a scope of its own after
+    the inlining, so the call around it is still reported.
+    """
+    if not isinstance(node.frame(), nodes.ClassDef):
+        return False
+    for comprehension in node.func.body.nodes_of_class(COMPREHENSION_NODES):
+        if not any(True for _ in comprehension.nodes_of_class(nodes.NamedExpr)):
+            continue
+        enclosing_scope = comprehension.parent
+        while enclosing_scope is not None and not isinstance(
+            enclosing_scope, (nodes.Lambda, nodes.FunctionDef)
+        ):
+            enclosing_scope = enclosing_scope.parent
+        if enclosing_scope is node.func:
+            return True
+    return False
 
 
 def register(linter: PyLinter) -> None:

--- a/tests/functional/u/unnecessary/unnecessary_direct_lambda_call.py
+++ b/tests/functional/u/unnecessary/unnecessary_direct_lambda_call.py
@@ -3,3 +3,29 @@
 
 y = (lambda x: x**2 + 2*x + 1)(a)  # [unnecessary-direct-lambda-call]
 y = max((lambda x: x**2)(a), (lambda x: x+1)(a))  # [unnecessary-direct-lambda-call,unnecessary-direct-lambda-call]
+
+
+class ClassBodyWalrus:  # pylint: disable=too-few-public-methods
+    """The lambda supplies the scope PEP 572 requires.
+
+    An assignment expression inside a comprehension is a SyntaxError when the
+    containing scope is a class body, so inlining these would not compile.
+    """
+
+    generator = (lambda: all((x := object()) is x for _ in range(1)))()
+    listcomp = (lambda: [(x := o) for o in range(1)])()
+    setcomp = (lambda: {(x := o) for o in range(1)})()
+    dictcomp = (lambda: {(x := o): o for o in range(1)})()
+
+    # Still reported: no comprehension, so the walrus is legal in a class body.
+    bare_walrus = (lambda: (x := 1))()  # [unnecessary-direct-lambda-call]
+    # Still reported: no assignment expression in the comprehension.
+    plain_comprehension = (lambda: [o + 1 for o in range(1)])()  # [unnecessary-direct-lambda-call]
+    # Still reported for both calls: after inlining the outer lambda, the
+    # comprehension is still inside the inner one, which keeps its own scope.
+    nested = (lambda: [(lambda: [(x := o) for o in range(1)])()])()  # [unnecessary-direct-lambda-call,unnecessary-direct-lambda-call]
+
+
+def outside_a_class_body():
+    """Only a class body carries the restriction."""
+    return (lambda: all((x := object()) is x for _ in range(1)))()  # [unnecessary-direct-lambda-call]

--- a/tests/functional/u/unnecessary/unnecessary_direct_lambda_call.txt
+++ b/tests/functional/u/unnecessary/unnecessary_direct_lambda_call.txt
@@ -1,3 +1,8 @@
 unnecessary-direct-lambda-call:4:4:4:33::Lambda expression called directly. Execute the expression inline instead.:HIGH
 unnecessary-direct-lambda-call:5:8:5:27::Lambda expression called directly. Execute the expression inline instead.:HIGH
 unnecessary-direct-lambda-call:5:29:5:47::Lambda expression called directly. Execute the expression inline instead.:HIGH
+unnecessary-direct-lambda-call:21:18:21:38:ClassBodyWalrus:Lambda expression called directly. Execute the expression inline instead.:HIGH
+unnecessary-direct-lambda-call:23:26:23:63:ClassBodyWalrus:Lambda expression called directly. Execute the expression inline instead.:HIGH
+unnecessary-direct-lambda-call:26:13:26:67:ClassBodyWalrus:Lambda expression called directly. Execute the expression inline instead.:HIGH
+unnecessary-direct-lambda-call:26:23:26:63:ClassBodyWalrus.<lambda>:Lambda expression called directly. Execute the expression inline instead.:HIGH
+unnecessary-direct-lambda-call:31:11:31:66:outside_a_class_body:Lambda expression called directly. Execute the expression inline instead.:HIGH


### PR DESCRIPTION
## Type of Changes

| | Type |
|---|---|
| ✓ | 🐛 Bug fix |

## Description

Closes #9294.

`unnecessary-direct-lambda-call` fired on a directly called lambda whose body holds a comprehension
containing an assignment expression, inside a class body. Doing what the message says produces code
that does not compile:

```python
class C:
    assert (lambda: all((x := object()) is x for _ in range(1)))()   # C3002
```

```
SyntaxError: assignment expression within a comprehension cannot be used in a class body
```

PEP 572 forbids that combination, and the lambda is what supplies the intervening function scope.

## Scope of the restriction

Checked each form rather than assuming, since the guard should be no wider than the rule:

```
genexp / listcomp / setcomp / dictcomp with a walrus, in a class body   SyntaxError
walrus without a comprehension, in a class body                        compiles
comprehension without a walrus, in a class body                        compiles
any of the above inside a function or at module level                  compiles
```

So the new helper suppresses only when the call's frame is a `ClassDef` and the lambda body holds a
comprehension containing a `NamedExpr`.

One case is deliberately still reported:

```python
class C:
    nested = (lambda: [(lambda: [(x := o) for o in range(1)])()])()
```

Inlining the outer lambda leaves the comprehension inside the inner one, which keeps a scope of its
own, so that compiles and both calls stay flagged. The helper checks that the comprehension's
nearest enclosing lambda or function is the called lambda itself, not something further in.

`isinstance` against concrete node types throughout, per `AGENTS.md`.

## Tests

Appended to `tests/functional/u/unnecessary/unnecessary_direct_lambda_call.py`: the four suppressed
comprehension forms, plus four that must still report (bare walrus, plain comprehension, the nested
lambda above, and the same construct in a function rather than a class body). Expected output
regenerated with `--update-functional-output`.

The file fails on `main` and passes with the change.

## Validation

```
pytest tests/test_functional.py -k test_functional     14 failed, 877 passed, 42 skipped
pylint pylint/checkers/lambda_expressions.py           10.00/10
pre-commit run --files <the four changed files>        all passed
```

The 14 failures are pre-existing. I ran the same selection on `main` with the change stashed and
diffed the failure lists: identical, same 14 names.

News fragment added at `doc/whatsnew/fragments/9294.false_positive`.