### PR TITLE
Fix too-many-try-statements for required pass statements

### DIFF
--- a/doc/whatsnew/fragments/9418.false_positive
+++ b/doc/whatsnew/fragments/9418.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for :ref:`too-many-try-statements` when a nested code block
+contains only a ``pass`` statement required by Python's syntax.
+
+Closes #9418

--- a/pylint/extensions/broad_try_clause.py
+++ b/pylint/extensions/broad_try_clause.py
@@ -49,6 +49,9 @@ class BroadTryClauseChecker(checkers.BaseChecker):
     def _count_statements(
         self, node: nodes.For | nodes.If | nodes.Try | nodes.While | nodes.With
     ) -> int:
+        if len(node.body) == 1 and isinstance(node.body[0], nodes.Pass):
+            return 0
+
         statement_count = len(node.body)
 
         for body_node in node.body:

--- a/tests/functional/ext/broad_try_clause/broad_try_clause_extension.py
+++ b/tests/functional/ext/broad_try_clause/broad_try_clause_extension.py
@@ -47,3 +47,43 @@ try:
     value = MY_DICTIONARY["key_one"]
 except KeyError:
     value = 0
+
+# A sole pass is required to keep these suites syntactically valid (#9418).
+try:
+    with open("blah.txt", "a", encoding="ascii"):
+        pass
+except OSError:
+    pass
+
+try:
+    if "key_one" in MY_DICTIONARY:
+        pass
+except KeyError:
+    pass
+
+try:
+    for item in MY_DICTIONARY:
+        pass
+except KeyError:
+    pass
+
+try:
+    while MY_DICTIONARY:
+        pass
+except KeyError:
+    pass
+
+# The with statement itself and subsequent work must still count.
+try:  # [too-many-try-statements]
+    with open("blah.txt", "a", encoding="ascii"):
+        pass
+    value = 1
+except OSError:
+    pass
+
+# A pass alongside another statement is not a required placeholder.
+try:  # [too-many-try-statements]
+    value = 1
+    pass  # [unnecessary-pass]
+except KeyError:
+    pass

--- a/tests/functional/ext/broad_try_clause/broad_try_clause_extension.txt
+++ b/tests/functional/ext/broad_try_clause/broad_try_clause_extension.txt
@@ -2,3 +2,6 @@ too-many-try-statements:5:0:10:8::try clause contains 3 statements, expected at 
 too-many-try-statements:12:0:17:8::try clause contains 3 statements, expected at most 1:UNDEFINED
 too-many-try-statements:19:0:27:8::try clause contains 4 statements, expected at most 1:UNDEFINED
 too-many-try-statements:29:0:44:8::try clause contains 7 statements, expected at most 1:UNDEFINED
+too-many-try-statements:77:0:82:8::try clause contains 2 statements, expected at most 1:UNDEFINED
+too-many-try-statements:85:0:89:8::try clause contains 2 statements, expected at most 1:UNDEFINED
+unnecessary-pass:87:4:87:8::Unnecessary pass statement:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

A `try` clause containing only `with ...: pass` currently counts as two statements and triggers `too-many-try-statements` with its default limit of one. The `pass` is required to make the empty body syntactically valid.

Ignore a sole `pass` when recursively counting a suite. The surrounding control-flow statement and any `pass` alongside other statements still count. Regression cases cover `with`, `if`, `for`, and `while`, plus controls for subsequent work and an unnecessary `pass`.

Closes #9418.

## Validation

- The four initial regression cases fail on current `main` and pass with this change.
- Full functional suite on Python 3.13.9 / Astroid 4.2.0b5: **903 passed, 37 skipped**; `pylint.extensions.broad_try_clause` coverage is **100%**.
- The broad-try-clause functional test also passes with `--minimal-messages-config`.
- All applicable pre-commit checks pass for the four changed files, including Ruff, Black, isort, Pylint, mypy, and the newsfragment check.
