### PR TITLE
Count properties and descriptors assigned in the class body as public methods

### DIFF
--- a/doc/whatsnew/fragments/10348.false_positive
+++ b/doc/whatsnew/fragments/10348.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for :ref:`too-few-public-methods` when a class defines its
+public interface through properties or descriptors assigned in the class body,
+such as ``name = property(getter)`` or ``name = Descriptor()``. They now count as
+public methods, like a method decorated with ``@property`` already did.
+
+Closes #10348

--- a/pylint/checkers/design_analysis.py
+++ b/pylint/checkers/design_analysis.py
@@ -11,10 +11,11 @@ from collections import defaultdict
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
-from astroid import nodes
+from astroid import bases, nodes, objects
+from astroid.exceptions import AttributeInferenceError
 
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import is_enum, only_required_for_messages
+from pylint.checkers.utils import is_enum, only_required_for_messages, safe_infer
 from pylint.interfaces import HIGH
 from pylint.typing import MessageDefinitionTuple
 
@@ -235,6 +236,50 @@ def _count_boolean_expressions(bool_op: nodes.BoolOp) -> int:
     return nb_bool_expr
 
 
+def _is_property_or_descriptor(node: nodes.NodeNG) -> bool:
+    """Check if the node is a ``property`` object or an instance of a descriptor."""
+    inferred = safe_infer(node)
+    if isinstance(inferred, objects.Property):
+        return True
+    if not isinstance(inferred, bases.Instance) or isinstance(inferred, nodes.NodeNG):
+        return False
+    try:
+        inferred.getattr("__get__")
+    except AttributeInferenceError:
+        return False
+    return True
+
+
+def _count_public_descriptors(node: nodes.ClassDef) -> int:
+    """Count the public class attributes that are properties or descriptors.
+
+    ``name = property(getter)`` and ``name = Descriptor()`` expose the same
+    interface as a method decorated with ``@property``, which counts as a
+    public method.
+    """
+    counted: set[str] = set()
+    for klass in (node, *node.ancestors()):
+        for name, values in klass.locals.items():
+            if name.startswith("_") or name in counted:
+                continue
+            for value in values:
+                if not isinstance(value, nodes.AssignName):
+                    continue
+                assignment = value.parent
+                if (
+                    isinstance(assignment, (nodes.Assign, nodes.AnnAssign))
+                    # Properties and descriptors are created by a call, or
+                    # aliased; there is no point inferring literals.
+                    and isinstance(
+                        assignment.value, (nodes.Call, nodes.Name, nodes.Attribute)
+                    )
+                    and _is_property_or_descriptor(assignment.value)
+                ):
+                    counted.add(name)
+                    break
+    return len(counted)
+
+
 def _count_methods_in_class(node: nodes.ClassDef) -> int:
     all_methods = sum(1 for method in node.methods() if not method.name.startswith("_"))
     # Special methods count towards the number of public methods,
@@ -242,7 +287,7 @@ def _count_methods_in_class(node: nodes.ClassDef) -> int:
     for method in node.mymethods():
         if SPECIAL_OBJ.search(method.name) and method.name != "__init__":
             all_methods += 1
-    return all_methods
+    return all_methods + _count_public_descriptors(node)
 
 
 def _get_parents_iter(

--- a/tests/functional/t/too/too_few_public_methods_property.py
+++ b/tests/functional/t/too/too_few_public_methods_property.py
@@ -1,0 +1,54 @@
+"""Properties and descriptors assigned in the class body count as public methods."""
+
+# pylint: disable=missing-class-docstring, missing-function-docstring, invalid-name
+# pylint: disable=unnecessary-lambda-assignment
+
+
+class Decorators:
+    @property
+    def id(self):
+        return None
+
+    @property
+    def name(self):
+        return None
+
+
+class Functions:
+    id = property(lambda self: None)
+    name = property(lambda self: None)
+
+
+def my_property():
+    def getter(_self):
+        return None
+
+    return property(getter)
+
+
+class Functions2:
+    id = my_property()
+    name = my_property()
+
+
+class Descriptor:  # [too-few-public-methods]
+    def __get__(self, instance, owner=None):
+        return None
+
+
+class Descriptors:
+    id = Descriptor()
+    name: Descriptor = Descriptor()
+
+
+class Inherited(Descriptors):
+    pass
+
+
+class OnlyOne:  # [too-few-public-methods]
+    id = property(lambda self: None)
+
+
+class PlainAttributes:  # [too-few-public-methods]
+    id = 1
+    name = "name"

--- a/tests/functional/t/too/too_few_public_methods_property.txt
+++ b/tests/functional/t/too/too_few_public_methods_property.txt
@@ -1,0 +1,3 @@
+too-few-public-methods:34:0:34:16:Descriptor:Too few public methods (1/2):UNDEFINED
+too-few-public-methods:48:0:48:13:OnlyOne:Too few public methods (1/2):UNDEFINED
+too-few-public-methods:52:0:52:21:PlainAttributes:Too few public methods (0/2):UNDEFINED


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

`too-few-public-methods` counted only methods, so these three classes were reported while `Decorators`, which exposes the same interface, was not:

```python
class Decorators:
    @property
    def id(self): ...
    @property
    def name(self): ...

class Functions:
    id = property(lambda self: None)
    name = property(lambda self: None)

class Descriptor:
    def __get__(self, instance, owner=None): ...

class Descriptors:
    id = Descriptor()
    name = Descriptor()
```

A public class attribute assigned a `property` object (built directly or through a helper) or an instance of a class that defines `__get__` now counts as a public method, in the class and its ancestors, the same way `methods()` is walked. Only calls, names and attributes are inferred, so literal class constants cost nothing. `too-many-public-methods` keeps counting the class's own methods only, so it cannot start firing on classes with many descriptors.

The functional test covers the three shapes from the issue, an `AnnAssign`, inheritance, and that `Descriptor` itself (one special method), a single property and plain constants are still reported.

Closes #10348
