### PR TITLE
Fix IndexError on empty Generator subscripts

### DIFF
--- a/doc/whatsnew/fragments/11357.bugfix
+++ b/doc/whatsnew/fragments/11357.bugfix
@@ -1,0 +1,7 @@
+Fix a crash in the ``unnecessary-default-type-args`` check when a ``Generator`` or
+``AsyncGenerator`` is subscripted with an empty tuple, such as ``Generator[()]``.
+The empty subscript produced an empty ``Tuple`` slice, and ``all()`` over the empty
+remainder was vacuously true, so the suggestion built afterwards indexed the first
+element and raised ``IndexError``.
+
+Closes #11357

--- a/pylint/extensions/typing.py
+++ b/pylint/extensions/typing.py
@@ -280,6 +280,10 @@ class TypingChecker(BaseChecker):
                 in {"_collections_abc.Generator", "_collections_abc.AsyncGenerator"}
             )
             and isinstance(node.slice, nodes.Tuple)
+            # An empty subscript such as `Generator[()]` has no elements, and
+            # `all()` over the empty `elts[1:]` is vacuously true, so without this
+            # guard the suggestion below would index `elts[0]` and raise IndexError.
+            and node.slice.elts
             and all(
                 (isinstance(el, nodes.Const) and el.value is None)
                 for el in node.slice.elts[1:]

--- a/tests/functional/ext/typing/unnecessary_default_type_args.py
+++ b/tests/functional/ext/typing/unnecessary_default_type_args.py
@@ -15,3 +15,7 @@ c3: ca.Generator[int]
 d1: ca.AsyncGenerator[int, str]
 d2: ca.AsyncGenerator[int, None]  # [unnecessary-default-type-args]
 d3: ca.AsyncGenerator[int]
+
+# Empty subscripts must not crash the checker (https://github.com/pylint-dev/pylint/issues/11357)
+c4: ca.Generator[()]
+d4: ca.AsyncGenerator[()]


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Closes #11357

`Generator[()]` gives a `Tuple` slice with no elements. The guard checks
`all(... for el in node.slice.elts[1:])`, which is vacuously true for an empty
list, so the suggestion built immediately after indexes `node.slice.elts[0]` and
raises `IndexError`.

Single-element subscripts like `Generator[int]` produce a `Name` slice rather than a
`Tuple`, so the empty tuple is the only reachable case — a non-empty check is the
complete fix.

### Testing
- Added `ca.Generator[()]` / `ca.AsyncGenerator[()]` to the existing
  `unnecessary_default_type_args` functional test; it fails with `IndexError` when
  the fix is reverted
- The checker still flags `Generator[int, None, None]` correctly