### PR TITLE
Fix bad-exception-cause false positive when the cause's bases are unknown

### DIFF
--- a/doc/whatsnew/fragments/11399.false_positive
+++ b/doc/whatsnew/fragments/11399.false_positive
@@ -1,0 +1,7 @@
+Fix a false positive for :ref:`bad-exception-cause` when the bases of the class
+being raised from cannot be inferred, such as an exception deriving from a
+C extension class. :ref:`raising-non-exception` and
+:ref:`catching-non-exception` already guard the same ``inherit_from_std_ex``
+helper with ``has_known_bases``.
+
+Refs #11399

--- a/pylint/checkers/exceptions.py
+++ b/pylint/checkers/exceptions.py
@@ -12,7 +12,7 @@ from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
 import astroid
-from astroid import nodes, objects, util
+from astroid import bases, nodes, objects, util
 from astroid.context import InferenceContext
 from astroid.typing import InferenceResult, SuccessfulInferenceResult
 
@@ -366,6 +366,13 @@ class ExceptionsChecker(checkers.BaseChecker):
         elif not isinstance(cause, nodes.ClassDef) and not utils.inherit_from_std_ex(
             cause
         ):
+            if isinstance(cause, bases.Instance) and not utils.has_known_bases(
+                cause._proxied
+            ):
+                # A base of the cause's class could not be inferred, so whether it
+                # derives from BaseException is unknown. raising-non-exception and
+                # catching-non-exception stay silent in that case too.
+                return
             self.add_message("bad-exception-cause", node=node, confidence=INFERENCE)
 
     def _check_raise_missing_from(self, node: nodes.Raise) -> None:

--- a/tests/functional/b/bad_exception_cause.py
+++ b/tests/functional/b/bad_exception_cause.py
@@ -22,6 +22,19 @@ def test():
     raise IndexError() from object() # [bad-exception-cause]
     raise IndexError() from unknown
 
+def unknown_bases():
+    """Don't emit when a base of the cause's class could not be inferred."""
+    from lala import bala  # pylint: disable=import-outside-toplevel
+
+    class MyException(bala):
+        """Whether this derives from BaseException cannot be determined."""
+
+    try:
+        pass
+    except MyException as exc:
+        raise IndexError from exc
+
+
 def function():
     """Function to be passed as exception"""
 

--- a/tests/functional/b/bad_exception_cause.txt
+++ b/tests/functional/b/bad_exception_cause.txt
@@ -1,6 +1,6 @@
 bad-exception-cause:13:4:13:27:test:Exception cause set to something which is not an exception, nor None:INFERENCE
 bad-exception-cause:16:4:16:34:test:Exception cause set to something which is not an exception, nor None:INFERENCE
 bad-exception-cause:22:4:22:36:test:Exception cause set to something which is not an exception, nor None:INFERENCE
-catching-non-exception:30:7:30:15::"Catching an exception which doesn't inherit from Exception: function":UNDEFINED
-bad-exception-cause:31:4:31:28::Exception cause set to something which is not an exception, nor None:INFERENCE
-broad-exception-raised:31:4:31:28::"Raising too general exception: Exception":INFERENCE
+catching-non-exception:43:7:43:15::"Catching an exception which doesn't inherit from Exception: function":UNDEFINED
+bad-exception-cause:44:4:44:28::Exception cause set to something which is not an exception, nor None:INFERENCE
+broad-exception-raised:44:4:44:28::"Raising too general exception: Exception":INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type          |
| --- | ------------- |
| ✓   | :bug: Bug fix |

## Description

`inherit_from_std_ex` looks for `BaseException` in `ancestors()`, so a class whose base cannot be inferred (a C extension, a conditional import) reads as a non-exception.

`raising-non-exception` and `catching-non-exception` already pair that helper with `has_known_bases`. `_check_bad_exception_cause` did not.

Reproduced on `anyio/to_interpreter.py:55`, where `ExecutionFailed` derives from `_interpreters.InterpreterError` and `ancestors()` comes back empty:

```python
except ExecutionFailed as exc:
    raise BrokenWorkerInterpreter(exc.excinfo) from exc
```

E0705 fires there while `catching-non-exception` stays silent on the same handler.
