### PR TITLE
Fix false positive in `reimported` for relative import sharing a bare name with an absolute import

### DIFF
--- a/doc/whatsnew/fragments/11353.false_positive
+++ b/doc/whatsnew/fragments/11353.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for :ref:`reimported` when a relative import (``from . import x``)
+shares a bare name with an unrelated absolute import of the same name.
+
+Closes #11353

--- a/pylint/checkers/imports.py
+++ b/pylint/checkers/imports.py
@@ -106,7 +106,10 @@ def _get_first_import(
         if first.scope() is node.scope() and first.fromlineno > node.fromlineno:
             continue
         if isinstance(first, nodes.Import):
-            if any(fullname == iname[0] for iname in first.names):
+            # A relative "from . import x" (level >= 1) targets a different
+            # module than an absolute "import x" of the same name, even
+            # though they share a bare name (see #11353).
+            if not level and any(fullname == iname[0] for iname in first.names):
                 found = True
                 break
             for imported_name, imported_alias in first.names:

--- a/tests/functional/r/reimported.py
+++ b/tests/functional/r/reimported.py
@@ -43,3 +43,9 @@ del sys, ElementTree, xml.etree.ElementTree, encoders, email.encoders
 
 from pandas._libs import algos as libalgos
 import pandas._libs.algos as algos  # [reimported]
+
+# https://github.com/pylint-dev/pylint/issues/11353
+# A relative import of a submodule that happens to share a bare name with an
+# unrelated absolute import is not a reimport of the same module.
+import json
+from . import json as my_json


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`from . import x` (a relative import, `level >= 1`) targets a different module than an absolute `import x` of the same name, but `_get_first_import` in `pylint/checkers/imports.py` compared their bare names without accounting for import level, so the `reimported` checker flagged them as the same target:

```python
import json                    # stdlib json
from . import json as my_json  # a local submodule that happens to be named "json" -- false positive [reimported]
```

The `ImportFrom`-vs-`ImportFrom` branch already guards this correctly (`if level == first.level`); the `Import`-vs-`ImportFrom` branch didn't, since a bare `import x` is always absolute (level 0). This PR adds the same level-compatibility guard to that branch, while leaving the alias-shadowing check (`shadowed-import`) untouched, since an alias genuinely rebinds the name in the local namespace regardless of level.

Added a regression case to `tests/functional/r/reimported.py` reproducing the exact repro from the issue, and a changelog fragment via `doc/whatsnew/fragments/11353.false_positive`.

Verified:
- The new test line fails on `main` (flags a false `reimported` on the relative import) and passes with the fix.
- Ran `tests/checkers/unittest_imports.py` and the full `tests/test_functional.py` suite; no new failures introduced (14 pre-existing failures on `main` are unrelated environment issues, reproduced identically before and after this change).

Closes #11353

🤖 Generated with [Claude Code](https://claude.com/claude-code)