### PR TITLE
fix(variables): avoid false positives for exception args

### DIFF
--- a/doc/whatsnew/fragments/11312.false_positive
+++ b/doc/whatsnew/fragments/11312.false_positive
@@ -1,0 +1,4 @@
+Avoid emitting ``unbalanced-tuple-unpacking`` for ``BaseException.args``, whose
+length cannot be inferred from the exception instance.
+
+Closes #11312

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2189,12 +2189,30 @@ class VariablesChecker(BaseChecker):
         # Check if we have starred nodes.
         if any(isinstance(target, nodes.Starred) for target in targets):
             return
+        if self._is_exception_args(node.value):
+            # ``BaseException.args`` is populated at runtime and cannot be
+            # inferred from the exception instance alone.  Astroid models it
+            # as an empty tuple, which would make every unpacking look
+            # unbalanced even though the tuple length is unknown.
+            return
         try:
             inferred = node.value.inferred()
             if inferred is not None and len(inferred) == 1:
                 self._check_unpacking(inferred[0], node, targets)
         except astroid.InferenceError:
             return
+
+    @staticmethod
+    def _is_exception_args(value: nodes.NodeNG) -> bool:
+        if not isinstance(value, nodes.Attribute) or value.attrname != "args":
+            return False
+        try:
+            return any(
+                isinstance(inferred, astroid.ExceptionInstance)
+                for inferred in value.expr.inferred()
+            )
+        except astroid.InferenceError:
+            return False
 
     # listcomp have now also their scope
     def visit_listcomp(self, node: nodes.ListComp) -> None:

--- a/tests/functional/u/unbalanced/unbalanced_tuple_unpacking.py
+++ b/tests/functional/u/unbalanced/unbalanced_tuple_unpacking.py
@@ -163,6 +163,16 @@ D, *_ = my_function("12")
 # https://github.com/pylint-dev/pylint/issues/5998
 x, y, z = (1, 2)  # [unbalanced-tuple-unpacking]
 
+
+def unpack_exception_args():
+    try:
+        pass
+    except ValueError as exc:
+        (message,) = exc.args
+        first, second = exc.args
+        return message, first, second
+    return None
+
 # https://github.com/pylint-dev/pylint/issues/7710
 # Using a lot of args, so we have a high probability to still trigger the problem if
 # we add arguments to our unittest command later


### PR DESCRIPTION
## Problem
Pylint emits `unbalanced-tuple-unpacking` for unpacking `BaseException.args`, even though an exception's argument tuple length is only known at runtime.

## Root Cause
Astroid models `BaseException.args` on an exception instance as an empty tuple. The variables checker interprets that inferred empty tuple as a known length and reports a false positive for every unpacking assignment.

## Solution
Skip the tuple-balance check when the assignment value is the `args` attribute of an inferred `astroid.ExceptionInstance`. Other tuple and list unpacking paths continue through the existing checker unchanged.

## Changes
- Add an exception-`args` guard to the variables checker.
- Add regression coverage for one- and two-target unpacking from `ValueError.args`.
- Add a `false_positive` towncrier fragment.

## Testing
- Baseline: `python -m pytest tests/test_functional.py -q -k unbalanced_tuple_unpacking` — 2 passed.
- Baseline reproducer on the unmodified tree: two `unbalanced-tuple-unpacking` diagnostics, as reported in #11312.
- Focused final: `python -m pytest tests/test_functional.py -q -k unbalanced_tuple_unpacking` — 2 passed.
- Related final: `python -m pytest tests/checkers/unittest_variables.py -q` — 10 passed.
- Final reproducer with `--from-stdin --disable=all --enable=unbalanced-tuple-unpacking` — no diagnostics, exit code 0.
- `compileall` — passed.
- `git diff --check` — passed.
- Ruff and mypy were not available in the local environment. Black was checked with the existing Python 3.10-compatible environment; the pre-existing functional fixture has unrelated formatting differences, so no broad reformat was applied.

## Compatibility/Risk
The guard applies only to assignments whose RHS is `.args` on an inferred exception instance. It preserves diagnostics for statically known tuples/lists and for non-exception attributes. No public API or dependency changes are included.

## Notes for Reviewer
The regression is intentionally expressed in the existing functional test so it verifies the user-visible W0632 behavior. The exception tuple is not treated as empty; it is treated as unknown, matching Python's runtime behavior.

## Linked Issue
Closes #11312

AI disclosure: This PR was prepared with AI assistance. The submitting contributor reviewed every changed line and ran the relevant checks listed above.