### PR TITLE
fix(issue #11357): IndexError with missing `Generator` arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ build-stamp
 .pytest_cache/
 .mypy_cache/
 .benchmarks/
+.cie/
+.venv/
+.forge/

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -280,6 +280,7 @@ class TypingChecker(BaseChecker):
                 in {"_collections_abc.Generator", "_collections_abc.AsyncGenerator"}
             )
             and isinstance(node.slice, nodes.Tuple)
+            and node.slice.elts
             and all(
                 (isinstance(el, nodes.Const) and el.value is None)
                 for el in node.slice.elts[1:]

--- a/tests/test_forge_11357.py
+++ b/tests/test_forge_11357.py
@@ -2,10 +2,11 @@
 
 See: https://github.com/pylint-dev/pylint/issues/11357
 """
-import pytest
-from pylint.testutils import CheckerTestCase, MessageTest, set_config
-from pylint.extensions.typing import TypingChecker
+
 import astroid
+
+from pylint.extensions.typing import TypingChecker
+from pylint.testutils import CheckerTestCase, set_config
 
 
 class TestTypingCheckerEmptyGenerator(CheckerTestCase):

--- a/tests/test_forge_11357.py
+++ b/tests/test_forge_11357.py
@@ -1,0 +1,26 @@
+"""Regression test for IndexError with missing Generator arguments.
+
+See: https://github.com/pylint-dev/pylint/issues/11357
+"""
+import pytest
+from pylint.testutils import CheckerTestCase, MessageTest, set_config
+from pylint.extensions.typing import TypingChecker
+import astroid
+
+
+class TestTypingCheckerEmptyGenerator(CheckerTestCase):
+    """Test that empty Generator subscript doesn't crash."""
+
+    CHECKER_CLASS = TypingChecker
+
+    @set_config()
+    def test_empty_generator_subscript_no_crash(self):
+        """Test that Generator[()] does not cause an IndexError."""
+        code = """
+from collections.abc import Generator
+
+Generator[()]
+"""
+        module = astroid.parse(code)
+        # This should not raise IndexError
+        self.walk(module)


### PR DESCRIPTION
Fixes https://github.com/pylint-dev/pylint/issues/11357

## What
autonomous fix via `atomic-forge fix` — CIE (code graph over MCP) localized the bug, generated a failing regression test, and forge's repair loop fixed the source against it.

## Issue
> **IndexError with missing `Generator` arguments**

### Bug description

```python
# Code from a local fuzzing run

from collections.abc import Generator

Generator[()]
```

### Configuration

```ini

```

### Command used

```shell
pylint --enable-all-extensions crash.py
```

### Pylint output

```python
Traceback (most recent call last):
  File "pylint/pylint/utils/ast_walker.py", line 87, in walk
    callback(astroid)
    ~~~~~~~~^^^^^^^^^
  File "pylint/pylint/extensions/typing.py", line 289, in visit_subscript
    f"{node.value.as_string()}[{node.slice.elts[0].as_string()}]"
                                ~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

### Expected behavior

No crash

### Pylint version

```shell
pylint-dev/astroid@cec5b897
pylint-dev/pylint@5ba4f69e7
Python 3.14.7

The crash also affects Pylint 4.0.7
```

### OS / Environment

Arch Linux

### Additional dependencies

```python

```

## How it was verified
- regression test: `tests/test_forge_11357.py` (CIE-generated; fails on the pre-fix code, passes on the fix)
- repair rounds: 1  failures: 1 -> 0
- repaired file(s): pylint/extensions/typing.py

---
<!-- atomic-forge:pr -->
[![Fixed by Forge](https://img.shields.io/badge/fixed_by-atomic--forge-6f42c1?logo=github)](https://github.com/kannamma-labs/atomic-forge)

🔨 Fixed by [Forge](https://github.com/kannamma-labs/atomic-forge) — an autonomous, test-driven issue→PR repair engine (`atomic-forge fix <issue-url>`).

⭐ If you found this useful, a star on [atomic-forge](https://github.com/kannamma-labs/atomic-forge) helps other maintainers find the tool that fixed your bug.
