### PR TITLE
Fix the ruff failure that keeps pre-commit.ci red on main

### DIFF
--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -729,9 +729,9 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
             # The 'pylint: disable whatever' should not be taken into account for line length count
             lines = self.remove_pylint_option_from_lines(mobj)
 
-        # Trailing pragmas from other tooling (``# type: ignore``, ``# noqa``,
-        # ``# pragma: no cover``, ...) should not be taken into account for the
-        # line length count either.
+        # Trailing pragmas from other tooling (mypy's ``type: ignore``, flake8's
+        # ``noqa``, coverage's ``pragma: no cover``, ...) should not be taken into
+        # account for the line length count either.
         lines = _IGNORED_PRAGMA_RGX.sub("", lines)
 
         ignore_pattern_in_long_lines = self.linter.config.ignore_pattern_in_long_lines

--- a/pylint/graph.py
+++ b/pylint/graph.py
@@ -274,11 +274,10 @@ def _get_longest_path_item(
     Prioritize the number of symbols (``a``, ``b``, ``c``), break ties with the total
     number of nodes in the path, and break further ties alphabetically.
     """
-    return sorted(
+    return max(
         items,
-        reverse=True,
         key=lambda x: (symbols_in_longest_path[x], nodes_in_longest_path[x], str(x)),
-    )[0]
+    )
 
 
 def _get_path(


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

pre-commit.ci has been failing on `main` since #7611 merged, which is why unrelated PRs such as #11388 show a red `pre-commit.ci - pr` check.

- `ruff` 0.16.5 flags `sorted(..., reverse=True)[0]` in `_get_longest_path_item` (FURB192) and asks for `max()`. The two are equivalent here: the key tuple ends with `str(x)`, so every tie is already broken.
- `ruff` also warned about the comment in `format.py` that spelled the pragmas with a leading `#`. It parsed ``# noqa`` as a real directive (`Invalid # noqa directive on pylint/checkers/format.py:732`), and coverage's default exclusion regex would likewise have matched ``# pragma: no cover``. The comment now names the tools and drops the hash signs.

No behaviour change, so no changelog entry.
