### PR TITLE
test: cover imported IntEnum members

### DIFF
--- a/tests/functional/e/enum_imported_members_10951.py
+++ b/tests/functional/e/enum_imported_members_10951.py
@@ -1,0 +1,11 @@
+"""Regression test for imported constants used as IntEnum members."""
+
+# pylint: disable=import-outside-toplevel,missing-class-docstring
+from enum import IntEnum
+
+
+class LogLevel(IntEnum):
+    from os import O_RDONLY as READ_ONLY
+
+
+print(LogLevel.READ_ONLY.value)  # [no-member]

--- a/tests/functional/e/enum_imported_members_10951.txt
+++ b/tests/functional/e/enum_imported_members_10951.txt
@@ -1,0 +1,1 @@
+no-member:11:6:11:30::Instance of 'int' has no 'value' member:INFERENCE


### PR DESCRIPTION
Refs #10951

## Type of Changes

|     | Type                   |
| --- | ---------------------- |
|     | :bug: Bug fix          |
|     | :sparkles: New feature |
|     | :hammer: Refactoring   |
|     | :scroll: Docs          |

## Description

Add a functional test reproducing the imported-integer-constant case inside an IntEnum class body. The test records the current false positive for .value access; it does not change Pylint's inference behavior. Issue #10951 should remain open until the diagnostic is fixed.

The change is test-only. The PR has the Skip news label, so no news fragment is needed.

## Validation

- python -m pytest -o addopts='' -q tests/test_functional.py -k enum_imported_members_10951
- git diff --check

- [x] Relates the change to issue #10951.
- [x] Includes a focused regression test.