### PR TITLE
Split mccabe --max-complexity into its own extension section

### DIFF
--- a/doc/exts/pylint_extensions.py
+++ b/doc/exts/pylint_extensions.py
@@ -17,6 +17,7 @@ import sphinx
 from sphinx.application import Sphinx
 
 from pylint.checkers import BaseChecker
+from pylint.checkers import initialize as initialize_checkers
 from pylint.constants import MAIN_CHECKER_NAME
 from pylint.lint import PyLinter
 from pylint.typing import MessageDefinitionTuple, OptionDict, ReportsCallable
@@ -58,6 +59,7 @@ def builder_inited(app: Sphinx | None) -> None:
         sys.exit("No Pylint extensions found?")
 
     linter = PyLinter()
+    initialize_checkers(linter)
     linter.load_plugin_modules(modules)
 
     extensions_doc = os.path.join(
@@ -85,9 +87,10 @@ def builder_inited(app: Sphinx | None) -> None:
         # Print checker documentation to stream
         by_checker = get_plugins_info(linter, doc_files)
         # Keep pylint core free of doc/exts imports.
-        from pylint_options import _get_options_anchor
+        from pylint_options import _colliding_checker_names, _get_options_anchor
 
         max_len = len(by_checker)
+        colliding = _colliding_checker_names(linter)
         for i, checker_information in enumerate(sorted(by_checker.items())):
             checker, information = checker_information
             j = -1
@@ -95,7 +98,9 @@ def builder_inited(app: Sphinx | None) -> None:
             if i == max_len - 1:
                 # Remove the \n\n at the end of the file
                 j = -3
-            options_anchor = _get_options_anchor(checker.name, information["module"])
+            options_anchor = _get_options_anchor(
+                checker.name, information["module"], colliding
+            )
             print(
                 checker.get_full_documentation(
                     msgs=information["msgs"],

--- a/doc/exts/pylint_extensions.py
+++ b/doc/exts/pylint_extensions.py
@@ -38,7 +38,9 @@ class _CheckerInfo(TypedDict):
 def builder_inited(app: Sphinx | None) -> None:
     """Output full documentation in ReST format for all extension modules."""
     # PACKAGE/docs/exts/pylint_extensions.py --> PACKAGE/
-    base_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    base_path = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
     # PACKAGE/ --> PACKAGE/pylint/extensions
     ext_path = os.path.join(base_path, "pylint", "extensions")
     modules = []
@@ -58,7 +60,9 @@ def builder_inited(app: Sphinx | None) -> None:
     linter = PyLinter()
     linter.load_plugin_modules(modules)
 
-    extensions_doc = os.path.join(base_path, "doc", "user_guide", "checkers", "extensions.rst")
+    extensions_doc = os.path.join(
+        base_path, "doc", "user_guide", "checkers", "extensions.rst"
+    )
     with open(extensions_doc, "w", encoding="utf-8") as stream:
         stream.write(get_rst_title("Optional checkers", "="))
         stream.write("""
@@ -74,7 +78,9 @@ def builder_inited(app: Sphinx | None) -> None:
             "by adding a ``load-plugins`` line to the ``MAIN`` "
             "section of your ``.pylintrc``, for example::\n"
         )
-        stream.write("\n    load-plugins=pylint.extensions.docparams,pylint.extensions.docstyle\n\n")
+        stream.write(
+            "\n    load-plugins=pylint.extensions.docparams,pylint.extensions.docstyle\n\n"
+        )
 
         # Print checker documentation to stream
         by_checker = get_plugins_info(linter, doc_files)
@@ -104,7 +110,9 @@ def builder_inited(app: Sphinx | None) -> None:
             )
 
 
-def get_plugins_info(linter: PyLinter, doc_files: dict[str, str]) -> dict[BaseChecker, _CheckerInfo]:
+def get_plugins_info(
+    linter: PyLinter, doc_files: dict[str, str]
+) -> dict[BaseChecker, _CheckerInfo]:
     by_checker: dict[BaseChecker, _CheckerInfo] = {}
     for checker in linter.get_checkers():
         if checker.name == MAIN_CHECKER_NAME:

--- a/doc/exts/pylint_extensions.py
+++ b/doc/exts/pylint_extensions.py
@@ -38,9 +38,7 @@ class _CheckerInfo(TypedDict):
 def builder_inited(app: Sphinx | None) -> None:
     """Output full documentation in ReST format for all extension modules."""
     # PACKAGE/docs/exts/pylint_extensions.py --> PACKAGE/
-    base_path = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    )
+    base_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     # PACKAGE/ --> PACKAGE/pylint/extensions
     ext_path = os.path.join(base_path, "pylint", "extensions")
     modules = []
@@ -60,9 +58,7 @@ def builder_inited(app: Sphinx | None) -> None:
     linter = PyLinter()
     linter.load_plugin_modules(modules)
 
-    extensions_doc = os.path.join(
-        base_path, "doc", "user_guide", "checkers", "extensions.rst"
-    )
+    extensions_doc = os.path.join(base_path, "doc", "user_guide", "checkers", "extensions.rst")
     with open(extensions_doc, "w", encoding="utf-8") as stream:
         stream.write(get_rst_title("Optional checkers", "="))
         stream.write("""
@@ -78,13 +74,13 @@ def builder_inited(app: Sphinx | None) -> None:
             "by adding a ``load-plugins`` line to the ``MAIN`` "
             "section of your ``.pylintrc``, for example::\n"
         )
-        stream.write(
-            "\n    load-plugins=pylint.extensions.docparams,"
-            "pylint.extensions.docstyle\n\n"
-        )
+        stream.write("\n    load-plugins=pylint.extensions.docparams,pylint.extensions.docstyle\n\n")
 
         # Print checker documentation to stream
         by_checker = get_plugins_info(linter, doc_files)
+        # Keep pylint core free of doc/exts imports.
+        from pylint_options import _get_options_anchor
+
         max_len = len(by_checker)
         for i, checker_information in enumerate(sorted(by_checker.items())):
             checker, information = checker_information
@@ -93,6 +89,7 @@ def builder_inited(app: Sphinx | None) -> None:
             if i == max_len - 1:
                 # Remove the \n\n at the end of the file
                 j = -3
+            options_anchor = _get_options_anchor(checker.name, information["module"])
             print(
                 checker.get_full_documentation(
                     msgs=information["msgs"],
@@ -101,14 +98,13 @@ def builder_inited(app: Sphinx | None) -> None:
                     doc=information["doc"],
                     module=information["module"],
                     show_options=False,
+                    options_anchor=options_anchor,
                 )[:j],
                 file=stream,
             )
 
 
-def get_plugins_info(
-    linter: PyLinter, doc_files: dict[str, str]
-) -> dict[BaseChecker, _CheckerInfo]:
+def get_plugins_info(linter: PyLinter, doc_files: dict[str, str]) -> dict[BaseChecker, _CheckerInfo]:
     by_checker: dict[BaseChecker, _CheckerInfo] = {}
     for checker in linter.get_checkers():
         if checker.name == MAIN_CHECKER_NAME:

--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -60,22 +60,29 @@ DYNAMICALLY_DEFINED_OPTIONS: dict[str, dict[str, str]] = {
 }
 
 
-_COLLIDING_EXTENSION_NAMES: frozenset[str] = frozenset({"design"})
+def _colliding_checker_names(linter: PyLinter) -> frozenset[str]:
+    """Names registered by more than one checker (core + extension reuse,
+    e.g. ``design`` / ``pylint.extensions.mccabe``).
+
+    Computed from the live
+    linter so future collisions are handled without hardcoding.
+    """
+    counts: dict[str, int] = {}
+    for checker in linter.get_checkers():
+        counts[checker.name] = counts.get(checker.name, 0) + 1
+    return frozenset(name for name, count in counts.items() if count > 1)
 
 
-def _get_colliding_extension_names() -> frozenset[str]:
-    """Return checker names that collide between core and extension registries."""
-    return _COLLIDING_EXTENSION_NAMES
-
-
-def _get_options_anchor(name: str, module: str | None) -> str:
+def _get_options_anchor(
+    name: str, module: str | None, colliding: frozenset[str]
+) -> str:
     """Return the ``-options`` anchor base for a checker.
 
     Non-colliding checkers keep ``{name}-options``. A colliding
     extension checker uses ``{module}-options`` so anchors stay in sync.
     The function is the only place ``f"{module}-options"`` is spelled.
     """
-    if module and name in _get_colliding_extension_names():
+    if module and name in colliding:
         return f"{module}-options"
     return f"{name}-options"
 
@@ -89,6 +96,7 @@ def _register_all_checkers_and_extensions(linter: PyLinter) -> None:
 def _get_all_options(linter: PyLinter) -> OptionsDataDict:
     """Get all options registered to a linter and return the data."""
     all_options: OptionsDataDict = defaultdict(list)
+    colliding = _colliding_checker_names(linter)
     for checker in sorted(linter.get_checkers()):
         for option_name, option_info in checker.options:
             changes_to_do = DYNAMICALLY_DEFINED_OPTIONS.get(option_name, {})
@@ -105,7 +113,7 @@ def _get_all_options(linter: PyLinter) -> OptionsDataDict:
             # their own section (``pylint.extensions.mccabe-options``) instead
             # of merging into the core ``design-options`` section (#9174).
             if is_extension:
-                anchor = _get_options_anchor(checker.name, module)
+                anchor = _get_options_anchor(checker.name, module, colliding)
                 key = anchor[: -len("-options")]
             else:
                 key = checker.name

--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -50,8 +50,7 @@ DYNAMICALLY_DEFINED_OPTIONS: dict[str, dict[str, str]] = {
         # backslash as an escape character, which would otherwise render as a
         # bare "t".
         "default": '"    "',
-        "help": "String used as indentation unit. This is usually "
-        '"    " (4 spaces) or "\\\\t" (1 tab).',  # noqa: RUF001
+        "help": 'String used as indentation unit. This is usually "    " (4 spaces) or "\\\\t" (1 tab).',  # noqa: RUF001
     },
     "py-version": {"default": "sys.version_info[:2]"},
     "spelling-dict": {
@@ -59,6 +58,26 @@ DYNAMICALLY_DEFINED_OPTIONS: dict[str, dict[str, str]] = {
         "help": "Spelling dictionary name. Available dictionaries depends on your local enchant installation",
     },
 }
+
+
+_COLLIDING_EXTENSION_NAMES: frozenset[str] = frozenset({"design"})
+
+
+def _get_colliding_extension_names() -> frozenset[str]:
+    """Return checker names that collide between core and extension registries."""
+    return _COLLIDING_EXTENSION_NAMES
+
+
+def _get_options_anchor(name: str, module: str | None) -> str:
+    """Return the ``-options`` anchor base for a checker.
+
+    Non-colliding checkers keep ``{name}-options``. A colliding
+    extension checker uses ``{module}-options`` so anchors stay in sync.
+    The function is the only place ``f"{module}-options"`` is spelled.
+    """
+    if module and name in _get_colliding_extension_names():
+        return f"{module}-options"
+    return f"{name}-options"
 
 
 def _register_all_checkers_and_extensions(linter: PyLinter) -> None:
@@ -80,23 +99,36 @@ def _get_all_options(linter: PyLinter) -> OptionsDataDict:
                         f"{new_value!r} (instead of {option_info[key_to_change]!r})"
                     )
                     option_info[key_to_change] = new_value
-            all_options[checker.name].append(
+            module = getmodule(checker).__name__  # type: ignore[union-attr]
+            is_extension = module.startswith("pylint.extensions.")
+            # Colliding extension checkers are keyed by module so they get
+            # their own section (``pylint.extensions.mccabe-options``) instead
+            # of merging into the core ``design-options`` section (#9174).
+            if is_extension:
+                anchor = _get_options_anchor(checker.name, module)
+                key = anchor[: -len("-options")]
+            else:
+                key = checker.name
+            all_options[key].append(
                 OptionsData(
                     option_name,
                     option_info,
                     checker,
-                    getmodule(checker).__name__.startswith("pylint.extensions."),  # type: ignore[union-attr]
+                    is_extension,
                 )
             )
 
     return all_options
 
 
-def _create_checker_section(
-    checker: str, options: list[OptionsData], linter: PyLinter
-) -> str:
+def _create_checker_section(checker: str, options: list[OptionsData], linter: PyLinter) -> str:
     checker_string = f".. _{checker}-options:\n\n"
-    checker_string += get_rst_title(f"``{checker.capitalize()}`` **Checker**", "-")
+    display_name = options[0].checker.name.capitalize()
+    if checker != options[0].checker.name:
+        # Colliding extension: the anchor is module-based - disambiguate the title.
+        checker_string += get_rst_title(f"``{display_name}`` **Checker** (``{checker}``)", "-")
+    else:
+        checker_string += get_rst_title(f"``{display_name}`` **Checker**", "-")
 
     toml_doc = tomlkit.document()
     tool_table = tomlkit.table(is_super_table=True)
@@ -146,11 +178,7 @@ def _create_checker_section(
         # Tomlkit doesn't support regular expressions
         if isinstance(value, re.Pattern):
             value = value.pattern
-        elif (
-            isinstance(value, (list, tuple))
-            and value
-            and isinstance(value[0], re.Pattern)
-        ):
+        elif isinstance(value, (list, tuple)) and value and isinstance(value[0], re.Pattern):
             value = [i.pattern for i in value]
 
         # Sorting in order for the output to be the same on all interpreters
@@ -164,9 +192,7 @@ def _create_checker_section(
         checker_table.add(tomlkit.nl())
 
     pylint_tool_table.add(options[0].checker.name.lower(), checker_table)
-    toml_string = "\n".join(
-        f"   {i}" if i else "" for i in tomlkit.dumps(toml_doc).split("\n")
-    )
+    toml_string = "\n".join(f"   {i}" if i else "" for i in tomlkit.dumps(toml_doc).split("\n"))
     checker_string += f"""
 .. raw:: html
 
@@ -200,9 +226,7 @@ def _write_options_page(options: OptionsDataDict, linter: PyLinter) -> None:
     # checkers then it wouldn't be possible to have a checker with the same name
     # spanning multiple classes. It would make pylint plugin code less readable by
     # forcing to use a single class / file.
-    for checker_name, checker_options in sorted(
-        options.items(), key=lambda x: x[1][0].checker
-    ):
+    for checker_name, checker_options in sorted(options.items(), key=lambda x: x[1][0].checker):
         if not found_extensions and checker_options[0].extension:
             sections.append(get_rst_title("Extensions", "^"))
             found_extensions = True

--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -121,12 +121,16 @@ def _get_all_options(linter: PyLinter) -> OptionsDataDict:
     return all_options
 
 
-def _create_checker_section(checker: str, options: list[OptionsData], linter: PyLinter) -> str:
+def _create_checker_section(
+    checker: str, options: list[OptionsData], linter: PyLinter
+) -> str:
     checker_string = f".. _{checker}-options:\n\n"
     display_name = options[0].checker.name.capitalize()
     if checker != options[0].checker.name:
         # Colliding extension: the anchor is module-based - disambiguate the title.
-        checker_string += get_rst_title(f"``{display_name}`` **Checker** (``{checker}``)", "-")
+        checker_string += get_rst_title(
+            f"``{display_name}`` **Checker** (``{checker}``)", "-"
+        )
     else:
         checker_string += get_rst_title(f"``{display_name}`` **Checker**", "-")
 
@@ -178,7 +182,11 @@ def _create_checker_section(checker: str, options: list[OptionsData], linter: Py
         # Tomlkit doesn't support regular expressions
         if isinstance(value, re.Pattern):
             value = value.pattern
-        elif isinstance(value, (list, tuple)) and value and isinstance(value[0], re.Pattern):
+        elif (
+            isinstance(value, (list, tuple))
+            and value
+            and isinstance(value[0], re.Pattern)
+        ):
             value = [i.pattern for i in value]
 
         # Sorting in order for the output to be the same on all interpreters
@@ -192,7 +200,9 @@ def _create_checker_section(checker: str, options: list[OptionsData], linter: Py
         checker_table.add(tomlkit.nl())
 
     pylint_tool_table.add(options[0].checker.name.lower(), checker_table)
-    toml_string = "\n".join(f"   {i}" if i else "" for i in tomlkit.dumps(toml_doc).split("\n"))
+    toml_string = "\n".join(
+        f"   {i}" if i else "" for i in tomlkit.dumps(toml_doc).split("\n")
+    )
     checker_string += f"""
 .. raw:: html
 
@@ -226,7 +236,9 @@ def _write_options_page(options: OptionsDataDict, linter: PyLinter) -> None:
     # checkers then it wouldn't be possible to have a checker with the same name
     # spanning multiple classes. It would make pylint plugin code less readable by
     # forcing to use a single class / file.
-    for checker_name, checker_options in sorted(options.items(), key=lambda x: x[1][0].checker):
+    for checker_name, checker_options in sorted(
+        options.items(), key=lambda x: x[1][0].checker
+    ):
         if not found_extensions and checker_options[0].extension:
             sections.append(get_rst_title("Extensions", "^"))
             found_extensions = True

--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import re
-from collections import defaultdict
+from collections import Counter, defaultdict
 from inspect import getmodule
 from pathlib import Path
 from typing import NamedTuple
@@ -67,9 +67,7 @@ def _colliding_checker_names(linter: PyLinter) -> frozenset[str]:
     Computed from the live
     linter so future collisions are handled without hardcoding.
     """
-    counts: dict[str, int] = {}
-    for checker in linter.get_checkers():
-        counts[checker.name] = counts.get(checker.name, 0) + 1
+    counts = Counter(checker.name for checker in linter.get_checkers())
     return frozenset(name for name, count in counts.items() if count > 1)
 
 
@@ -112,9 +110,8 @@ def _get_all_options(linter: PyLinter) -> OptionsDataDict:
             # Colliding extension checkers are keyed by module so they get
             # their own section (``pylint.extensions.mccabe-options``) instead
             # of merging into the core ``design-options`` section (#9174).
-            if is_extension:
-                anchor = _get_options_anchor(checker.name, module, colliding)
-                key = anchor[: -len("-options")]
+            if is_extension and checker.name in colliding:
+                key = module
             else:
                 key = checker.name
             all_options[key].append(

--- a/doc/test_options_documentation.py
+++ b/doc/test_options_documentation.py
@@ -1,0 +1,154 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+
+"""Tests for the options documentation generation (doc/exts/pylint_options.py)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("sphinx")
+
+# ``doc/exts`` is not a package - add it to ``sys.path`` so
+# ``pylint_options`` is importable both inside the sphinx build
+# (conf.py already does this) and when pytest is invoked from the
+# project root.
+_EXTS_PATH = str(Path(__file__).resolve().parent / "exts")
+if _EXTS_PATH not in sys.path:
+    sys.path.insert(0, _EXTS_PATH)
+
+import pylint_options  # type: ignore[import-not-found, unused-ignore]  # pylint: disable=wrong-import-position,import-error  # noqa: E402
+
+from pylint.checkers.base_checker import BaseChecker  # noqa: E402  # pylint: disable=wrong-import-position
+from pylint.extensions.mccabe import McCabeMethodChecker  # noqa: E402  # pylint: disable=wrong-import-position
+from pylint.lint import PyLinter  # noqa: E402  # pylint: disable=wrong-import-position
+from pylint.typing import MessageDefinitionTuple  # noqa: E402  # pylint: disable=wrong-import-position
+
+
+def test_colliding_extension_names_contains_design() -> None:
+    colliding = pylint_options._get_colliding_extension_names()
+    assert "design" in colliding
+    # Today only ``design`` (core vs mccabe) collides.
+    assert colliding == frozenset({"design"})
+
+
+def test_get_options_anchor_single_source_of_truth() -> None:
+    get_anchor = pylint_options._get_options_anchor
+    # Colliding extension -> module-based anchor.
+    assert get_anchor("design", "pylint.extensions.mccabe") == "pylint.extensions.mccabe-options"
+    # Core checker (module is None) keeps name-based anchor even when colliding.
+    assert get_anchor("design", None) == "design-options"
+    # Non-colliding extensions keep name-based anchors.
+    assert get_anchor("dunder", "pylint.extensions.dunder") == "dunder-options"
+    assert get_anchor("typing", "pylint.extensions.typing") == "typing-options"
+    assert get_anchor("broad_try_clause", "pylint.extensions.broad_try_clause") == "broad_try_clause-options"
+
+
+def test_all_options_splits_design_checker() -> None:
+    linter = PyLinter()
+    pylint_options._register_all_checkers_and_extensions(linter)
+    options = pylint_options._get_all_options(linter)
+
+    # Two distinct sections: core ``design`` and colliding ext ``pylint.extensions.mccabe``.
+    assert "design" in options
+    assert "pylint.extensions.mccabe" in options
+
+    core_option_names = {o.name for o in options["design"]}
+    mccabe_option_names = {o.name for o in options["pylint.extensions.mccabe"]}
+
+    assert "max-complexity" in mccabe_option_names
+    assert "max-complexity" not in core_option_names
+
+    # The colliding ext section must be flagged as extension, core as non-extension.
+    assert all(o.extension for o in options["pylint.extensions.mccabe"])
+    assert not any(o.extension for o in options["design"])
+
+    # Non-colliding extension anchors are unchanged (name-based).
+    assert "dunder" in options
+    assert "typing" in options
+    assert "broad_try_clause" in options
+    # No module-based keys leaked for non-colliding extensions.
+    assert "pylint.extensions.dunder" not in options
+    assert "pylint.extensions.typing" not in options
+
+
+def test_create_checker_section_titles() -> None:
+    linter = PyLinter()
+    pylint_options._register_all_checkers_and_extensions(linter)
+    options = pylint_options._get_all_options(linter)
+
+    core_section = pylint_options._create_checker_section(
+        "design", options["design"], linter
+    )
+    assert ".. _design-options:" in core_section
+    assert "``Design`` **Checker**" in core_section
+    # Core section must NOT have a module suffix.
+    assert "(``design``)" not in core_section
+    assert "(``pylint.extensions.mccabe``)" not in core_section
+
+    mccabe_section = pylint_options._create_checker_section(
+        "pylint.extensions.mccabe", options["pylint.extensions.mccabe"], linter
+    )
+    assert ".. _pylint.extensions.mccabe-options:" in mccabe_section
+    assert "``Design`` **Checker** (``pylint.extensions.mccabe``)" in mccabe_section
+
+
+def test_get_full_documentation_options_anchor_kwarg() -> None:
+    """``BaseChecker.get_full_documentation`` must honour ``options_anchor``.
+
+    Default -> ``<design-options>``; explicit module anchor ->
+    ``<pylint.extensions.mccabe-options>``.
+    """
+    linter = PyLinter()
+    checker: BaseChecker = McCabeMethodChecker(linter)
+    options = list(checker._options_and_values())
+    assert options, "McCabe checker must expose --max-complexity"
+
+    default_doc = checker.get_full_documentation(
+        msgs=checker.msgs,
+        options=options,
+        reports=checker.reports,
+        module="pylint.extensions.mccabe",
+        show_options=False,
+    )
+    assert "<design-options>" in default_doc
+
+    module_doc = checker.get_full_documentation(
+        msgs=checker.msgs,
+        options=options,
+        reports=checker.reports,
+        module="pylint.extensions.mccabe",
+        show_options=False,
+        options_anchor="pylint.extensions.mccabe-options",
+    )
+    assert "<pylint.extensions.mccabe-options>" in module_doc
+    assert "<design-options>" not in module_doc
+
+    # Non-colliding checker must be unaffected when the kwarg is not passed.
+    # Use a tiny ad-hoc checker to avoid coupling to a specific extension.
+    from pylint.checkers.base_checker import BaseChecker as _BC  # local import
+
+    class _DummyChecker(_BC):
+        name = "dummy_test_checker_xyz"
+        msgs: dict[str, MessageDefinitionTuple] = {}
+        options = (
+            (
+                "dummy-opt",
+                {"default": 1, "type": "int", "metavar": "<int>", "help": "dummy"},
+            ),
+        )
+
+    dummy = _DummyChecker(linter)
+    dummy_opts = list(dummy._options_and_values())
+    dummy_doc = dummy.get_full_documentation(
+        msgs=dummy.msgs,
+        options=dummy_opts,
+        reports=dummy.reports,
+        module="pylint.extensions.dummy_test_checker_xyz",
+        show_options=False,
+    )
+    assert "<dummy_test_checker_xyz-options>" in dummy_doc

--- a/doc/test_options_documentation.py
+++ b/doc/test_options_documentation.py
@@ -23,10 +23,16 @@ if _EXTS_PATH not in sys.path:
 
 import pylint_options  # type: ignore[import-not-found, unused-ignore]  # pylint: disable=wrong-import-position,import-error  # noqa: E402
 
-from pylint.checkers.base_checker import BaseChecker  # noqa: E402  # pylint: disable=wrong-import-position
-from pylint.extensions.mccabe import McCabeMethodChecker  # noqa: E402  # pylint: disable=wrong-import-position
+from pylint.checkers.base_checker import (  # noqa: E402  # pylint: disable=wrong-import-position
+    BaseChecker,
+)
+from pylint.extensions.mccabe import (  # noqa: E402  # pylint: disable=wrong-import-position
+    McCabeMethodChecker,
+)
 from pylint.lint import PyLinter  # noqa: E402  # pylint: disable=wrong-import-position
-from pylint.typing import MessageDefinitionTuple  # noqa: E402  # pylint: disable=wrong-import-position
+from pylint.typing import (  # noqa: E402  # pylint: disable=wrong-import-position
+    MessageDefinitionTuple,
+)
 
 
 def test_colliding_extension_names_contains_design() -> None:
@@ -39,13 +45,19 @@ def test_colliding_extension_names_contains_design() -> None:
 def test_get_options_anchor_single_source_of_truth() -> None:
     get_anchor = pylint_options._get_options_anchor
     # Colliding extension -> module-based anchor.
-    assert get_anchor("design", "pylint.extensions.mccabe") == "pylint.extensions.mccabe-options"
+    assert (
+        get_anchor("design", "pylint.extensions.mccabe")
+        == "pylint.extensions.mccabe-options"
+    )
     # Core checker (module is None) keeps name-based anchor even when colliding.
     assert get_anchor("design", None) == "design-options"
     # Non-colliding extensions keep name-based anchors.
     assert get_anchor("dunder", "pylint.extensions.dunder") == "dunder-options"
     assert get_anchor("typing", "pylint.extensions.typing") == "typing-options"
-    assert get_anchor("broad_try_clause", "pylint.extensions.broad_try_clause") == "broad_try_clause-options"
+    assert (
+        get_anchor("broad_try_clause", "pylint.extensions.broad_try_clause")
+        == "broad_try_clause-options"
+    )
 
 
 def test_all_options_splits_design_checker() -> None:

--- a/doc/test_options_documentation.py
+++ b/doc/test_options_documentation.py
@@ -36,26 +36,53 @@ from pylint.typing import (  # noqa: E402  # pylint: disable=wrong-import-positi
 
 
 def test_colliding_extension_names_contains_design() -> None:
-    colliding = pylint_options._get_colliding_extension_names()
+    linter = PyLinter()
+    pylint_options._register_all_checkers_and_extensions(linter)
+    colliding = pylint_options._colliding_checker_names(linter)
     assert "design" in colliding
-    # Today only ``design`` (core vs mccabe) collides.
-    assert colliding == frozenset({"design"})
+    # Non-colliding extensions must NOT appear in the set.
+    assert "dunder" not in colliding
+
+
+def test_builder_inited_detects_collision_with_core_loaded() -> None:
+    """``builder_inited`` must load core checkers so collision detection sees both
+    ``design`` (core) and ``design`` (mccabe ext), producing the correct module-based
+    anchor ``pylint.extensions.mccabe-options``.
+    """
+    from pylint.checkers import initialize as initialize_checkers
+
+    linter = PyLinter()
+    initialize_checkers(linter)
+    linter.load_plugin_modules(["pylint.extensions.mccabe"])
+    colliding = pylint_options._colliding_checker_names(linter)
+    assert "design" in colliding
+    assert (
+        pylint_options._get_options_anchor(
+            "design", "pylint.extensions.mccabe", colliding
+        )
+        == "pylint.extensions.mccabe-options"
+    )
 
 
 def test_get_options_anchor_single_source_of_truth() -> None:
     get_anchor = pylint_options._get_options_anchor
+    colliding = frozenset({"design"})
     # Colliding extension -> module-based anchor.
     assert (
-        get_anchor("design", "pylint.extensions.mccabe")
+        get_anchor("design", "pylint.extensions.mccabe", colliding)
         == "pylint.extensions.mccabe-options"
     )
     # Core checker (module is None) keeps name-based anchor even when colliding.
-    assert get_anchor("design", None) == "design-options"
+    assert get_anchor("design", None, colliding) == "design-options"
     # Non-colliding extensions keep name-based anchors.
-    assert get_anchor("dunder", "pylint.extensions.dunder") == "dunder-options"
-    assert get_anchor("typing", "pylint.extensions.typing") == "typing-options"
     assert (
-        get_anchor("broad_try_clause", "pylint.extensions.broad_try_clause")
+        get_anchor("dunder", "pylint.extensions.dunder", colliding) == "dunder-options"
+    )
+    assert (
+        get_anchor("typing", "pylint.extensions.typing", colliding) == "typing-options"
+    )
+    assert (
+        get_anchor("broad_try_clause", "pylint.extensions.broad_try_clause", colliding)
         == "broad_try_clause-options"
     )
 

--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -215,6 +215,11 @@ Design checker Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You can now use this plugin for finding complexity issues in your code base.
 
+Shares the ``design`` name with pylint's standard Design checker, which is
+always enabled. This extension is opt-in via ``--load-plugins``; it adds
+``--max-complexity`` and the ``too-complex`` message. Disable the standard
+checker with ``--disable=design``.
+
 Activate it through ``pylint --load-plugins=pylint.extensions.mccabe``. It introduces
 a new warning, ``too-complex``, which is emitted when a code block has a complexity
 higher than a preestablished value, which can be controlled through the
@@ -251,7 +256,7 @@ higher than a preestablished value, which can be controlled through the
     $ pylint a.py --load-plugins=pylint.extensions.mccabe --max-complexity=50
     $
 
-See also :ref:`design checker's options' documentation <design-options>`
+See also :ref:`design checker's options' documentation <pylint.extensions.mccabe-options>`
 
 Design checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/user_guide/checkers/extensions.rst
+++ b/doc/user_guide/checkers/extensions.rst
@@ -218,7 +218,8 @@ You can now use this plugin for finding complexity issues in your code base.
 Shares the ``design`` name with pylint's standard Design checker, which is
 always enabled. This extension is opt-in via ``--load-plugins``; it adds
 ``--max-complexity`` and the ``too-complex`` message. Disable the standard
-checker with ``--disable=design``.
+checker with ``--disable=design``. Configure ``max-complexity`` under
+``[tool.pylint.design]``.
 
 Activate it through ``pylint --load-plugins=pylint.extensions.mccabe``. It introduces
 a new warning, ``too-complex``, which is emitted when a code block has a complexity

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -914,15 +914,6 @@ Standard Checkers
 **Default:**  ``12``
 
 
-.. _max-complexity-option:
-
---max-complexity
-""""""""""""""""
-*McCabe complexity cyclomatic threshold*
-
-**Default:**  ``10``
-
-
 .. _max-locals-option:
 
 --max-locals
@@ -1008,8 +999,6 @@ Standard Checkers
    max-bool-expr = 5
 
    max-branches = 12
-
-   max-complexity = 10
 
    max-locals = 15
 
@@ -2099,6 +2088,39 @@ Extensions
 
    [tool.pylint.deprecated_builtins]
    bad-functions = ["map", "filter"]
+
+
+
+.. raw:: html
+
+   </details>
+
+
+.. _pylint.extensions.mccabe-options:
+
+``Design`` **Checker** (``pylint.extensions.mccabe``)
+-----------------------------------------------------
+.. _max-complexity-option:
+
+--max-complexity
+""""""""""""""""
+*McCabe complexity cyclomatic threshold*
+
+**Default:**  ``10``
+
+
+
+.. raw:: html
+
+   <details>
+   <summary><a>Example configuration section</a></summary>
+
+**Note:** Only ``tool.pylint`` is required, the section title is not. These are the default values.
+
+.. code-block:: toml
+
+   [tool.pylint.design]
+   max-complexity = 10
 
 
 

--- a/doc/whatsnew/fragments/9174.other
+++ b/doc/whatsnew/fragments/9174.other
@@ -1,0 +1,3 @@
+``--max-complexity`` from ``pylint.extensions.mccabe`` now has its own extension section in ``all-options.rst``.
+
+Closes #9174

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -101,6 +101,7 @@ class BaseChecker(_ArgumentsProvider):
         doc: str | None = None,
         module: str | None = None,
         show_options: bool = True,
+        options_anchor: str | None = None,
     ) -> str:
         result = ""
         checker_title = f"{self.name.replace('_', ' ').title()} checker"
@@ -129,12 +130,11 @@ class BaseChecker(_ArgumentsProvider):
                 result += get_rst_title(f"{checker_title} Options", "^")
                 result += f"{get_rst_section(None, options_list)}\n"
             else:
-                result += f"See also :ref:`{self.name} checker's options' documentation <{self.name}-options>`\n\n"
+                anchor = options_anchor or f"{self.name}-options"
+                result += f"See also :ref:`{self.name} checker's options' documentation <{anchor}>`\n\n"
         if msgs:
             result += get_rst_title(f"{checker_title} Messages", "^")
-            for msgid, msg in sorted(
-                msgs.items(), key=lambda kv: (_MSG_ORDER.index(kv[0][0]), kv[0])
-            ):
+            for msgid, msg in sorted(msgs.items(), key=lambda kv: (_MSG_ORDER.index(kv[0][0]), kv[0])):
                 msg_def = self.create_message_definition_from_tuple(msgid, msg)
                 result += f"{msg_def.format_help(checkerref=False)}\n"
             result += "\n"
@@ -157,9 +157,7 @@ class BaseChecker(_ArgumentsProvider):
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
     ) -> None:
-        self.linter.add_message(
-            msgid, line, node, args, confidence, col_offset, end_lineno, end_col_offset
-        )
+        self.linter.add_message(msgid, line, node, args, confidence, col_offset, end_lineno, end_col_offset)
 
     def check_consistency(self) -> None:
         """Check the consistency of msgid.

--- a/pylint/checkers/base_checker.py
+++ b/pylint/checkers/base_checker.py
@@ -134,7 +134,9 @@ class BaseChecker(_ArgumentsProvider):
                 result += f"See also :ref:`{self.name} checker's options' documentation <{anchor}>`\n\n"
         if msgs:
             result += get_rst_title(f"{checker_title} Messages", "^")
-            for msgid, msg in sorted(msgs.items(), key=lambda kv: (_MSG_ORDER.index(kv[0][0]), kv[0])):
+            for msgid, msg in sorted(
+                msgs.items(), key=lambda kv: (_MSG_ORDER.index(kv[0][0]), kv[0])
+            ):
                 msg_def = self.create_message_definition_from_tuple(msgid, msg)
                 result += f"{msg_def.format_help(checkerref=False)}\n"
             result += "\n"
@@ -157,7 +159,9 @@ class BaseChecker(_ArgumentsProvider):
         end_lineno: int | None = None,
         end_col_offset: int | None = None,
     ) -> None:
-        self.linter.add_message(msgid, line, node, args, confidence, col_offset, end_lineno, end_col_offset)
+        self.linter.add_message(
+            msgid, line, node, args, confidence, col_offset, end_lineno, end_col_offset
+        )
 
     def check_consistency(self) -> None:
         """Check the consistency of msgid.

--- a/pylint/extensions/mccabe.rst
+++ b/pylint/extensions/mccabe.rst
@@ -1,5 +1,10 @@
 You can now use this plugin for finding complexity issues in your code base.
 
+Shares the ``design`` name with pylint's standard Design checker, which is
+always enabled. This extension is opt-in via ``--load-plugins``; it adds
+``--max-complexity`` and the ``too-complex`` message. Disable the standard
+checker with ``--disable=design``.
+
 Activate it through ``pylint --load-plugins=pylint.extensions.mccabe``. It introduces
 a new warning, ``too-complex``, which is emitted when a code block has a complexity
 higher than a preestablished value, which can be controlled through the

--- a/pylint/extensions/mccabe.rst
+++ b/pylint/extensions/mccabe.rst
@@ -3,7 +3,8 @@ You can now use this plugin for finding complexity issues in your code base.
 Shares the ``design`` name with pylint's standard Design checker, which is
 always enabled. This extension is opt-in via ``--load-plugins``; it adds
 ``--max-complexity`` and the ``too-complex`` message. Disable the standard
-checker with ``--disable=design``.
+checker with ``--disable=design``. Configure ``max-complexity`` under
+``[tool.pylint.design]``.
 
 Activate it through ``pylint --load-plugins=pylint.extensions.mccabe``. It introduces
 a new warning, ``too-complex``, which is emitted when a code block has a complexity

--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,9 @@ commands =
 [testenv:test_doc]
 deps =
     -r {toxinidir}/requirements_test.txt
+    Sphinx==8.2.3  # keep in sync with doc/requirements.txt – needed for doc/test_options_documentation.py (pylint_options imports sphinx)
 commands =
-    pytest {toxinidir}/doc/test_messages_documentation.py
+    pytest {toxinidir}/doc/test_messages_documentation.py {toxinidir}/doc/test_options_documentation.py
 
 [testenv:benchmark]
 deps =


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

Two checkers share `name = "design"`, so `--max-complexity` merged into the standard Design section. Collision detection runs live via `_colliding_checker_names` over the registered linter, so future core/extension name clashes split automatically. An optional `options_anchor` kwarg on `BaseChecker.get_full_documentation()` lets the doc generator pass the correct anchor; callers that don't pass it keep the old behavior.

Closes #9174
