### PR TITLE
Add implicit-reimport check for redundant parent imports

### DIFF
--- a/doc/data/messages/i/implicit-reimport/bad.py
+++ b/doc/data/messages/i/implicit-reimport/bad.py
@@ -1,0 +1,2 @@
+import logging  # [implicit-reimport]
+import logging.config

--- a/doc/data/messages/i/implicit-reimport/good.py
+++ b/doc/data/messages/i/implicit-reimport/good.py
@@ -1,0 +1,2 @@
+import logging.config
+import logging.handlers

--- a/doc/data/messages/u/ungrouped-imports/good.py
+++ b/doc/data/messages/u/ungrouped-imports/good.py
@@ -1,5 +1,5 @@
-import logging
 import logging.config
+import logging.handlers
 import os
 import sys
 from logging.handlers import FileHandler

--- a/doc/whatsnew/fragments/9873.new_check
+++ b/doc/whatsnew/fragments/9873.new_check
@@ -1,0 +1,3 @@
+Added the ``implicit-reimport`` warning for redundant parent-package imports when an unaliased submodule import already binds the parent package.
+
+Closes #9873

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -645,7 +645,9 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                         if not isinstance(other, nodes.Import):
                             continue
                         for other_name, other_alias in other.names:
-                            if other_alias is not None or not other_name.startswith(prefix):
+                            if other_alias is not None or not other_name.startswith(
+                                prefix
+                            ):
                                 continue
                             self.add_message(
                                 "implicit-reimport",

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -317,6 +317,11 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "shadowed-import",
         "Used when a module is aliased with a name that shadows another import.",
     ),
+    "W0417": (
+        "Import %r is unnecessary, as %r implicitly imports it",
+        "implicit-reimport",
+        "Used when importing a submodule also imports its parent module.",
+    ),
 }
 
 
@@ -466,6 +471,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
         BaseChecker.__init__(self, linter)
         self.import_graph: defaultdict[str, set[str]] = defaultdict(set)
         self._imports_stack: list[tuple[ImportNode, str]] = []
+        self._scope_imports: dict[int, tuple[nodes.NodeNG, list[ImportNode]]] = {}
         self._non_import_nodes: list[nodes.NodeNG] = []
         self._module_pkg: dict[Any, Any] = (
             {}
@@ -543,9 +549,11 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
     def visit_module(self, node: nodes.Module) -> None:
         """Store if current module is a package, i.e. an __init__ file."""
         self._current_module_package = node.package
+        self._scope_imports = {}
 
     def visit_import(self, node: nodes.Import) -> None:
         """Triggered when an import statement is seen."""
+        self._record_scope_import(node)
         self._check_reimport(node)
         self._check_import_as_rename(node)
         self._check_toplevel(node)
@@ -571,6 +579,7 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
 
     def visit_importfrom(self, node: nodes.ImportFrom) -> None:
         """Triggered when a from statement is seen."""
+        self._record_scope_import(node)
         basename = node.modname
         imported_module = self._get_imported_module(node, basename)
         absolute_name = get_import_name(node, basename)
@@ -598,12 +607,56 @@ class ImportsChecker(DeprecatedMixin, BaseChecker):
                 self._add_imported_module(node, imported_module.name)
 
     def leave_module(self, node: nodes.Module) -> None:
+        self._check_implicit_reimports()
         # Skip the expensive isort-based classification when no
         # import-ordering message is enabled (e.g. only cyclic-import).
         if any(self.linter.is_message_enabled(m) for m in ISORT_MESSAGES):
             self.isort_leave_module(node)
         self._imports_stack = []
+        self._scope_imports = {}
         self._non_import_nodes = []
+
+    def _record_scope_import(self, node: ImportNode) -> None:
+        frame = node.frame()
+        imports = self._scope_imports.setdefault(id(frame), (frame, []))[1]
+        imports.append(node)
+
+    def _check_implicit_reimports(self) -> None:
+        if not self.linter.is_message_enabled("implicit-reimport"):
+            return
+
+        for _, imports in self._scope_imports.values():
+            for node in imports:
+                if not isinstance(node, nodes.Import):
+                    continue
+
+                # ``import package`` is only redundant when a later import
+                # binds the parent package name as well.  An aliased dotted
+                # import (``import package.submodule as submodule``) binds
+                # only the alias and therefore must not trigger this check.
+                for imported_name, alias in node.names:
+                    if alias or "." in imported_name:
+                        continue
+
+                    prefix = f"{imported_name}."
+                    for other in imports:
+                        if other is node or astroid.are_exclusive(other, node):
+                            continue
+                        if not isinstance(other, nodes.Import):
+                            continue
+                        for other_name, other_alias in other.names:
+                            if other_alias is not None or not other_name.startswith(prefix):
+                                continue
+                            self.add_message(
+                                "implicit-reimport",
+                                node=node,
+                                args=(imported_name, other_name),
+                                confidence=HIGH,
+                            )
+                            break
+                        else:
+                            continue
+                        break
 
     def isort_leave_module(self, node: nodes.Module) -> None:
         # Check imports are grouped by category (standard, 3rd party, local)

--- a/tests/functional/d/disable_ungrouped_imports.py
+++ b/tests/functional/d/disable_ungrouped_imports.py
@@ -1,6 +1,6 @@
 """Checks that disabling 'ungrouped-imports' on an import prevents subsequent
 imports from being considered ungrouped in respect to it."""
-# pylint: disable=unused-import,wrong-import-position,wrong-import-order,using-constant-test
+# pylint: disable=unused-import,wrong-import-position,wrong-import-order,using-constant-test,implicit-reimport
 # pylint: disable=import-error
 from os.path import basename
 import logging.config  # pylint: disable=ungrouped-imports

--- a/tests/functional/ext/typing/typing_consider_using_alias.py
+++ b/tests/functional/ext/typing/typing_consider_using_alias.py
@@ -4,7 +4,7 @@
 With 'from __future__ import annotations' present.
 """
 
-# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unnecessary-direct-lambda-call
+# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unnecessary-direct-lambda-call,implicit-reimport
 
 # Disabled because of a bug with pypy 3.8 see
 # https://github.com/pylint-dev/pylint/pull/7918#issuecomment-1352737369

--- a/tests/functional/ext/typing/typing_consider_using_alias_without_future.py
+++ b/tests/functional/ext/typing/typing_consider_using_alias_without_future.py
@@ -3,7 +3,7 @@
 'py-version' needs to be set to '3.7' or '3.8' and 'runtime-typing=no'.
 """
 
-# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unsubscriptable-object
+# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unsubscriptable-object,implicit-reimport
 # pylint: disable=unnecessary-direct-lambda-call
 
 # Disabled because of a bug with pypy 3.8 see

--- a/tests/functional/ext/typing/typing_deprecated_alias.py
+++ b/tests/functional/ext/typing/typing_deprecated_alias.py
@@ -2,7 +2,7 @@
 
 'py-version' needs to be set to >= '3.9'.
 """
-# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unsubscriptable-object,unnecessary-direct-lambda-call
+# pylint: disable=missing-docstring,invalid-name,unused-argument,line-too-long,unsubscriptable-object,unnecessary-direct-lambda-call,implicit-reimport
 import collections
 import collections.abc
 import typing

--- a/tests/functional/g/generic_alias/generic_alias_collections.py
+++ b/tests/functional/g/generic_alias/generic_alias_collections.py
@@ -1,6 +1,6 @@
 """Test generic alias support for stdlib types (added in PY39)."""
 # flake8: noqa
-# pylint: disable=missing-docstring,pointless-statement
+# pylint: disable=missing-docstring,pointless-statement,implicit-reimport
 # pylint: disable=too-few-public-methods,multiple-statements,line-too-long
 import abc
 import collections

--- a/tests/functional/g/generic_alias/generic_alias_mixed_py39.py
+++ b/tests/functional/g/generic_alias/generic_alias_mixed_py39.py
@@ -1,6 +1,6 @@
 """Test generic alias support with mix of typing.py and stdlib types (PY39+)."""
 # flake8: noqa
-# pylint: disable=missing-docstring,pointless-statement
+# pylint: disable=missing-docstring,pointless-statement,implicit-reimport
 # pylint: disable=too-few-public-methods,multiple-statements,line-too-long
 import collections
 import collections.abc

--- a/tests/functional/i/implicit/implicit_reimport.py
+++ b/tests/functional/i/implicit/implicit_reimport.py
@@ -1,0 +1,25 @@
+"""Tests for implicit-reimport."""
+
+# pylint: disable=missing-module-docstring,unused-import,wrong-import-order
+# pylint: disable=consider-using-from-import,import-outside-toplevel,redefined-outer-name
+
+import logging  # [implicit-reimport]
+import logging.config
+
+import os.path
+import os  # [implicit-reimport]
+
+import json
+import json.decoder as decoder
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pathlib
+else:
+    import pathlib._abc
+
+
+def separate_scope() -> None:
+    """Imports in a different scope do not make the module import redundant."""
+    import logging.handlers

--- a/tests/functional/i/implicit/implicit_reimport.txt
+++ b/tests/functional/i/implicit/implicit_reimport.txt
@@ -1,0 +1,2 @@
+implicit-reimport:6:0:6:14::Import 'logging' is unnecessary, as 'logging.config' implicitly imports it:HIGH
+implicit-reimport:10:0:10:9::Import 'os' is unnecessary, as 'os.path' implicitly imports it:HIGH

--- a/tests/functional/p/postponed/postponed_evaluation_pep585.py
+++ b/tests/functional/p/postponed/postponed_evaluation_pep585.py
@@ -1,5 +1,5 @@
 """Test PEP 585 works as expected, starting with Python 3.9"""
-# pylint: disable=missing-docstring,unused-argument,unused-import,too-few-public-methods,invalid-name,inherit-non-class,unsupported-binary-operation,wrong-import-position,ungrouped-imports,unused-variable,unnecessary-direct-lambda-call
+# pylint: disable=missing-docstring,unused-argument,unused-import,too-few-public-methods,invalid-name,inherit-non-class,unsupported-binary-operation,wrong-import-position,ungrouped-imports,unused-variable,unnecessary-direct-lambda-call,implicit-reimport
 import collections
 import dataclasses
 import typing

--- a/tests/functional/r/regression/regression_3507_typing_alias_isinstance.py
+++ b/tests/functional/r/regression/regression_3507_typing_alias_isinstance.py
@@ -3,6 +3,7 @@ https://github.com/pylint-dev/pylint/issues/3507
 False-positive 'isinstance-second-argument-not-valid-type'
 for typing aliases in 'isinstance' calls.
 """
+# pylint: disable=implicit-reimport
 import collections
 import collections.abc
 import typing

--- a/tests/functional/u/ungrouped_imports.py
+++ b/tests/functional/u/ungrouped_imports.py
@@ -1,5 +1,5 @@
 """Checks import order rule"""
-# pylint: disable=unused-import,wrong-import-position,wrong-import-order,using-constant-test
+# pylint: disable=unused-import,wrong-import-position,wrong-import-order,using-constant-test,implicit-reimport
 # pylint: disable=import-error
 import six
 import logging.config

--- a/tests/functional/u/ungrouped_imports_suppression.py
+++ b/tests/functional/u/ungrouped_imports_suppression.py
@@ -3,7 +3,7 @@
 Previously disabling ungrouped-imports would always lead to useless-suppression.
 """
 # pylint: enable=useless-suppression
-# pylint: disable=unused-import, wrong-import-order
+# pylint: disable=unused-import, wrong-import-order, implicit-reimport
 
 import logging.config
 import os.path

--- a/tests/functional/u/unused/unused_import.py
+++ b/tests/functional/u/unused/unused_import.py
@@ -25,7 +25,7 @@ class SomeClass:
 
 from never import __all__
 
-# pylint: disable=wrong-import-order,ungrouped-imports,reimported
+# pylint: disable=wrong-import-order,ungrouped-imports,reimported,implicit-reimport
 import typing
 from typing import TYPE_CHECKING
 import typing as t


### PR DESCRIPTION
## Type of Changes

- [x] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Docs

## Description

Closes #9873

Adds the `implicit-reimport` (W0417) warning for redundant parent-package imports such as `import logging` when an unaliased `import logging.config` is present in the same scope. The check handles either import order, ignores aliased submodule imports and mutually exclusive branches, and keeps imports in separate scopes independent.

Also updates the `ungrouped-imports` documentation example and adds functional coverage for aliases, reverse order, separate scopes, and exclusive branches.

## Validation

- `pytest tests/checkers/unittest_imports.py -q`
- `pytest tests/test_functional.py -k implicit_reimport -q`
- `pytest tests/test_functional_directories.py -q`
- `pylint --disable=all --enable=E,F pylint/checkers/imports.py`

The full suite passed except the existing Windows symlink fixture (`symlink_module0`) and environment-specific cache-path checks when using a writable temporary Pylint cache.