### PR TITLE
Clarify the target of no-else elif suggestions

### DIFF
--- a/doc/data/messages/n/no-else-return/bad.py
+++ b/doc/data/messages/n/no-else-return/bad.py
@@ -1,7 +1,10 @@
-def compare_numbers(a: int, b: int) -> int:
-    if a == b:  # [no-else-return]
-        return 0
-    elif a < b:
-        return -1
+def describe_number(value: int | None) -> str:
+    if value is None:  # [no-else-return]
+        return "missing"
+    elif value < 0:
+        description = "negative"
+    elif value == 0:
+        return "zero"
     else:
-        return 1
+        description = "positive"
+    return description

--- a/doc/data/messages/n/no-else-return/details.rst
+++ b/doc/data/messages/n/no-else-return/details.rst
@@ -1,0 +1,33 @@
+When the message names an ``elif``, the diagnostic is attached to the ``if``
+whose branch cannot fall through. Change only the first ``elif`` following that
+reported branch to ``if``. Any later ``elif`` and ``else`` clauses remain
+attached to the new ``if`` during this transformation.
+
+If another branch in the remaining chain also cannot fall through, a later
+Pylint run may report that branch separately. Each diagnostic describes one
+transformation; it does not ask you to change every ``elif`` at once.
+
+For example, after changing the first ``elif`` below, the remaining clauses
+still form one mutually exclusive chain::
+
+    if value is None:
+        return "missing"
+    if value < 0:
+        description = "negative"
+    elif value == 0:
+        return "zero"
+    else:
+        description = "positive"
+    return description
+
+This check only identifies redundant control-flow nesting. It cannot decide
+whether keeping an ``elif`` makes a deliberately exhaustive decision tree easier
+for readers to recognize. If that structure is clearer for a particular case,
+keep it and disable the message locally on the reported ``if`` statement::
+
+    if value is None:  # pylint: disable=no-else-return
+        return "missing"
+    elif value < 0:
+        return "negative"
+    else:
+        return "non-negative"

--- a/doc/data/messages/n/no-else-return/good.py
+++ b/doc/data/messages/n/no-else-return/good.py
@@ -1,6 +1,10 @@
-def compare_numbers(a: int, b: int) -> int:
-    if a == b:
-        return 0
-    if a < b:
-        return -1
-    return 1
+def describe_number(value: int | None) -> str:
+    if value is None:
+        return "missing"
+    if value < 0:
+        description = "negative"
+    elif value == 0:
+        return "zero"
+    else:
+        description = "positive"
+    return description

--- a/doc/whatsnew/fragments/9274.other
+++ b/doc/whatsnew/fragments/9274.other
@@ -1,0 +1,6 @@
+Clarify related ``no-else-*`` messages so they say that only the first ``elif``
+after the reported branch should change. Expand the ``no-else-return``
+documentation to explain later branches and when retaining an ``elif`` chain
+can better communicate an exhaustive decision.
+
+Closes #9274

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -834,7 +834,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         ):
             orelse = node.orelse[0]
             if (orelse.lineno, orelse.col_offset) in self._elifs:
-                args = ("elif", 'replace only the first following "elif" with "if"')
+                args = ("elif", 'replace only that "elif" with "if"')
             else:
                 args = ("else", 'remove the "else" and de-indent the code inside it')
             self.add_message(msg_id, node=node, args=args, confidence=HIGH)

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -834,7 +834,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         ):
             orelse = node.orelse[0]
             if (orelse.lineno, orelse.col_offset) in self._elifs:
-                args = ("elif", 'remove the leading "el" from "elif"')
+                args = ("elif", 'replace only the first following "elif" with "if"')
             else:
                 args = ("else", 'remove the "else" and de-indent the code inside it')
             self.add_message(msg_id, node=node, args=args, confidence=HIGH)

--- a/tests/functional/n/no/no_else_break.txt
+++ b/tests/functional/n/no/no_else_break.txt
@@ -1,7 +1,7 @@
 no-else-break:8:8:11:17:foo1:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-break:16:8:21:17:foo2:"Unnecessary ""elif"" after ""break"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-break:16:8:21:17:foo2:"Unnecessary ""elif"" after ""break"", replace only that ""elif"" with ""if""":HIGH
 no-else-break:28:12:33:21:foo3:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-break:41:8:48:17:foo4:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-break:54:8:63:17:foo5:"Unnecessary ""elif"" after ""break"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-break:54:8:63:17:foo5:"Unnecessary ""elif"" after ""break"", replace only that ""elif"" with ""if""":HIGH
 no-else-break:70:12:74:21:foo6:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-break:110:8:116:21:bar4:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH

--- a/tests/functional/n/no/no_else_break.txt
+++ b/tests/functional/n/no/no_else_break.txt
@@ -1,7 +1,7 @@
 no-else-break:8:8:11:17:foo1:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-break:16:8:21:17:foo2:"Unnecessary ""elif"" after ""break"", remove the leading ""el"" from ""elif""":HIGH
+no-else-break:16:8:21:17:foo2:"Unnecessary ""elif"" after ""break"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-break:28:12:33:21:foo3:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-break:41:8:48:17:foo4:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-break:54:8:63:17:foo5:"Unnecessary ""elif"" after ""break"", remove the leading ""el"" from ""elif""":HIGH
+no-else-break:54:8:63:17:foo5:"Unnecessary ""elif"" after ""break"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-break:70:12:74:21:foo6:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-break:110:8:116:21:bar4:"Unnecessary ""else"" after ""break"", remove the ""else"" and de-indent the code inside it":HIGH

--- a/tests/functional/n/no/no_else_continue.txt
+++ b/tests/functional/n/no/no_else_continue.txt
@@ -1,7 +1,7 @@
 no-else-continue:8:8:11:17:foo1:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-continue:16:8:21:17:foo2:"Unnecessary ""elif"" after ""continue"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-continue:16:8:21:17:foo2:"Unnecessary ""elif"" after ""continue"", replace only that ""elif"" with ""if""":HIGH
 no-else-continue:28:12:33:24:foo3:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-continue:41:8:48:17:foo4:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-continue:54:8:63:17:foo5:"Unnecessary ""elif"" after ""continue"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-continue:54:8:63:17:foo5:"Unnecessary ""elif"" after ""continue"", replace only that ""elif"" with ""if""":HIGH
 no-else-continue:70:12:74:21:foo6:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-continue:110:8:116:24:bar4:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH

--- a/tests/functional/n/no/no_else_continue.txt
+++ b/tests/functional/n/no/no_else_continue.txt
@@ -1,7 +1,7 @@
 no-else-continue:8:8:11:17:foo1:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-continue:16:8:21:17:foo2:"Unnecessary ""elif"" after ""continue"", remove the leading ""el"" from ""elif""":HIGH
+no-else-continue:16:8:21:17:foo2:"Unnecessary ""elif"" after ""continue"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-continue:28:12:33:24:foo3:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-continue:41:8:48:17:foo4:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-continue:54:8:63:17:foo5:"Unnecessary ""elif"" after ""continue"", remove the leading ""el"" from ""elif""":HIGH
+no-else-continue:54:8:63:17:foo5:"Unnecessary ""elif"" after ""continue"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-continue:70:12:74:21:foo6:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-continue:110:8:116:24:bar4:"Unnecessary ""else"" after ""continue"", remove the ""else"" and de-indent the code inside it":HIGH

--- a/tests/functional/n/no/no_else_raise.txt
+++ b/tests/functional/n/no/no_else_raise.txt
@@ -1,7 +1,7 @@
 no-else-raise:6:4:11:26:foo1:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-raise:15:4:23:26:foo2:"Unnecessary ""elif"" after ""raise"", remove the leading ""el"" from ""elif""":HIGH
+no-else-raise:15:4:23:26:foo2:"Unnecessary ""elif"" after ""raise"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-raise:29:8:34:30:foo3:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-raise:41:4:48:13:foo4:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-raise:53:4:62:13:foo5:"Unnecessary ""elif"" after ""raise"", remove the leading ""el"" from ""elif""":HIGH
+no-else-raise:53:4:62:13:foo5:"Unnecessary ""elif"" after ""raise"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-raise:68:8:72:17:foo6:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-raise:104:4:110:33:bar4:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH

--- a/tests/functional/n/no/no_else_raise.txt
+++ b/tests/functional/n/no/no_else_raise.txt
@@ -1,7 +1,7 @@
 no-else-raise:6:4:11:26:foo1:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-raise:15:4:23:26:foo2:"Unnecessary ""elif"" after ""raise"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-raise:15:4:23:26:foo2:"Unnecessary ""elif"" after ""raise"", replace only that ""elif"" with ""if""":HIGH
 no-else-raise:29:8:34:30:foo3:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-raise:41:4:48:13:foo4:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-raise:53:4:62:13:foo5:"Unnecessary ""elif"" after ""raise"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-raise:53:4:62:13:foo5:"Unnecessary ""elif"" after ""raise"", replace only that ""elif"" with ""if""":HIGH
 no-else-raise:68:8:72:17:foo6:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-raise:104:4:110:33:bar4:"Unnecessary ""else"" after ""raise"", remove the ""else"" and de-indent the code inside it":HIGH

--- a/tests/functional/n/no/no_else_return.txt
+++ b/tests/functional/n/no/no_else_return.txt
@@ -1,8 +1,8 @@
 no-else-return:6:4:11:16:foo1:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-return:15:4:23:16:foo2:"Unnecessary ""elif"" after ""return"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-return:15:4:23:16:foo2:"Unnecessary ""elif"" after ""return"", replace only that ""elif"" with ""if""":HIGH
 no-else-return:29:8:34:20:foo3:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-return:41:4:48:13:foo4:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-return:53:4:62:13:foo5:"Unnecessary ""elif"" after ""return"", replace only the first following ""elif"" with ""if""":HIGH
+no-else-return:53:4:62:13:foo5:"Unnecessary ""elif"" after ""return"", replace only that ""elif"" with ""if""":HIGH
 no-else-return:68:8:72:17:foo6:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-return:104:4:110:23:bar4:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-return:114:4:120:19:try_one_except:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH

--- a/tests/functional/n/no/no_else_return.txt
+++ b/tests/functional/n/no/no_else_return.txt
@@ -1,8 +1,8 @@
 no-else-return:6:4:11:16:foo1:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-return:15:4:23:16:foo2:"Unnecessary ""elif"" after ""return"", remove the leading ""el"" from ""elif""":HIGH
+no-else-return:15:4:23:16:foo2:"Unnecessary ""elif"" after ""return"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-return:29:8:34:20:foo3:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-return:41:4:48:13:foo4:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
-no-else-return:53:4:62:13:foo5:"Unnecessary ""elif"" after ""return"", remove the leading ""el"" from ""elif""":HIGH
+no-else-return:53:4:62:13:foo5:"Unnecessary ""elif"" after ""return"", replace only the first following ""elif"" with ""if""":HIGH
 no-else-return:68:8:72:17:foo6:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-return:104:4:110:23:bar4:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH
 no-else-return:114:4:120:19:try_one_except:"Unnecessary ""else"" after ""return"", remove the ""else"" and de-indent the code inside it":HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |
| ✓   | :scroll: Docs |

## Description

The `no-else-return` diagnostic is emitted on the preceding `if`, while its
suggestion refers to an `elif` later in the chain. In a chain with more than one
`elif`, the previous wording—`remove the leading "el" from "elif"`—did not make
it clear which keyword should change. That ambiguity is the source of the
unsafe-looking transformation reported in #9274.

This change makes the suggested edit explicit: replace only the first `elif`
following the reported branch with `if`. The checker uses the same suggestion
builder for `no-else-return`, `no-else-raise`, `no-else-break`, and
`no-else-continue`, so the corresponding functional expectations are updated
together. Detection, message location, confidence, message IDs, and local
suppression behavior are unchanged.

The `no-else-return` documentation now uses a multi-`elif` example in which the
first non-returning branch falls through. Its corrected form changes only the
targeted `elif` and keeps the later `elif`/`else` chain attached. Additional
guidance explains that a later Pylint run may report another independently
redundant branch, and that retaining an exhaustive-looking chain can be a valid
readability choice handled with a local disable.

Validation:

- `python -m pytest tests/test_functional.py -k "no_else_return or no_else_raise or no_else_break or no_else_continue"` — 4 passed
- `python -m pytest doc/test_messages_documentation.py` — 852 passed, 2 skipped
- `sphinx-build -T -W -j auto --keep-going -b html -d _build/doctrees -D language=en . _build/html` — build succeeded
- `pre-commit run --all-files` — all hooks passed
- `git diff --check` — passed

Closes #9274

AI assistance was used for issue and code-path research and for drafting. I
reviewed the final diff and ran the validation listed above.
