### PR TITLE
Emit deprecated-method for datetime.utcnow() on Python 3.12+

### DIFF
--- a/doc/whatsnew/fragments/6234.false_negative
+++ b/doc/whatsnew/fragments/6234.false_negative
@@ -1,0 +1,7 @@
+``deprecated-method`` is now emitted for ``datetime.datetime.utcnow()`` and
+``datetime.datetime.utcfromtimestamp()`` on Python 3.12 and above. Both were
+already listed as deprecated, but astroid's ``datetime`` brain extends the
+module with ``from _pydatetime import *`` on 3.12+, so inference reported the
+private implementation module and the check never matched.
+
+Refs #6234

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -301,6 +301,11 @@ DEPRECATED_METHODS: dict[int, DeprecationDict] = {
             "builtins.bool.__invert__",
             "datetime.datetime.utcfromtimestamp",
             "datetime.datetime.utcnow",
+            # On 3.12+ astroid's datetime brain extends the module with
+            # ``from _pydatetime import *``, so inference reports the private
+            # implementation module and the public names above never match.
+            "_pydatetime.datetime.utcfromtimestamp",
+            "_pydatetime.datetime.utcnow",
             "pkgutil.find_loader",
             "pkgutil.get_loader",
             "pty.master_open",

--- a/tests/functional/d/deprecated/deprecated_methods_py312.py
+++ b/tests/functional/d/deprecated/deprecated_methods_py312.py
@@ -1,0 +1,12 @@
+"""Test deprecated methods from Python 3.12."""
+# pylint: disable=missing-function-docstring
+
+import datetime
+
+
+def naive_now():
+    return datetime.datetime.utcnow()  # [deprecated-method]
+
+
+def naive_from_timestamp(timestamp):
+    return datetime.datetime.utcfromtimestamp(timestamp)  # [deprecated-method]

--- a/tests/functional/d/deprecated/deprecated_methods_py312.rc
+++ b/tests/functional/d/deprecated/deprecated_methods_py312.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/d/deprecated/deprecated_methods_py312.txt
+++ b/tests/functional/d/deprecated/deprecated_methods_py312.txt
@@ -1,0 +1,2 @@
+deprecated-method:8:11:8:37:naive_now:Using deprecated method utcnow():UNDEFINED
+deprecated-method:12:11:12:56:naive_from_timestamp:Using deprecated method utcfromtimestamp():UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`deprecated-method` never fires for `datetime.datetime.utcnow()` or `datetime.datetime.utcfromtimestamp()`, even though both have been listed in `DEPRECATED_METHODS` under `(3, 12, 0)` since they were deprecated in Python 3.12.

On 3.12+ `astroid`'s datetime brain extends the module with `from _pydatetime import *`, because the module was C-accelerated and the brain wants the Python source:

```python
# astroid/brain/brain_datetime.py
def datetime_transform() -> nodes.Module:
    """The datetime module was C-accelerated in Python 3.12, so use the
    Python source."""
    return AstroidBuilder(AstroidManager()).string_build("from _pydatetime import *")
```

So a call infers to a `BoundMethod` whose `qname()` is `_pydatetime.datetime.utcnow`, while `DeprecatedMixin.check_deprecated_method` compares `{inferred.qname(), func_name}` against the public dotted name. Those never match, and the entries are silently dead:

```pycon
>>> import astroid
>>> m = astroid.parse("import datetime\ndatetime.datetime.utcnow()")
>>> next(list(m.nodes_of_class(astroid.nodes.Call))[-1].func.infer()).qname()
'_pydatetime.datetime.utcnow'
```

Before, on Python 3.13:

```console
$ cat dep.py
import datetime
datetime.datetime.utcnow()
datetime.datetime.utcfromtimestamp(0)

$ pylint --persistent=n --disable=all --enable=deprecated-method dep.py
------------------------------------
Your code has been rated at 10.00/10
```

After:

```console
$ pylint --persistent=n --disable=all --enable=deprecated-method dep.py
************* Module dep
dep.py:2:0: W4902: Using deprecated method utcnow() (deprecated-method)
dep.py:3:0: W4902: Using deprecated method utcfromtimestamp() (deprecated-method)
```

This adds the private implementation names next to the public ones. The public names are kept deliberately: on Python 3.11 and earlier the brain is not registered (`PY312_PLUS`), and inference reports `datetime.datetime.utcnow` there. Listing a private implementation module has precedent in the codebase, `design_analysis.py` already refers to `_collections_abc.*` qnames for the same reason.

Scope is kept to the entries that are actually reachable. Some other multi-dotted entries such as `configparser.RawConfigParser.readfp` and `xml.etree.ElementTree.Element.getchildren` also do not emit, but that is a different situation: those methods were *removed* from the stdlib, so there is nothing to infer and `no-member` covers them. I left them alone.

The new functional test is gated with `min_pyver=3.12` and fails on `main` for the right reason, reporting both expected lines as missing. `pytest tests/` is green locally: 2145 passed, 306 skipped, 5 xfailed.

Refs #6234

This does not close #6234, which also asks for a warning on timezone-naive `datetime.now()` and on older `py-version` targets. That part needs a new check and a decision on whether it is on by default, so it seemed better kept separate from this one.
