### PR TITLE
tests: skip symlink_module functional test on win32

### DIFF
--- a/tests/functional/s/symlink/_binding/symlink_module.rc
+++ b/tests/functional/s/symlink/_binding/symlink_module.rc
@@ -1,0 +1,3 @@
+[testoptions]
+# On Windows, git clones without symlink privileges materialize this symlink as a text file
+exclude_platforms=win32


### PR DESCRIPTION
<!--
Thank you for contributing to pylint!
Please refer to our contributor documentation:
https://pylint.readthedocs.io/en/latest/development_guide/contributor_guide/index.html
-->

Closes #11359

### Description

On Windows, standard git checkouts default to `core.symlinks=false` unless Developer Mode or elevated privileges are enabled. This causes git to materialize tracked symlinks (such as `tests/functional/s/symlink/_binding/symlink_module.py`) as 1-line text files containing the relative destination path (`../symlink_module/symlink_module.py`). When `test_functional[symlink_module0]` runs, pylint attempts to parse the relative path string as Python source, emitting `syntax-error` and failing the test suite locally.

This PR adds `tests/functional/s/symlink/_binding/symlink_module.rc` specifying `exclude_platforms=win32`, using pylint's standard functional test configuration mechanism (analogous to `bad_char_carriage_return.rc`). The sibling non-symlink test under `tests/functional/s/symlink/symlink_module/symlink_module.py` continues to run and pass across all platforms.
