### PR TITLE
Fix invalid-*-returned false positives for subclasses of the expected builtin

### DIFF
--- a/doc/whatsnew/fragments/11306.false_positive
+++ b/doc/whatsnew/fragments/11306.false_positive
@@ -1,0 +1,8 @@
+Fix false positives for ``invalid-str-returned``, ``invalid-repr-returned``,
+``invalid-format-returned``, ``invalid-hash-returned``, ``invalid-index-returned``,
+``invalid-length-returned``, ``invalid-length-hint-returned``,
+``invalid-bytes-returned`` and ``invalid-getnewargs-returned`` when the returned
+value is an instance of a subclass of the expected builtin type, such as
+``return self`` from a ``str`` subclass in ``__str__``.
+
+Closes #11306

--- a/pylint/checkers/classes/special_methods_checker.py
+++ b/pylint/checkers/classes/special_methods_checker.py
@@ -246,10 +246,18 @@ class SpecialMethodsChecker(BaseChecker):
 
     @staticmethod
     def _is_wrapped_type(node: InferenceResult, type_: str) -> bool:
+        # Instances of subclasses of the builtin are valid return values,
+        # e.g. `return self` from a str subclass in __str__.
         return (
             isinstance(node, bases.Instance)
-            and node.name == type_
             and not isinstance(node, nodes.Const)
+            and (
+                node.name == type_
+                or any(
+                    ancestor.qname() == f"builtins.{type_}"
+                    for ancestor in node._proxied.ancestors()
+                )
+            )
         )
 
     @staticmethod

--- a/tests/functional/i/invalid/invalid_bytes_returned.py
+++ b/tests/functional/i/invalid/invalid_bytes_returned.py
@@ -62,3 +62,10 @@ class AnotherAmbiguousBytes:
 
     def __bytes__(self):
         return bytes(Missing)
+
+
+class SubclassGoodBytes(bytes):
+    """__bytes__ returns a bytes subclass instance."""
+
+    def __bytes__(self):
+        return self

--- a/tests/functional/i/invalid/invalid_format_returned.py
+++ b/tests/functional/i/invalid/invalid_format_returned.py
@@ -62,3 +62,10 @@ class AnotherAmbiguousFormat:
 
     def __format__(self, format_spec):
         return str(Missing)
+
+
+class SubclassGoodFormat(str):
+    """__format__ returns a str subclass instance."""
+
+    def __format__(self, format_spec):
+        return self

--- a/tests/functional/i/invalid/invalid_getnewargs/invalid_getnewargs_returned.py
+++ b/tests/functional/i/invalid/invalid_getnewargs/invalid_getnewargs_returned.py
@@ -60,3 +60,10 @@ class AnotherAmbiguousGetNewArgs:
     """Potential uninferable return value"""
     def __getnewargs__(self):
         return tuple(Missing)
+
+
+class SubclassGoodGetNewArgs(tuple):
+    """__getnewargs__ returns a tuple subclass instance."""
+
+    def __getnewargs__(self):
+        return self

--- a/tests/functional/i/invalid/invalid_hash_returned.py
+++ b/tests/functional/i/invalid/invalid_hash_returned.py
@@ -69,3 +69,10 @@ class AnotherAmbiguousHash:
 
     def __hash__(self):
         return hash(Missing)
+
+
+class SubclassGoodHash(int):
+    """__hash__ returns an int subclass instance."""
+
+    def __hash__(self):
+        return self

--- a/tests/functional/i/invalid/invalid_index_returned.py
+++ b/tests/functional/i/invalid/invalid_index_returned.py
@@ -69,3 +69,10 @@ class AnotherAmbiguousIndex:
 
     def __index__(self):
         return int(Missing)
+
+
+class SubclassGoodIndex(int):
+    """__index__ returns an int subclass instance."""
+
+    def __index__(self):
+        return self

--- a/tests/functional/i/invalid/invalid_length/invalid_length_hint_returned.py
+++ b/tests/functional/i/invalid/invalid_length/invalid_length_hint_returned.py
@@ -62,3 +62,10 @@ class AnotherAmbiguousLengthHint:
     """Potential uninferable return value"""
     def __length_hint__(self):
         return int(Missing)
+
+
+class SubclassGoodLengthHint(int):
+    """__length_hint__ returns an int subclass instance."""
+
+    def __length_hint__(self):
+        return self

--- a/tests/functional/i/invalid/invalid_length/invalid_length_returned.py
+++ b/tests/functional/i/invalid/invalid_length/invalid_length_returned.py
@@ -69,3 +69,10 @@ class AnotherAmbiguousLen:
     """Potential uninferable return value"""
     def __len__(self):
         return int(Missing)
+
+
+class SubclassGoodLen(int):
+    """__len__ returns an int subclass instance."""
+
+    def __len__(self):
+        return self

--- a/tests/functional/i/invalid/invalid_repr_returned.py
+++ b/tests/functional/i/invalid/invalid_repr_returned.py
@@ -62,3 +62,10 @@ class AnotherAmbiguousRepr:
 
     def __repr__(self):
         return str(Missing)
+
+
+class SubclassGoodRepr(str):
+    """__repr__ returns a str subclass instance, like pdb._rstr."""
+
+    def __repr__(self):
+        return self

--- a/tests/functional/i/invalid/invalid_str_returned.py
+++ b/tests/functional/i/invalid/invalid_str_returned.py
@@ -62,3 +62,10 @@ class AnotherAmbiguousStr:
 
     def __str__(self):
         return str(Missing)
+
+
+class SubclassGoodStr(str):
+    """__str__ returns a str subclass instance, e.g. `return self`."""
+
+    def __str__(self):
+        return self


### PR DESCRIPTION
## Type of Changes

|     | Type         |
| --- | ------------ |
| ✓   | :bug: Bug fix |

## Description

`SpecialMethodsChecker._is_wrapped_type()` compared the inferred instance's class name exactly with the builtin (`node.name == type_`), so returning an instance of a *subclass* of the expected builtin raised the whole `invalid-*-returned` family of messages even though such values are valid at runtime -- e.g. `return self` from a `str` subclass in `__str__`, which the stdlib itself does in `pdb._rstr.__repr__`.

The fix also accepts instances whose ancestors include the expected builtin (matched by `builtins.<type>` qname), mirroring the approach of #11342. Genuinely invalid returns are still reported -- the existing functional-test expectations are unchanged, and each affected functional test file gains an appended good-case with a subclass `return self` (append-only, so no expected-output regeneration was needed).

`pytest tests/test_functional.py -k invalid` passes (41 passed, 1 skipped).

Closes #11306
