### PR TITLE
Improve py-version guidance for multi-version projects

### DIFF
--- a/doc/user_guide/installation/command_line_installation.rst
+++ b/doc/user_guide/installation/command_line_installation.rst
@@ -19,10 +19,14 @@ Or if you want to also check spelling with ``enchant`` (you might need to
 
 The newest pylint supports all Python interpreters that are not past end of life.
 
-We recommend to use the latest interpreter because we rely on the ``ast`` builtin
-module that gets better with each new Python interpreter. For example a Python
-3.6 interpreter can't analyse 3.8 syntax (amongst others, because of the new walrus operator) while a 3.8
-interpreter can also deal with Python 3.6. See :ref:`using pylint with multiple interpreters <continuous-integration>` for more details.
+Pylint relies on the ``ast`` module provided by the Python interpreter that runs
+it, so that interpreter must be able to parse the syntax used by the code. Newer
+interpreters generally provide a more capable parser. However, for projects that
+support multiple Python versions, running Pylint on the oldest supported interpreter
+is usually the most reliable way to match the compatibility floor. If the lint
+environment uses a newer interpreter, set ``py-version`` to the oldest supported
+version for version-aware checks; it does not emulate the older interpreter. See
+:ref:`using pylint with multiple interpreters <continuous-integration>` for more details.
 
 .. note::
     You can also use ``conda`` or your system package manager on debian based OS.

--- a/doc/user_guide/installation/with-multiple-interpreters.rst
+++ b/doc/user_guide/installation/with-multiple-interpreters.rst
@@ -3,13 +3,32 @@
 Installation with multiple interpreters
 =======================================
 
-It's possible to analyse code written for older or multiple interpreters by using
-the ``py-version`` option and setting it to the oldest supported interpreter of your code. For example you can check
-that there are no ``f-strings`` in Python 3.5 code using Python 3.8 with an up-to-date
-pylint even if Python 3.5 is past end of life (EOL) and the version of pylint you use is not
-compatible with it.
+Pylint runs inside a real Python interpreter. For most projects, the most reliable
+way to check code that supports multiple Python versions is therefore to run Pylint
+with the oldest Python version that the project supports. This makes the parser,
+standard library, and import environment match the project's compatibility floor.
 
-We do not guarantee that ``py-version`` will work for all EOL Python interpreters indefinitely,
-(for anything before Python 3.5, it probably won't). If a newer version does not work for you,
-the best available pylint might be an old version that works with your old interpreter but
-without the bug fixes and features of later versions.
+Sometimes the lint environment intentionally uses a newer interpreter. For example,
+a pre-commit configuration might standardize all development tools on Python 3.13
+while the project still supports Python 3.10. In that case, set ``py-version`` to
+the oldest supported version::
+
+    [tool.pylint.main]
+    py-version = "3.10"
+
+The equivalent command-line option is ``--py-version=3.10``. Without an explicit
+value, ``py-version`` defaults to the version of Python that runs Pylint.
+
+``py-version`` tells version-aware checks which Python features are available to
+every supported interpreter. For example, it prevents Pylint from suggesting a
+refactoring that requires a version newer than Python 3.10 and allows the
+unsupported-version checker to report syntax that Python 3.10 cannot use. It does
+not switch the interpreter that runs Pylint or emulate that interpreter's complete
+standard library and runtime behavior, so running Pylint on the oldest supported
+version remains preferable when practical.
+
+Pylint does not guarantee that ``py-version`` will continue to support every
+end-of-life Python release indefinitely. If current Pylint cannot analyse the
+project's oldest supported release, the best available fallback may be an older
+Pylint that still runs on that interpreter, without the fixes and features added
+to later Pylint releases.

--- a/doc/whatsnew/fragments/5038.other
+++ b/doc/whatsnew/fragments/5038.other
@@ -1,0 +1,4 @@
+Clarify how to choose the Python interpreter and ``py-version`` when linting a
+project that supports multiple Python versions.
+
+Closes #5038


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
| ✓   | :scroll: Docs          |

## Description

Closes #5038.

The existing multiple-interpreter page mentioned `py-version`, but it did not clearly separate two independent choices:

1. the real Python interpreter in which Pylint runs; and
2. the minimum Python version supplied to version-aware checks.

That distinction matters when a project supports several Python versions but runs development tools through a newer pre-commit interpreter. The revised page now:

- recommends running Pylint on the project's oldest supported interpreter when practical, so parsing, imports, and the standard library are checked in the closest available environment;
- gives a concrete `pyproject.toml` and command-line example for a Python 3.10 compatibility floor when Pylint itself runs on Python 3.13;
- documents that the default is the interpreter currently running Pylint;
- explains both sides of version-aware behavior: newer-only refactoring suggestions are suppressed, while the unsupported-version checker can report syntax unavailable at the configured floor;
- makes the non-emulation boundary explicit—`py-version` does not replace the running interpreter or reproduce its complete runtime and standard library;
- retains the warning that support for end-of-life targets is not guaranteed indefinitely.

The generated-default inconsistency originally listed in #5038 was already addressed by #5069, so this PR keeps the current generated option output unchanged and completes the remaining usage guidance.

An open documentation-wide option-linking PR (#11266) changes the two existing `py-version` literals in the same page into cross-references. Its overlap is mechanical; this PR deliberately does not duplicate that broader linking work.

## Validation

- `pre-commit run --files doc/user_guide/installation/with-multiple-interpreters.rst doc/whatsnew/fragments/5038.other`
- `pre-commit run --all-files`
- `python -m sphinx -T -W --keep-going -E -a -b html doc <external-build-dir>` — 704 sources, build succeeded
- rendered HTML assertions for the oldest-version recommendation, the current-interpreter default, and the non-emulation boundary
- existing examples exercised with `--py-version=3.5` and `3.6`: the unsupported f-string diagnostic appears for 3.5, the f-string refactoring suggestion is absent for 3.5, and the suggestion appears for 3.6
- `git diff --check`
