### PR TITLE
Reword a comment so the spell-check hook stops failing on main

### DIFF
--- a/pylint/checkers/format.py
+++ b/pylint/checkers/format.py
@@ -729,9 +729,9 @@ class FormatChecker(BaseTokenChecker, BaseRawFileChecker):
             # The 'pylint: disable whatever' should not be taken into account for line length count
             lines = self.remove_pylint_option_from_lines(mobj)
 
-        # Trailing pragmas from other tooling (mypy's ``type: ignore``, flake8's
-        # ``noqa``, coverage's ``pragma: no cover``, ...) should not be taken into
-        # account for the line length count either.
+        # Trailing pragmas from other tooling (``type: ignore`` for mypy, ``noqa``
+        # for flake8, ``pragma: no cover`` for coverage, ...) should not be taken
+        # into account for the line length count either.
         lines = _IGNORED_PRAGMA_RGX.sub("", lines)
 
         ignore_pattern_in_long_lines = self.linter.config.ignore_pattern_in_long_lines


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :hammer: Refactoring   |

## Description

The `pylint` CI job (the manual `pylint-with-spelling` hook) has been failing on `main` since #11389 merged, which is why unrelated PRs such as #11388 show a red `pylint` check:

```
************* Module pylint.checkers.format
Wrong spelling of a word 'mypy's' in a comment:
# Trailing pragmas from other tooling (mypy's ``type: ignore``, flake8's
                                       ^^^^^^
Did you mean: ''pygmy's' or 'mypy''?
```

aspell only derives possessives for words in its own dictionary: `coverage's` on the same line passes, but `mypy` comes from `custom_dict.txt`, so `mypy's` is flagged. The comment now names each tool after its pragma instead of using a possessive. The pragmas still have no leading `#`, so the ruff `noqa` warning fixed in #11389 does not come back.

No behaviour change, so no changelog entry.
