### PR TITLE
[Backport maintenance/4.0.x] Support isort 9

### DIFF
--- a/doc/whatsnew/fragments/11351.other
+++ b/doc/whatsnew/fragments/11351.other
@@ -1,0 +1,3 @@
+Upgrade the ``isort`` upper bound so ``isort`` 9 can be installed alongside pylint.
+
+Closes #11351

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "dill>=0.2; python_version<'3.11'",
   "dill>=0.3.6; python_version>='3.11'",
   "dill>=0.3.7; python_version>='3.12'",
-  "isort>=5,!=5.13,<9",
+  "isort>=5,!=5.13,<10",
   "mccabe>=0.6,<0.8",
   "platformdirs>=2.2",
   "tomli>=1.1; python_version<'3.11'",


### PR DESCRIPTION
Backport 48d3c5490fe5f42f8752e86157c69bdc3882b8bd from #11352.

The automated backport failed on `.pre-commit-config.yaml`: `main` had already moved
the `isort` hook to `9.0.0b5`, while this branch is still on `6.1.0`. The hook version
only affects how we format our own code, so this branch keeps `6.1.0` and the backport
carries just the runtime pin and the changelog fragment.

Verified with `astroid==4.0.2` (the version this branch pins for CI) and `isort==9.0.0`
installed: `2075 passed, 226 skipped, 5 xfailed`, identical to the same run on
`isort==8.0.1`. Pylint only touches `isort.Config` and `isort.place_module`, both
unchanged in isort 9.

Closes #11351