### PR TITLE
Handle InferenceError in attribute lookup instead of crashing

### DIFF
--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1210,6 +1210,13 @@ accessed. Python regular expressions are accepted.",
                 continue
             except astroid.DuplicateBasesError:
                 continue
+            except astroid.InferenceError:
+                # A metaclass attribute lookup can end up inferring the
+                # right-hand side of an assignment target (e.g. a class
+                # attribute assigned through a for-loop target), which
+                # astroid can fail to resolve. Nothing useful can be said
+                # about the attribute in that case.
+                continue
             except astroid.NotFoundError:
                 # Avoid false positive in case a decorator supplies member.
                 if (

--- a/tests/functional/i/inference_error_metaclass_attr_11356.py
+++ b/tests/functional/i/inference_error_metaclass_attr_11356.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-class-docstring,too-few-public-methods,undefined-variable
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11356."""
+from collections.abc import GenericAlias
+
+
+class C:
+    pass
+
+
+x = C.a
+
+for GenericAlias.a in _:
+    pass


### PR DESCRIPTION
Closes #11356.

`visit_attribute` already catches a few things astroid's `owner.getattr()` can raise (`AttributeError`, `DuplicateBasesError`, `NotFoundError`), but not `InferenceError`. When a metaclass attribute lookup ends up needing to infer something astroid can't resolve, that exception was escaping unhandled and taking down the whole run.

The reproducer from the issue triggers it through a slightly odd path: a for-loop target assigns through a class attribute (`for GenericAlias.a in _:`), which astroid can't infer, and that failure surfaces later while resolving an unrelated `C.a` lookup via the metaclass. Added the missing except clause, matching how the sibling exceptions right next to it are already handled, plus a regression test built from the reproducer in the issue.

Ran the functional suite and the typecheck unit tests locally, both green aside from a few pre-existing failures in unrelated tests that depend on which third-party packages happen to be installed (missing_timeout, wrong_import_order), which fail the same way on main without this change.