### PR TITLE
Fix f-string suggestion for format method callbacks

### DIFF
--- a/doc/whatsnew/fragments/8224.false_positive
+++ b/doc/whatsnew/fragments/8224.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for ``consider-using-f-string`` when passing a string's
+``format`` method as a positional argument, such as ``map("{:,d}".format, values)``.
+
+Closes #8224

--- a/pylint/checkers/refactoring/recommendation_checker.py
+++ b/pylint/checkers/refactoring/recommendation_checker.py
@@ -395,7 +395,10 @@ class RecommendationChecker(checkers.BaseChecker):
             and node.parent.attrname == "format"
         ):
             # Don't warn on referencing / assigning .format without calling it
-            if not isinstance(node.parent.parent, nodes.Call):
+            if (
+                not isinstance(node.parent.parent, nodes.Call)
+                or node.parent.parent.func is not node.parent
+            ):
                 return
 
             # Don't raise message on bad format string

--- a/tests/functional/c/consider/consider_using_f_string.py
+++ b/tests/functional/c/consider/consider_using_f_string.py
@@ -136,3 +136,15 @@ def invalid_format_string_good():
     print("{a[0] + a[1]}".format(a=[0, 1]))
     print("{".format(a=1))
     print("{".format(1))
+
+
+def format_method_references():
+    # Referencing .format in a positional argument is not a formatting call.
+    map("{:,d}".format, [1, 10, 100, 1000])
+    print("{}".format)
+    print("formatter:", "{}".format)
+    sorted([1, 10, 100], key="{}".format)
+
+    # Parentheses and callback arguments do not prevent checking actual calls.
+    print(("{}".format)(PARAM_1))  # [consider-using-f-string]
+    print("{}".format("{}".format))  # [consider-using-f-string]

--- a/tests/functional/c/consider/consider_using_f_string.txt
+++ b/tests/functional/c/consider/consider_using_f_string.txt
@@ -28,3 +28,5 @@ consider-using-f-string:119:8:119:19:assignment_bad:Formatting a regular string 
 consider-using-f-string:120:8:120:19:assignment_bad:Formatting a regular string which could be an f-string:UNDEFINED
 consider-using-f-string:121:8:121:22:assignment_bad:Formatting a regular string which could be an f-string:UNDEFINED
 consider-using-f-string:122:8:122:19:assignment_bad:Formatting a regular string which could be an f-string:UNDEFINED
+consider-using-f-string:149:11:149:15:format_method_references:Formatting a regular string which could be an f-string:UNDEFINED
+consider-using-f-string:150:10:150:14:format_method_references:Formatting a regular string which could be an f-string:UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

Passing a format method as a callback, such as `map("{:,d}".format, values)`, currently emits `consider-using-f-string`. The checker sees the surrounding call but does not check whether the format attribute is its callee.

Require the attribute to be `Call.func` before examining a format invocation. Callback references no longer trigger the suggestion; actual calls still do, including parenthesized calls and calls receiving another format method as an argument. This applies to ordinary callbacks and pandas-style contexts without a `map` special case.

Closes #8224.

The regression fixture preserves its 30 existing diagnostics and adds two actual-call controls. A news fragment is included.

## Validation

- Regression reproduced with four unexpected diagnostics before the fix; the final functional fixture passes.
- A separate review checked 91 CLI contexts against the original worktree: 19 incorrect case counts before the fix, zero afterward, with all 47 intended diagnostics retained. An additional 18-case callback matrix passes.
- Functional and checker suites: 1,359 passed, 41 skipped, 4 xfailed, plus one existing Windows symlink-fixture failure. Excluding the two symlink cases gives 1,358 passed.
- Full suite on Python 3.12.14: both original and modified versions have 2,183 passed, 276 skipped, 5 xfailed and the same 17 failure IDs. Sixteen involve Windows short versus long temporary paths; rerunning the two affected files with a local temporary directory passes all 86 tests. The remaining failure is a symlink checked out as a regular file.
- All applicable pre-commit hooks pass for the four changed files. Repository-wide hooks also encountered existing symlink EOF and unavailable documentation-subprocess failures.

AI assistance was used for implementation and a separate automated review. The validation above was run locally; it is not a claim of human code review.
