### PR TITLE
Fix unused arguments in dataclass __new__ methods

### DIFF
--- a/doc/whatsnew/fragments/9843.false_positive
+++ b/doc/whatsnew/fragments/9843.false_positive
@@ -1,0 +1,4 @@
+Fix a false positive for ``unused-argument`` in dataclass ``__new__`` methods
+when the arguments are consumed by a generated ``__init__`` method.
+
+Closes #9843

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1,6 +1,7 @@
 # Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 # For details: https://github.com/pylint-dev/pylint/blob/main/LICENSE
 # Copyright (c) https://github.com/pylint-dev/pylint/blob/main/CONTRIBUTORS.txt
+# Modified on 2026-09-09 to recognize generated class initializers.
 
 """Variables checkers for Python code."""
 
@@ -2828,16 +2829,16 @@ class VariablesChecker(BaseChecker):
         argnames = node.argnames()
         # Care about functions with unknown argument (builtins)
         if name in argnames:
-            if node.name == "__new__":
-                is_init_def = False
-                # Look for the `__init__` method in all the methods of the same class.
-                for n in node.parent.get_children():
-                    is_init_def = hasattr(n, "name") and (n.name == "__init__")
-                    if is_init_def:
-                        break
-                # Ignore unused arguments check for `__new__` if `__init__` is defined.
-                if is_init_def:
-                    return
+            if (
+                node.name == "__new__"
+                and isinstance(node.parent, nodes.ClassDef)
+                and any(
+                    isinstance(initializer, nodes.FunctionDef)
+                    for initializer in node.parent.locals.get("__init__", ())
+                )
+            ):
+                # Include generated initializers, which are not children of the class.
+                return
             self._check_unused_arguments(name, node, stmt, argnames, nonlocal_names)
         else:
             if stmt.parent and isinstance(

--- a/tests/functional/u/unused/unused_argument.py
+++ b/tests/functional/u/unused/unused_argument.py
@@ -128,3 +128,31 @@ class TestClassWithInitAndNew:
 class TestClassWithOnlyNew:
     def __new__(cls, argA, argB): # [unused-argument, unused-argument]
         return object.__new__(cls)
+
+
+# Modified on 2026-09-09: cover generated dataclass initializers (issue #9843).
+from dataclasses import dataclass
+
+
+@dataclass
+class DataWithGeneratedInit:
+    arg: int
+
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls)
+
+
+@dataclass()
+class DataWithCalledDecorator:
+    arg: int
+
+    def __new__(cls, arg):
+        return super().__new__(cls)
+
+
+@dataclass(init=False)
+class DataWithoutGeneratedInit:
+    arg: int
+
+    def __new__(cls, *args, **kwargs):  # [unused-argument, unused-argument]
+        return super().__new__(cls)

--- a/tests/functional/u/unused/unused_argument.txt
+++ b/tests/functional/u/unused/unused_argument.txt
@@ -9,3 +9,5 @@ unused-argument:92:23:92:26:BBBB.__init__:Unused argument 'arg':INFERENCE
 unused-argument:103:34:103:39:Ancestor.set_thing:Unused argument 'other':INFERENCE
 unused-argument:129:21:129:25:TestClassWithOnlyNew.__new__:Unused argument 'argA':INFERENCE
 unused-argument:129:27:129:31:TestClassWithOnlyNew.__new__:Unused argument 'argB':INFERENCE
+unused-argument:157:0:157:None:DataWithoutGeneratedInit.__new__:Unused argument 'args':INFERENCE
+unused-argument:157:0:157:None:DataWithoutGeneratedInit.__new__:Unused argument 'kwargs':INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type |
| --- | --- |
| ✓ | :bug: Bug fix |

## Description

Dataclasses generate an `__init__` that consumes constructor arguments, but those arguments are still reported as unused in a custom `__new__`. Astroid keeps the generated initializer in the class's local symbol table, so the existing child-node scan misses it.

Check for a `FunctionDef` in the same class's `__init__` bindings. This preserves the existing explicit-initializer exemption without exempting every dataclass or searching inherited methods. Extend the functional fixture with bare and called dataclass decorators, and keep warnings for `init=False`.

Closes #9843.

Validation: the new positive cases fail on the original checker and pass with this change; the negative cases retain their warnings. Full suite: macOS Python 3.14, 2,163 passed / 309 skipped / 5 xfailed; Linux Python 3.13, 2,162 passed / 305 skipped / 5 xfailed. Configured pre-commit checks pass, including Pylint, mypy, formatting and the news fragment checks.
