### PR TITLE
Fix unbalanced-tuple-unpacking false positive when unpacking exception args

### DIFF
--- a/doc/whatsnew/fragments/11312.false_positive
+++ b/doc/whatsnew/fragments/11312.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``unbalanced-tuple-unpacking`` when unpacking an
+exception's ``args``: astroid models ``BaseException.args`` as an empty tuple,
+but its actual length is unknown.
+
+Closes #11312

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -3121,6 +3121,15 @@ class VariablesChecker(BaseChecker):
         if isinstance(inferred, util.UninferableBase):
             return
         if (
+            isinstance(inferred, nodes.Tuple)
+            and not inferred.elts
+            and isinstance(inferred.parent, bases.Instance)
+            and inferred.parent._proxied.is_subtype_of("builtins.BaseException")
+        ):
+            # astroid models BaseException.args on an exception instance as
+            # an empty tuple; its actual length is unknown.
+            return
+        if (
             isinstance(inferred.parent, nodes.Arguments)
             and isinstance(node.value, nodes.Name)
             and node.value.name == inferred.parent.vararg

--- a/tests/functional/u/unbalanced/unbalanced_tuple_unpacking.py
+++ b/tests/functional/u/unbalanced/unbalanced_tuple_unpacking.py
@@ -178,3 +178,17 @@ def main():
     _, _ = fruit(1, 2, 3)  # known false negative, requires better None comprehension in astroid
     _, _, _ = fruit(1, 2)  # known false negative, requires better None comprehension in astroid
     _, _, _ = fruit(1, 2, 3)
+
+
+def unpack_exception_args():
+    """No warning for BaseException.args: its length is unknown.
+
+    https://github.com/pylint-dev/pylint/issues/11312
+    """
+    try:
+        pass
+    except ValueError as exc:
+        (message,) = exc.args
+        first, second = exc.args
+        return message, first, second
+    return None


### PR DESCRIPTION
## Type of Changes

|     | Type         |
| --- | ------------ |
| ✓   | :bug: Bug fix |

## Description

astroid models `BaseException.args` on an exception instance as a *known empty* tuple (`ExceptionInstanceModel.attr_args` returns `nodes.Tuple(parent=self._instance)` with no elements), so `unbalanced-tuple-unpacking` reported "right side has 0 values" for any unpacking of `exc.args` -- the stdlib does exactly this in `importlib.metadata`'s `PackageNotFoundError.name`.

The synthetic model tuple is reliably recognizable: its `parent` is the exception *instance* rather than an AST node. `_check_unpacking` now skips an empty inferred tuple whose parent is an instance of a `BaseException` subtype, since the actual length of `args` is unknown. Real empty-tuple unpackings (`a, b = ()`) still have an AST parent and are still reported, as are all other existing cases -- the three `unbalanced*` functional tests pass unchanged, extended with the `exc.args` case.

Closes #11312
