### PR TITLE
Fix a crash in unnecessary-default-type-args for an empty tuple subscript

### DIFF
--- a/doc/whatsnew/fragments/11357.bugfix
+++ b/doc/whatsnew/fragments/11357.bugfix
@@ -1,0 +1,4 @@
+Fix a crash in the ``unnecessary-default-type-args`` check when a ``Generator``
+or ``AsyncGenerator`` subscript holds an empty tuple, such as ``Generator[()]``.
+
+Closes #11357

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -280,6 +280,7 @@ class TypingChecker(BaseChecker):
                 in {"_collections_abc.Generator", "_collections_abc.AsyncGenerator"}
             )
             and isinstance(node.slice, nodes.Tuple)
+            and node.slice.elts
             and all(
                 (isinstance(el, nodes.Const) and el.value is None)
                 for el in node.slice.elts[1:]

--- a/tests/functional/ext/typing/unnecessary_default_type_args.py
+++ b/tests/functional/ext/typing/unnecessary_default_type_args.py
@@ -15,3 +15,9 @@ c3: ca.Generator[int]
 d1: ca.AsyncGenerator[int, str]
 d2: ca.AsyncGenerator[int, None]  # [unnecessary-default-type-args]
 d3: ca.AsyncGenerator[int]
+
+# https://github.com/pylint-dev/pylint/issues/11357
+e1: ca.Generator[()]
+e2: ca.AsyncGenerator[()]
+e3: t.Generator[()]
+e4: t.AsyncGenerator[()]


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`Generator[()]` parses to a `Subscript` whose slice is an empty `Tuple`. The guard in `visit_subscript` only tested `elts[1:]`, which is empty, so `all()` returned `True` and the suggestion string then read `elts[0]` and raised `IndexError`. Requiring at least one element leaves the empty subscript alone.

Without the source change the added functional cases fail with `IndexError: list index out of range` at `pylint/extensions/typing.py:289`, surfaced as `astroid-error`. With it, `pytest tests/` passes: 2154 passed, 314 skipped, 5 xfailed.

Closes #11357