### PR TITLE
Fix bad-string-format-type false positive for subclasses of builtin types

### DIFF
--- a/doc/whatsnew/fragments/11315.false_positive
+++ b/doc/whatsnew/fragments/11315.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``bad-string-format-type`` when the argument is an
+instance of a subclass of the expected builtin type, such as ``bool`` for
+``%d``, an ``enum.IntEnum`` member for ``%x``, or a user-defined subclass of
+``float`` for ``%f``: these format exactly like their builtin base type.
+
+Closes #11315

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -227,15 +227,20 @@ def arg_matches_format_type(
         # All types can be printed with %s, %r and %a
         return True
     if isinstance(arg_type, astroid.Instance):
-        match arg_type.pytype():
-            case "builtins.str":
-                return format_type == "c"
-            case "builtins.float":
-                # ``i`` and ``u`` accept a float at runtime (truncated like ``d``)
-                return format_type in "diueEfFgGn%"
-            case "builtins.int":
-                # Integers allow all types
-                return True
+        # Subclasses such as bool, IntEnum members or user-defined
+        # subclasses of float format exactly like their builtin base
+        arg_types = {arg_type.pytype()}
+        arg_types.update(
+            ancestor.qname() for ancestor in arg_type._proxied.ancestors()
+        )
+        if "builtins.int" in arg_types:
+            # Integers allow all types
+            return True
+        if "builtins.float" in arg_types:
+            # ``i`` and ``u`` accept a float at runtime (truncated like ``d``)
+            return format_type in "diueEfFgGn%"
+        if "builtins.str" in arg_types:
+            return format_type == "c"
         return False
     return True
 

--- a/pylint/checkers/strings.py
+++ b/pylint/checkers/strings.py
@@ -230,9 +230,7 @@ def arg_matches_format_type(
         # Subclasses such as bool, IntEnum members or user-defined
         # subclasses of float format exactly like their builtin base
         arg_types = {arg_type.pytype()}
-        arg_types.update(
-            ancestor.qname() for ancestor in arg_type._proxied.ancestors()
-        )
+        arg_types.update(ancestor.qname() for ancestor in arg_type._proxied.ancestors())
         if "builtins.int" in arg_types:
             # Integers allow all types
             return True

--- a/tests/functional/b/bad_string_format_type.py
+++ b/tests/functional/b/bad_string_format_type.py
@@ -1,5 +1,6 @@
 """Tests for bad string format type"""
-# pylint: disable=consider-using-f-string, pointless-statement
+# pylint: disable=consider-using-f-string, pointless-statement, expression-not-assigned
+import enum
 
 # Test formatting of bytes
 b"test".format(1, 2) # [no-member]
@@ -54,3 +55,21 @@ def test_format(my_input_value, my_other_input_value):
     print("%d %s" % (my_input_value, my_other_input_value))
     to_be_formatted = (my_input_value, my_other_input_value)
     print("%d %s" % to_be_formatted)
+
+
+# Subclasses of the builtin types format exactly like their base type:
+# bool and IntEnum members are ints, a float subclass is a float.
+class IntChoice(enum.IntEnum):
+    """An IntEnum whose members are ints."""
+
+    OPTION = 1
+
+
+class UnitFloat(float):
+    """A user-defined subclass of float."""
+
+
+"%i" % True
+"%d %x" % (IntChoice.OPTION, IntChoice.OPTION)
+"%f %i" % (UnitFloat(1.5), UnitFloat(1.5))
+"%d %x" % (1, UnitFloat(1.5))  # [bad-string-format-type]

--- a/tests/functional/b/bad_string_format_type.txt
+++ b/tests/functional/b/bad_string_format_type.txt
@@ -1,10 +1,11 @@
-no-member:5:0:5:14::Instance of 'bytes' has no 'format' member:INFERENCE
-bad-string-format-type:33:0:33:10::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:34:0:34:24::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:35:0:35:10::Argument 'builtins.float' does not match format type 'x':UNDEFINED
-bad-string-format-type:36:0:36:24::Argument 'builtins.float' does not match format type 'x':UNDEFINED
-bad-string-format-type:37:0:37:9::Argument 'builtins.list' does not match format type 'd':UNDEFINED
-bad-string-format-type:38:0:38:23::Argument 'builtins.list' does not match format type 'd':UNDEFINED
-bad-string-format-type:41:0:41:11::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:42:0:42:22::Argument 'builtins.str' does not match format type 'd':UNDEFINED
-bad-string-format-type:46:0:46:29::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+no-member:6:0:6:14::Instance of 'bytes' has no 'format' member:INFERENCE
+bad-string-format-type:34:0:34:10::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:35:0:35:24::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:36:0:36:10::Argument 'builtins.float' does not match format type 'x':UNDEFINED
+bad-string-format-type:37:0:37:24::Argument 'builtins.float' does not match format type 'x':UNDEFINED
+bad-string-format-type:38:0:38:9::Argument 'builtins.list' does not match format type 'd':UNDEFINED
+bad-string-format-type:39:0:39:23::Argument 'builtins.list' does not match format type 'd':UNDEFINED
+bad-string-format-type:42:0:42:11::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:43:0:43:22::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:47:0:47:29::Argument 'builtins.str' does not match format type 'd':UNDEFINED
+bad-string-format-type:75:0:75:29::Argument 'functional.b.bad_string_format_type.UnitFloat' does not match format type 'x':UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type         |
| --- | ------------ |
| ✓   | :bug: Bug fix |

## Description

`arg_matches_format_type()` compared `arg_type.pytype()` exactly against `builtins.int` / `builtins.float` / `builtins.str`, so instances of subclasses never matched: `bool` for `%d`, `enum.IntEnum` members for `%x`, or a user-defined subclass of `float` for `%f` were all reported as `bad-string-format-type` even though they format exactly like their base type at runtime (the stdlib itself hits this in `curses/has_key.py`).

The fix collects the ancestor qnames of the inferred instance and checks the builtin base types against that set, so subclasses inherit the format compatibility of their base. Incompatible combinations are still reported — the functional tests include a float subclass with `%x`, which keeps producing E1307.

Uses the same `_proxied` / `ancestors()` / `qname()` pattern as `pylint/checkers/logging.py`. Functional test expectations regenerated; `pytest tests -k "string or format"` passes (56 passed, 2 skipped).

Closes #11315
