### PR TITLE
Fix unreachable false positive after instantiating _sitebuiltins.Quitter

### DIFF
--- a/doc/whatsnew/fragments/11310.false_positive
+++ b/doc/whatsnew/fragments/11310.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``unreachable`` after instantiating
+``_sitebuiltins.Quitter``: constructing a ``Quitter`` does not exit the
+program, only calling the ``exit`` / ``quit`` instances does.
+
+Closes #11310

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2224,6 +2224,11 @@ def is_terminating_func(node: nodes.Call) -> bool:
 
     for inferred in inferred_funcs:
         if hasattr(inferred, "qname") and inferred.qname() in TERMINATING_FUNCS_QNAMES:
+            # Calling the _sitebuiltins.Quitter class constructs a Quitter
+            # instead of exiting; only calling an existing instance (the
+            # exit and quit builtins) terminates the program.
+            if isinstance(inferred, nodes.ClassDef):
+                continue
             return True
         match inferred:
             case astroid.BoundMethod(_proxied=astroid.UnboundMethod(_proxied=p)):

--- a/tests/functional/u/unreachable.py
+++ b/tests/functional/u/unreachable.py
@@ -105,3 +105,17 @@ async def func15():
     coro = inner()
     print("reachable")
     await coro
+
+
+def func16():
+    # https://github.com/pylint-dev/pylint/issues/11310
+    # Constructing a Quitter does not exit; only calling the exit/quit
+    # instances does.
+    import _sitebuiltins  # pylint: disable=import-outside-toplevel
+
+    commands = {
+        "exit": _sitebuiltins.Quitter("exit", ""),
+        "quit": _sitebuiltins.Quitter("quit", ""),
+    }
+    print("reachable")
+    return commands


### PR DESCRIPTION
## Type of Changes

|     | Type         |
| --- | ------------ |
| ✓   | :bug: Bug fix |

## Description

`is_terminating_func()` treated any call whose callee infers to the qualified name `_sitebuiltins.Quitter` as terminating. That is correct for `exit()` / `quit()` -- the builtins are *instances* of `Quitter` -- but it also matched the `Quitter` **class** itself, so constructing a `Quitter` was treated as if the program exits there, and the next statement was reported as `unreachable`. The stdlib trips this in `_pyrepl/simple_interact.py`, which builds a `REPL_COMMANDS` dict with `_sitebuiltins.Quitter(...)` entries.

The fix skips the terminating-qname match when the inferred callee is a `ClassDef` (construction); calling an instance still terminates, and the `sys.exit` / `os._exit` entries are function definitions and unaffected. Verified that `sys.exit()` and `exit()` still produce `unreachable` for the following statement.

Closes #11310
