### PR TITLE
Fix using-constant-test for unpacked generator values

### DIFF
--- a/doc/whatsnew/fragments/10080.false_positive
+++ b/doc/whatsnew/fragments/10080.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for :ref:`using-constant-test` when testing a value unpacked from a generator.
+
+Closes #10080

--- a/pylint/checkers/base/basic_checker.py
+++ b/pylint/checkers/base/basic_checker.py
@@ -360,6 +360,15 @@ class BasicChecker(_BasicChecker):
         if emit:
             self.add_message("using-constant-test", node=test, confidence=INFERENCE)
         elif isinstance(inferred, const_nodes):
+            # Astroid infers names bound by unpacking a generator as the
+            # built-in generator class, even though they hold yielded values.
+            if (
+                isinstance(test, nodes.Name)
+                and isinstance(inferred, nodes.ClassDef)
+                and inferred.qname() == "builtins.generator"
+                and self._name_is_unpacked_from_generator(test)
+            ):
+                return
             # If the constant node is a FunctionDef or Lambda then
             # it may be an illicit function call due to missing parentheses
             call_inferred = None
@@ -378,6 +387,22 @@ class BasicChecker(_BasicChecker):
                     confidence=INFERENCE,
                 )
             self.add_message("using-constant-test", node=test, confidence=INFERENCE)
+
+    @staticmethod
+    def _name_is_unpacked_from_generator(test: nodes.Name) -> bool:
+        """Return whether ``test`` names a value unpacked from a generator."""
+        assignments = test.frame().lookup(test.name)[1]
+        for assignment in assignments:
+            if not isinstance(assignment, nodes.AssignName):
+                continue
+            statement = assignment.statement()
+            if (
+                isinstance(statement, nodes.Assign)
+                and assignment.parent is not statement
+                and isinstance(utils.safe_infer(statement.value), bases.Generator)
+            ):
+                return True
+        return False
 
     @staticmethod
     def _name_holds_generator(test: nodes.Name) -> tuple[bool, nodes.Call | None]:

--- a/tests/functional/u/using_constant_test.py
+++ b/tests/functional/u/using_constant_test.py
@@ -176,3 +176,17 @@ if z:
 gen = get_generator()
 if gen:  # [using-constant-test]
     pass
+
+
+# Values unpacked from a generator are not necessarily truthy (#10080).
+def generator_with_unknown_value():
+    yield input()
+
+
+[unpacked_list_item] = generator_with_unknown_value()
+if unpacked_list_item:
+    pass
+
+(unpacked_tuple_item,) = generator_with_unknown_value()
+if unpacked_tuple_item:
+    pass


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Closes #10080

Astroid currently infers a name bound by unpacking a generator as the built-in generator class. This makes using-constant-test treat the yielded value as always truthy. Ignore that inference only when the name is an unpacking target whose assignment value resolves to a generator.

This adds regression cases for list and tuple unpacking. Generators assigned directly to a name are still reported.

## Tests

- python -m pytest -q tests/test_functional.py
- 897 passed, 41 skipped