### PR TITLE
Generate documentation for Run options

### DIFF
--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -122,6 +122,9 @@ def _create_checker_section(
 
         # Start adding the option to the toml example
         if option.optdict.get("hide_from_config_file"):
+            checker_string += (
+                "**This option is only available on the command line.**\n\n\n"
+            )
             continue
 
         # Get current value of option
@@ -221,11 +224,11 @@ def build_options_page(app: Sphinx | None) -> None:
 
     Documentation is written in ReST format.
     """
-    # Create linter, register all checkers and extensions and get all options
-    # Build the argument parser without executing Run, which would start linting.
+    # ``_make_run_options`` only stores the uninitialized ``Run`` instance in
+    # callback action kwargs. The callbacks are never invoked while generating
+    # this page, so the instance is not dereferenced here.
     run = object.__new__(Run)
-    linter = PyLinter(_make_run_options(run), option_groups=Run.option_groups)
-    run.linter = linter
+    linter = PyLinter(_make_run_options(run))
     _register_all_checkers_and_extensions(linter)
 
     options = _get_all_options(linter)

--- a/doc/exts/pylint_options.py
+++ b/doc/exts/pylint_options.py
@@ -18,7 +18,8 @@ from sphinx.application import Sphinx
 from pylint.checkers import initialize as initialize_checkers
 from pylint.checkers.base_checker import BaseChecker
 from pylint.extensions import initialize as initialize_extensions
-from pylint.lint import PyLinter
+from pylint.lint import PyLinter, Run
+from pylint.lint.base_options import _make_run_options
 from pylint.typing import OptionDict
 from pylint.utils import get_rst_title
 from pylint.utils.utils import _unquote
@@ -221,7 +222,10 @@ def build_options_page(app: Sphinx | None) -> None:
     Documentation is written in ReST format.
     """
     # Create linter, register all checkers and extensions and get all options
-    linter = PyLinter()
+    # Build the argument parser without executing Run, which would start linting.
+    run = object.__new__(Run)
+    linter = PyLinter(_make_run_options(run), option_groups=Run.option_groups)
+    run.linter = linter
     _register_all_checkers_and_extensions(linter)
 
     options = _get_all_options(linter)

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -67,6 +67,9 @@ Standard Checkers
 **Default:**  ``None``
 
 
+**This option is only available on the command line.**
+
+
 .. _errors-only-option:
 
 --errors-only
@@ -74,6 +77,9 @@ Standard Checkers
 *In error mode, messages with a category besides ERROR or FATAL are suppressed, and no reports are done by default. Error mode is compatible with disabling specific errors.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 .. _evaluation-option:
@@ -157,6 +163,9 @@ Standard Checkers
 **Default:**  ``None``
 
 
+**This option is only available on the command line.**
+
+
 .. _generate-rcfile-option:
 
 --generate-rcfile
@@ -164,6 +173,9 @@ Standard Checkers
 *Generate a sample configuration file according to the current configuration. You can put other options before this one to get them in the generated configuration.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 .. _generate-toml-config-option:
@@ -175,6 +187,9 @@ Standard Checkers
 **Default:**  ``None``
 
 
+**This option is only available on the command line.**
+
+
 .. _help-msg-option:
 
 --help-msg
@@ -182,6 +197,9 @@ Standard Checkers
 *Display a help message for the given message id and exit. The value may be a comma separated list of message ids.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 .. _ignore-option:
@@ -256,6 +274,9 @@ Standard Checkers
 **Default:**  ``None``
 
 
+**This option is only available on the command line.**
+
+
 .. _list-extensions-option:
 
 --list-extensions
@@ -263,6 +284,9 @@ Standard Checkers
 *List available extensions.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 .. _list-groups-option:
@@ -274,6 +298,9 @@ Standard Checkers
 **Default:**  ``None``
 
 
+**This option is only available on the command line.**
+
+
 .. _list-msgs-option:
 
 --list-msgs
@@ -283,6 +310,9 @@ Standard Checkers
 **Default:**  ``None``
 
 
+**This option is only available on the command line.**
+
+
 .. _list-msgs-enabled-option:
 
 --list-msgs-enabled
@@ -290,6 +320,9 @@ Standard Checkers
 *Display a list of what messages are enabled, disabled and non-emittable with the given configuration.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 .. _load-plugins-option:
@@ -310,6 +343,9 @@ Standard Checkers
 **Default:**  ``None``
 
 
+**This option is only available on the command line.**
+
+
 .. _msg-template-option:
 
 --msg-template
@@ -326,6 +362,9 @@ Standard Checkers
 *Specify an output file.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 .. _output-format-option:
@@ -371,6 +410,9 @@ Standard Checkers
 *Specify a configuration file to load.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 .. _recursive-option:
@@ -425,6 +467,9 @@ Standard Checkers
 *In verbose mode, extra non-checker-related info will be displayed.*
 
 **Default:**  ``None``
+
+
+**This option is only available on the command line.**
 
 
 

--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -58,6 +58,24 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _enable-all-extensions-option:
+
+--enable-all-extensions
+"""""""""""""""""""""""
+*Load and enable all available extensions. Use --list-extensions to see a list all available extensions.*
+
+**Default:**  ``None``
+
+
+.. _errors-only-option:
+
+--errors-only
+"""""""""""""
+*In error mode, messages with a category besides ERROR or FATAL are suppressed, and no reports are done by default. Error mode is compatible with disabling specific errors.*
+
+**Default:**  ``None``
+
+
 .. _evaluation-option:
 
 --evaluation
@@ -130,6 +148,42 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _full-documentation-option:
+
+--full-documentation
+""""""""""""""""""""
+*Generate pylint's full documentation.*
+
+**Default:**  ``None``
+
+
+.. _generate-rcfile-option:
+
+--generate-rcfile
+"""""""""""""""""
+*Generate a sample configuration file according to the current configuration. You can put other options before this one to get them in the generated configuration.*
+
+**Default:**  ``None``
+
+
+.. _generate-toml-config-option:
+
+--generate-toml-config
+""""""""""""""""""""""
+*Generate a sample configuration file according to the current configuration. You can put other options before this one to get them in the generated configuration. The config is in the .toml format.*
+
+**Default:**  ``None``
+
+
+.. _help-msg-option:
+
+--help-msg
+""""""""""
+*Display a help message for the given message id and exit. The value may be a comma separated list of message ids.*
+
+**Default:**  ``None``
+
+
 .. _ignore-option:
 
 --ignore
@@ -166,6 +220,15 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _init-hook-option:
+
+--init-hook
+"""""""""""
+*Python code to execute, usually for sys.path manipulation such as pygtk.require().*
+
+**Default:**  ``None``
+
+
 .. _jobs-option:
 
 --jobs
@@ -184,6 +247,51 @@ Standard Checkers
 **Default:**  ``100``
 
 
+.. _list-conf-levels-option:
+
+--list-conf-levels
+""""""""""""""""""
+*Generate pylint's confidence levels.*
+
+**Default:**  ``None``
+
+
+.. _list-extensions-option:
+
+--list-extensions
+"""""""""""""""""
+*List available extensions.*
+
+**Default:**  ``None``
+
+
+.. _list-groups-option:
+
+--list-groups
+"""""""""""""
+*List pylint's message groups.*
+
+**Default:**  ``None``
+
+
+.. _list-msgs-option:
+
+--list-msgs
+"""""""""""
+*Display a list of all pylint's messages divided by whether they are emittable with the given interpreter.*
+
+**Default:**  ``None``
+
+
+.. _list-msgs-enabled-option:
+
+--list-msgs-enabled
+"""""""""""""""""""
+*Display a list of what messages are enabled, disabled and non-emittable with the given configuration.*
+
+**Default:**  ``None``
+
+
 .. _load-plugins-option:
 
 --load-plugins
@@ -193,6 +301,15 @@ Standard Checkers
 **Default:**  ``()``
 
 
+.. _long-help-option:
+
+--long-help
+"""""""""""
+*Show more verbose help.*
+
+**Default:**  ``None``
+
+
 .. _msg-template-option:
 
 --msg-template
@@ -200,6 +317,15 @@ Standard Checkers
 *Template used to display messages. This is a python new-style format string used to format the message information. See doc for all details.*
 
 **Default:** ``""``
+
+
+.. _output-option:
+
+--output
+""""""""
+*Specify an output file.*
+
+**Default:**  ``None``
 
 
 .. _output-format-option:
@@ -236,6 +362,15 @@ Standard Checkers
 *Minimum Python version to use for version dependent checks. Will default to the version used to run pylint.*
 
 **Default:**  ``sys.version_info[:2]``
+
+
+.. _rcfile-option:
+
+--rcfile
+""""""""
+*Specify a configuration file to load.*
+
+**Default:**  ``None``
 
 
 .. _recursive-option:
@@ -283,6 +418,15 @@ Standard Checkers
 **Default:**  ``False``
 
 
+.. _verbose-option:
+
+--verbose
+"""""""""
+*In verbose mode, extra non-checker-related info will be displayed.*
+
+**Default:**  ``None``
+
+
 
 .. raw:: html
 
@@ -327,6 +471,8 @@ Standard Checkers
    ignore-patterns = ["^\\.#"]
 
    ignored-modules = []
+
+   # init-hook =
 
    jobs = 1
 

--- a/doc/whatsnew/fragments/6938.other
+++ b/doc/whatsnew/fragments/6938.other
@@ -1,0 +1,4 @@
+Documentation for options defined by ``Run``, such as ``--errors-only`` and
+``--init-hook``, is now generated alongside checker configuration options.
+
+Closes #6938

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -567,7 +567,7 @@ def _make_run_options(self: Run) -> Options:
                 "short": "E",
                 "help": "In error mode, messages with a category besides "
                 "ERROR or FATAL are suppressed, and no reports are done by default. "
-                "Error mode is compatible with disabling specific errors. ",
+                "Error mode is compatible with disabling specific errors.",
                 "hide_from_config_file": True,
             },
         ),


### PR DESCRIPTION
## Type of Changes

|     | Type             |
| --- | ---------------- |
| ✓   | :scroll: Docs    |

## Description

Pylint's generated all-options page previously constructed a bare `PyLinter`. That registered checker and linter options, but it omitted the options supplied by `Run`, including `--errors-only`, `--init-hook`, `--rcfile`, `--output`, and the command/listing switches.

This change builds the documentation linter with the same `_make_run_options` metadata used by a normal `Run`, without executing a lint invocation. The temporary `Run` reference is connected to the constructed linter so the registered callback actions retain the same object relationship as the real CLI.

As a result:

- all 16 options currently defined by `Run` are generated into the `Main` options section from their in-code help metadata;
- options marked `hide_from_config_file` are documented but remain excluded from the TOML example;
- `--init-hook`, which is configurable, is documented and remains present in the generated `[tool.pylint.main]` example; and
- future changes to these options continue to use `pylint/lint/base_options.py` as the single source of truth instead of requiring hand-written option pages.

The checked-in `all-options.rst` was regenerated. I also removed the trailing space from the existing `--errors-only` help text so its generated emphasis has no stray whitespace.

## Validation

- Confirmed the pre-change generated page had no `errors-only`, `init-hook`, or `enable-all-extensions` option anchors.
- Regenerated the page and programmatically verified that all 16/16 `Run` option names have anchors.
- Built all 704 documentation sources with Sphinx 8.2.3 using `-T -W --keep-going -E -a`; the build completed without warnings.
- Verified the rendered HTML contains the new `--errors-only` and `--init-hook` sections and index links.
- Ran the focused pre-commit hooks on all four changed files.
- Ran `pre-commit run --all-files`; every hook passed.
- Ran `git diff --check`.

Closes #6938
