### PR TITLE
Fix bad-super-call false positive for nested functions attached to another class

### DIFF
--- a/doc/whatsnew/fragments/11313.false_positive
+++ b/doc/whatsnew/fragments/11313.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for ``bad-super-call`` when a function nested in a method
+binds its own first argument in ``super()``, such as an ``__init_subclass__``
+being attached to another class as ``warnings.deprecated`` does.
+
+Closes #11313

--- a/pylint/checkers/newstyle.py
+++ b/pylint/checkers/newstyle.py
@@ -67,6 +67,21 @@ class NewStyleConflictChecker(BaseChecker):
                     # super first arg should not be the class
                     continue
 
+            scope = stmt.scope()
+            if scope is not node and len(call.args) > 1:
+                second_arg = call.args[1]
+                if (
+                    isinstance(second_arg, nodes.Name)
+                    and isinstance(scope, (nodes.FunctionDef, nodes.Lambda))
+                    and second_arg.name in scope.argnames()
+                ):
+                    # A nested function that binds its own first argument in
+                    # super() is presumably attached to another class later,
+                    # e.g. warnings.deprecated attaching __init_subclass__;
+                    # super()'s first argument then legitimately refers to a
+                    # class other than the one of the enclosing method.
+                    continue
+
             # calling super(type(self), self) can lead to recursion loop
             # in derived classes
             match arg0:

--- a/tests/functional/s/super/super_checks.py
+++ b/tests/functional/s/super/super_checks.py
@@ -154,3 +154,22 @@ class AlabamaCousin(Child, Niece):
     def method(self):
         print("AlabamaCousin")
         super(Child, self).method()
+
+
+# https://github.com/pylint-dev/pylint/issues/11313
+# A nested function that binds its own first argument in super() is
+# presumably attached to another class later, like warnings.deprecated
+# attaching __init_subclass__.
+class Decorator:
+    def __call__(self, arg):
+        if isinstance(arg, type):
+            def __init_subclass__(cls, *args, **kwargs):
+                return super(arg, cls).__init_subclass__(*args, **kwargs)
+
+            arg.__init_subclass__ = classmethod(__init_subclass__)
+        return arg
+
+    def closure_still_reported(self):
+        def helper():
+            return super(Niece, self).method()  # [bad-super-call]
+        return helper()

--- a/tests/functional/s/super/super_checks.txt
+++ b/tests/functional/s/super/super_checks.txt
@@ -14,3 +14,4 @@ no-member:98:8:98:55:InvalidSuperChecks.__init__:Super of 'InvalidSuperChecks' h
 bad-super-call:120:8:120:31:SuperWithType.__init__:Bad first argument 'type' given to super():UNDEFINED
 bad-super-call:125:8:125:35:SuperWithSelfClass.__init__:Bad first argument 'self.__class__' given to super():UNDEFINED
 bad-super-call:149:8:149:26:GrandChild.method:Bad first argument 'Niece' given to super():UNDEFINED
+bad-super-call:174:19:174:37:Decorator.closure_still_reported.helper:Bad first argument 'Niece' given to super():UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type         |
| --- | ------------ |
| ✓   | :bug: Bug fix |

## Description

`bad-super-call` examines every `super(X, y)` call in a method, including those inside functions nested in the method, and compares `X` with the class of the *enclosing* method. When the nested function is destined to become a method of some other class -- it takes its own `self`/`cls` first parameter and is attached later -- `X` legitimately names that other class. The stdlib does this in `warnings.deprecated.__call__` (`_py_warnings.py`), which builds an `__init_subclass__` with `super(arg, cls)` and attaches it to the decorated class; pylint reported `E1003` on it.

Per the issue's suggested rule, the checker now skips a `super()` call inside a nested function when its second argument is a parameter *of that nested function*. This deliberately keeps reporting nested closures that use the enclosing method's `self` (`def helper(): return super(Wrong, self).m()`) -- the new functional test contains exactly that case as a still-reported true positive next to the now-accepted `__init_subclass__` pattern.

The `super_init_not_called_extensions_py310` functional test fails identically on a clean checkout in my environment and is unrelated.

Closes #11313
