### PR TITLE
Fix unnecessary-ellipsis false positive for Protocol methods

### DIFF
--- a/doc/whatsnew/fragments/9319.false_positive
+++ b/doc/whatsnew/fragments/9319.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for :ref:`unnecessary-ellipsis` when an ellipsis is the
+sole body statement of a method defined on a ``Protocol``.
+
+Closes #9319

--- a/pylint/checkers/ellipsis_checker.py
+++ b/pylint/checkers/ellipsis_checker.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from astroid import nodes
 
-from pylint.checkers import BaseChecker
+from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import only_required_for_messages
 
 if TYPE_CHECKING:
@@ -40,17 +40,22 @@ class EllipsisChecker(BaseChecker):
            For example: A function consisting of an ellipsis followed by a
            return statement on the next line.
         """
-        if (
-            node.pytype() == "builtins.Ellipsis"
-            and isinstance(node.parent, nodes.Expr)
-            and (
-                (
-                    isinstance(node.parent.parent, (nodes.ClassDef, nodes.FunctionDef))
-                    and node.parent.parent.doc_node
-                )
-                or len(node.parent.parent.body) > 1
-            )
+        if node.pytype() != "builtins.Ellipsis" or not isinstance(
+            node.parent, nodes.Expr
         ):
+            return
+
+        scope = node.parent.parent
+        if (
+            isinstance(scope, nodes.FunctionDef)
+            and utils.is_function_body_ellipsis(scope)
+            and utils.is_protocol_class(scope.parent)
+        ):
+            return
+
+        if (
+            isinstance(scope, (nodes.ClassDef, nodes.FunctionDef)) and scope.doc_node
+        ) or len(scope.body) > 1:
             self.add_message("unnecessary-ellipsis", node=node)
 
 

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.py
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=missing-docstring, too-few-public-methods, invalid-name, unused-argument, comparison-of-constants
 
-from typing import List, overload, Union
+from typing import List, overload, Protocol, Union
 
 # Ellipsis and preceding statement
 try:
@@ -129,3 +129,16 @@ def func2(val1, val2):
 
 
 assert "x" != ...
+
+
+class ProtocolInterface(Protocol):
+    def value(self) -> int:
+        """Return a value."""
+        ...
+
+
+class ProtocolWithImplementation(Protocol):
+    def value(self) -> int:
+        """Return a value."""
+        ...  # [unnecessary-ellipsis]
+        return 1

--- a/tests/functional/u/unnecessary/unnecessary_ellipsis.txt
+++ b/tests/functional/u/unnecessary/unnecessary_ellipsis.txt
@@ -2,3 +2,4 @@ unnecessary-ellipsis:12:4:12:7::Unnecessary ellipsis constant:UNDEFINED
 unnecessary-ellipsis:15:4:15:7:ellipsis_and_subsequent_statement:Unnecessary ellipsis constant:UNDEFINED
 unnecessary-ellipsis:50:4:50:7:docstring_and_ellipsis:Unnecessary ellipsis constant:UNDEFINED
 unnecessary-ellipsis:66:4:66:7:DocstringAndEllipsis:Unnecessary ellipsis constant:UNDEFINED
+unnecessary-ellipsis:143:8:143:11:ProtocolWithImplementation.value:Unnecessary ellipsis constant:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`unnecessary-ellipsis` currently treats an ellipsis after a method docstring as
redundant. For a method declared on a `Protocol`, however, a body consisting
only of `...` intentionally marks the method as unimplemented. Removing it can
also make type checkers interpret the method as having an implicit `None`
return, which conflicts with a declared non-`None` return type.

This change suppresses the message only when all three relevant conditions are
true:

1. the ellipsis belongs to a function body;
2. it is the function's sole body statement; and
3. the containing class resolves to a `typing.Protocol`.

The narrower conditions preserve the existing diagnostic for Protocol methods
that contain an ellipsis alongside real statements. They also leave ordinary
classes, class-level ellipses, overload stubs, and `abstractmethod` behavior
unchanged; the latter is intentionally outside the accepted scope of #9319.

The functional fixture covers both sides of the boundary: a documented
Protocol method whose sole body is an ellipsis is accepted, while a documented
Protocol method with an ellipsis followed by `return 1` is still reported.

## Validation

- red/green functional regression: the accepted Protocol case produced an
  unexpected `unnecessary-ellipsis` on the base implementation, then passed
  after the checker change
- focused functional test: 1 passed
- complete functional suite: 901 passed, 37 skipped
- `pre-commit run --all-files`: all hooks passed, including Ruff, Black,
  Pylint, mypy, Bandit, codespell, and the news-fragment checks
- `git diff --check`: passed

Closes #9319

AI assistance was used for repository research and drafting. I reviewed the
final implementation and ran every validation command listed above.
