### PR TITLE
Check every parameter kind for invalid-name, not just positional-or-keyword

### DIFF
--- a/doc/whatsnew/fragments/11376.false_negative
+++ b/doc/whatsnew/fragments/11376.false_negative
@@ -1,0 +1,6 @@
+:ref:`invalid-name` now checks every parameter kind against the argument
+naming style. Positional-only parameters, ``*args``, keyword-only parameters
+and ``**kwargs`` were skipped, so only positional-or-keyword names were ever
+reported.
+
+Refs #11376

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -436,8 +436,9 @@ class NameChecker(_BasicChecker):
             node,
             confidence,
         )
-        # Check argument names
-        args = node.args.args
+        # Check argument names. `Arguments.arguments` covers every parameter kind:
+        # positional-only, positional-or-keyword, *args, keyword-only and **kwargs.
+        args = node.args.arguments
         if args is not None:
             self._recursive_check_names(args)
 

--- a/tests/functional/n/name/name_argument_kinds.py
+++ b/tests/functional/n/name/name_argument_kinds.py
@@ -1,0 +1,27 @@
+"""Every parameter kind is subject to the argument naming style."""
+# pylint: disable=too-few-public-methods
+
+
+def function(
+    BadPosOnly,  # [invalid-name]
+    /,
+    BadPlain,  # [invalid-name]
+    *BadStar,  # [invalid-name]
+    BadKwOnly,  # [invalid-name]
+    **BadKw,  # [invalid-name]
+):
+    """A function using all five parameter kinds."""
+    return BadPosOnly, BadPlain, BadStar, BadKwOnly, BadKw
+
+
+# visit_asyncfunctiondef is an alias of visit_functiondef.
+async def coroutine(
+    GoodEnough, /, *Args, KwOnly, **Kwargs  # [invalid-name,invalid-name,invalid-name,invalid-name]
+):
+    """An async function using four of the five parameter kinds."""
+    return GoodEnough, Args, KwOnly, Kwargs
+
+
+def well_named(pos_only, /, plain, *args, kw_only, **kwargs):
+    """No message for any of these."""
+    return pos_only, plain, args, kw_only, kwargs

--- a/tests/functional/n/name/name_argument_kinds.txt
+++ b/tests/functional/n/name/name_argument_kinds.txt
@@ -1,0 +1,9 @@
+invalid-name:6:4:6:14:function:"Argument name ""BadPosOnly"" doesn't conform to snake_case naming style":HIGH
+invalid-name:8:4:8:12:function:"Argument name ""BadPlain"" doesn't conform to snake_case naming style":HIGH
+invalid-name:9:5:9:12:function:"Argument name ""BadStar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:10:4:10:13:function:"Argument name ""BadKwOnly"" doesn't conform to snake_case naming style":HIGH
+invalid-name:11:6:11:11:function:"Argument name ""BadKw"" doesn't conform to snake_case naming style":HIGH
+invalid-name:19:20:19:24:coroutine:"Argument name ""Args"" doesn't conform to snake_case naming style":HIGH
+invalid-name:19:4:19:14:coroutine:"Argument name ""GoodEnough"" doesn't conform to snake_case naming style":HIGH
+invalid-name:19:26:19:32:coroutine:"Argument name ""KwOnly"" doesn't conform to snake_case naming style":HIGH
+invalid-name:19:36:19:42:coroutine:"Argument name ""Kwargs"" doesn't conform to snake_case naming style":HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`NameChecker.visit_functiondef` passes `node.args.args` to `_recursive_check_names`, which is only the positional-or-keyword slice. So `argument-naming-style` / `argument-rgx` silently never applied to positional-only, `*args`, keyword-only or `**kwargs` names — 1 of 5 parameter kinds checked:

```python
def foo(BadPosOnly, /, BadPlain, *BadStar, BadKwOnly, **BadKw):
    ...
```
```
before: sample.py:4:23: C0103: Argument name "BadPlain" ...      (1 message)
after:  cols 8, 23, 34, 43, 56                                   (5 messages)
```

All five are parameters bound in the function's local namespace ([reference §8.8](https://docs.python.org/3/reference/compound_stmts.html#function-definitions), PEP 570), and the option docs describe `argument-naming-style` with no carve-out. astroid exposes `Arguments.arguments` for exactly this, and `basic_error_checker` already switched to it for `duplicate-argument-name` in #9670 / Closes #9669 — same bug shape, same fix; the name checker was left behind.

**Ran:** full suite `2160 passed, 309 skipped, 5 xfailed, 0 failed` — no change outside the new functional test. An earlier version of this description reported 11 errors in `tests/benchmark/`; those were a missing `pytest-benchmark`, and they pass after `pip install -r requirements_test.txt`. `pre-commit run --files <the three files>` all green.

**Two mutants, same command and env:** reverting only `checker.py` fails the new functional test; and the *historical* naive form `args + kwonlyargs` — literally what #9670 replaced in the sibling checker — also fails it, so the test distinguishes the partial fix from the complete one.

**Not covered:** `Lambda` arguments, which this checker never visited and I did not add.

**How I found it:** auditing pylint's checkers for visitors that enumerate fewer node kinds than astroid produces, then diffing `node.args.args` against `node.args.arguments` across the checkers. Not from hitting it in real work — weigh it accordingly. #9670 turned up afterwards and is the precedent.

I'll push a `doc/whatsnew/fragments/<this PR>.false_negative` fragment right after opening, since there's no existing issue to number it from — happy to renumber if you'd rather I file one.

_AI disclosure: prepared with assistance from Claude Opus 5 (`claude-opus-5`). Every command and number above I ran and read myself._

