### PR TITLE
tests: skip the symlink functional test on Windows

### DIFF
--- a/doc/whatsnew/fragments/11359.internal
+++ b/doc/whatsnew/fragments/11359.internal
@@ -1,0 +1,8 @@
+The ``symlink_module`` functional test is now skipped on Windows. ``git`` sets
+``core.symlinks=false`` for a non-elevated Windows user and materialises
+``tests/functional/s/symlink/_binding/`` as regular files containing the link target,
+which pylint then lints as Python and reports ``syntax-error``. CI does not see this
+because its Windows runners materialise the symlink, so the suite was green there and
+red on an ordinary contributor's machine.
+
+Closes #11359

--- a/doc/whatsnew/fragments/11359.internal
+++ b/doc/whatsnew/fragments/11359.internal
@@ -1,8 +1,0 @@
-The ``symlink_module`` functional test is now skipped on Windows. ``git`` sets
-``core.symlinks=false`` for a non-elevated Windows user and materialises
-``tests/functional/s/symlink/_binding/`` as regular files containing the link target,
-which pylint then lints as Python and reports ``syntax-error``. CI does not see this
-because its Windows runners materialise the symlink, so the suite was green there and
-red on an ordinary contributor's machine.
-
-Closes #11359

--- a/tests/functional/s/symlink/_binding/symlink_module.rc
+++ b/tests/functional/s/symlink/_binding/symlink_module.rc
@@ -1,0 +1,3 @@
+[testoptions]
+# git cannot materialise the symlink on Windows without elevation or Developer Mode
+exclude_platforms=win32


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Closes #11359

`tests/functional/s/symlink/_binding/` is tracked as symlinks (mode `120000`). On
Windows, git sets `core.symlinks=false` unless the user is elevated or has Developer
Mode enabled, and materialises those entries as regular text files containing the link
target:

    $ cat tests/functional/s/symlink/_binding/symlink_module.py
    ../symlink_module/symlink_module.py

pylint lints that path string as Python, reports `syntax-error`, and
`test_functional[symlink_module0]` fails.

CI does not catch this: the `windows-latest` job materialises the symlink, so the suite
is green there and red on an ordinary Windows contributor's machine. It is the only
failure in a full run on Windows (`1 failed, 2182 passed, 262 skipped, 5 xfailed`).

This uses the existing `exclude_platforms` mechanism, as `bad_char_carriage_return` and
`super_init_not_called_extensions_py310` already do. A `.internal` changelog fragment is
included.

**Known trade-off:** this also skips on CI Windows, where the test currently passes and
provides real coverage. If you would rather keep that, I am happy to switch to a
documentation note (enable Developer Mode, or clone with `git -c core.symlinks=true`)
instead — the issue lays out both options.

### Testing

- `pytest tests/test_functional.py` → 892 passed, 40 skipped, 0 failed
- The `symlink_module0` case now skips with `Test cannot run on platform 'win32'`; the
  sibling `symlink_module` test still runs and passes