### PR TITLE
Fix declare-non-slot false positives for ClassVar annotations

### DIFF
--- a/doc/whatsnew/fragments/9950.bugfix
+++ b/doc/whatsnew/fragments/9950.bugfix
@@ -1,0 +1,2 @@
+Fix a false positive for ``declare-non-slot`` when a class variable is
+annotated with ``ClassVar`` without an initial value.

--- a/doc/whatsnew/fragments/9950.bugfix
+++ b/doc/whatsnew/fragments/9950.bugfix
@@ -1,2 +1,4 @@
 Fix a false positive for ``declare-non-slot`` when a class variable is
 annotated with ``ClassVar`` without an initial value.
+
+Closes #9950

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1017,7 +1017,9 @@ a metaclass class method.",
             match child:
                 case nodes.AnnAssign(
                     target=nodes.AssignName(name=name), value=None
-                ) if (name not in slot_names):
+                ) if name not in slot_names and not utils.is_assign_name_annotated_with(
+                    child.target, "ClassVar"
+                ):
                     self.add_message(
                         "declare-non-slot",
                         args=child.target.name,

--- a/tests/functional/s/slots_checks_classvar.py
+++ b/tests/functional/s/slots_checks_classvar.py
@@ -1,0 +1,22 @@
+"""Class variables are not restricted by instance slots (regression for #9950)."""
+import typing
+from typing import ClassVar
+
+
+class ClassVariables:
+    __slots__ = ("value",)
+
+    value: int
+    direct: ClassVar[int]
+    qualified: typing.ClassVar[int]
+    unsubscripted: ClassVar
+    initialized: ClassVar[int] = 1
+    instance: int  # [declare-non-slot]
+
+
+class Derived(ClassVariables):
+    __slots__ = ("extra",)
+
+    extra: int
+    shared: ClassVar[str]
+    missing: int  # [declare-non-slot]

--- a/tests/functional/s/slots_checks_classvar.rc
+++ b/tests/functional/s/slots_checks_classvar.rc
@@ -1,0 +1,3 @@
+[MESSAGES CONTROL]
+disable=all
+enable=declare-non-slot

--- a/tests/functional/s/slots_checks_classvar.txt
+++ b/tests/functional/s/slots_checks_classvar.txt
@@ -1,0 +1,2 @@
+declare-non-slot:14:4:14:12:ClassVariables:No such name 'instance' in __slots__:INFERENCE
+declare-non-slot:22:4:22:11:Derived:No such name 'missing' in __slots__:INFERENCE


### PR DESCRIPTION
## Type of Changes

| | Type |
| --- | --- |
| ✓ | Bug fix |

## Description

Closes #9950.

`declare-non-slot` currently treats an uninitialized ClassVar annotation as an instance attribute, even though `__slots__` restricts instance attributes. Reuse the existing ClassVar annotation helper to skip these declarations.

Add a functional regression covering imported, qualified, unsubscripted, initialized and inherited ClassVar declarations. Keep explicit expected diagnostics for ordinary instance annotations missing from the class's slots, and add a bugfix news fragment.

## Testing

- Confirmed the new functional test fails before the checker change with four unexpected `declare-non-slot` diagnostics.
- `pytest tests/test_functional.py -k slots -q`: 7 passed.
- `pytest tests/checkers/unittest_classes.py tests/checkers/unittest_utils.py -q`: 55 passed.
- Ruff, Black (26.5.1 with `--target-version py310`), and `git diff --check` pass.
- Tested on Python 3.12 with astroid 4.2.0b5. The full Pylint suite was not run.

AI assistance: Codex helped implement, review, and test this change.