### PR TITLE
Fix InferenceError crash on attributes bound by a loop target

### DIFF
--- a/doc/whatsnew/fragments/11356.bugfix
+++ b/doc/whatsnew/fragments/11356.bugfix
@@ -1,0 +1,6 @@
+Fix a crash in the ``no-member`` check when a class attribute is bound by a for-loop
+target, such as ``for SomeClass.attr in ...``. Metaclass attribute lookup could fail to
+infer the resulting ``AssignAttr`` and raise ``InferenceError``, which is a sibling of
+``NotFoundError`` rather than a subclass and so was not handled alongside it.
+
+Closes #11356

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1210,6 +1210,13 @@ accessed. Python regular expressions are accepted.",
                 continue
             except astroid.DuplicateBasesError:
                 continue
+            except astroid.InferenceError:
+                # Metaclass attribute lookup can fail to infer any of the statements
+                # it finds, e.g. when the attribute was assigned through a for-loop
+                # target such as `for SomeClass.attr in ...`. InferenceError is a
+                # sibling of NotFoundError rather than a subclass, so it is not
+                # covered below. Nothing can be concluded about this owner, so move on.
+                continue
             except astroid.NotFoundError:
                 # Avoid false positive in case a decorator supplies member.
                 if (

--- a/tests/functional/n/no/no_member_assignattr_loop_target.py
+++ b/tests/functional/n/no/no_member_assignattr_loop_target.py
@@ -1,0 +1,17 @@
+"""Regression test for https://github.com/pylint-dev/pylint/issues/11356.
+
+Metaclass attribute lookup could fail to infer an ``AssignAttr`` bound by a for-loop
+target and raise ``InferenceError``, which was not handled alongside ``NotFoundError``.
+"""
+# pylint: disable=too-few-public-methods,undefined-variable
+from collections.abc import GenericAlias
+
+
+class C:
+    """Attribute is looked up here before the loop below binds it elsewhere."""
+
+
+x = C.a
+
+for GenericAlias.a in _:
+    pass


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Closes #11356

Binding a class attribute through a for-loop target crashes `visit_attribute`:

    for GenericAlias.a in _:
        pass

    astroid.exceptions.InferenceError: Inference failed for all members of [<AssignAttr.a>]

`owner.getattr()` already has handlers for `AttributeError`, `DuplicateBasesError`
and `NotFoundError`. `InferenceError` is a *sibling* of `NotFoundError` rather than a
subclass, so it escapes them and crashes the run.

Nothing can be concluded about that owner, so skip it as the neighbouring handlers do.

### Testing
- New functional test `no_member_assignattr_loop_target`, which fails with the
  original `InferenceError` when the fix is reverted
- `no-member` still fires normally; the 45 member functional tests pass unchanged