### PR TITLE
Fix not-callable false positive for types.FunctionType

### DIFF
--- a/doc/whatsnew/fragments/7500.false_positive
+++ b/doc/whatsnew/fragments/7500.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for :ref:`not-callable` when calling functions constructed with
+``types.FunctionType`` or ``types.LambdaType``.
+
+Closes #7500

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1924,8 +1924,8 @@ accessed. Python regular expressions are accepted.",
             # Ignore descriptor instances
             if "__get__" in inferred_call.locals:
                 return
-            # NamedTuple instances are callable
-            if inferred_call.qname() == "typing.NamedTuple":
+            # These instances are callable despite not exposing __call__ in astroid.
+            if inferred_call.qname() in {"builtins.function", "typing.NamedTuple"}:
                 return
 
         self.add_message("not-callable", node=node, args=node.func.as_string())

--- a/tests/functional/n/not_callable.py
+++ b/tests/functional/n/not_callable.py
@@ -243,3 +243,11 @@ ATTRIBUTES = {
 
 for key, (name, validate) in ATTRIBUTES.items():
     name = validate(1)
+
+
+# Regression test for https://github.com/pylint-dev/pylint/issues/7500
+import types
+
+FUNCTION_CODE = compile("pass", "<string>", "exec")
+types.FunctionType(FUNCTION_CODE, {})()
+types.LambdaType(FUNCTION_CODE, {})()


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Closes #7500

Astroid infers functions constructed through `types.FunctionType`, including its `types.LambdaType` alias, as `builtins.function` instances. That built-in model does not expose `__call__`, so Pylint incorrectly emitted `not-callable` when the constructed function was invoked.

This change treats that exact inferred type as callable alongside the existing `typing.NamedTuple` exception. It adds regression coverage for both public constructor names and a false-positive news fragment. Other inferred instance types continue through the existing callable checks.

## Verification

- `.venv/bin/python -m pytest tests/ -q -n auto` (`2159 passed, 308 skipped, 5 xfailed`)
- `env PATH="$PWD/.venv/bin:$PATH" pre-commit run --all-files`
- Manual regression check for both `types.FunctionType` and `types.LambdaType`

OpenAI Codex assisted with the implementation, tests, and preparation of this pull request.