### PR TITLE
Splat the single argument of an inner call in the nested-min-max suggestion

### DIFF
--- a/doc/whatsnew/fragments/9923.bugfix
+++ b/doc/whatsnew/fragments/9923.bugfix
@@ -1,0 +1,7 @@
+The suggestion of :ref:`nested-min-max` now splats the argument of an inner call
+that has a single argument, e.g. ``min(lo, hi, *elements)`` for
+``min(lo, hi, min(elements))``. A single-argument ``min()`` or ``max()`` only
+accepts an iterable, so the previous suggestion, ``min(lo, hi, elements)``,
+raised ``TypeError`` whenever the argument could not be inferred.
+
+Closes #9923

--- a/pylint/checkers/nested_min_max.py
+++ b/pylint/checkers/nested_min_max.py
@@ -116,9 +116,7 @@ class NestedMinMaxChecker(BaseChecker):
 
         for idx, arg in enumerate(fixed_node.args):
             if not isinstance(arg, (nodes.Const, nodes.Starred)):
-                if id(arg) in single_arguments or self._is_splattable_expression(
-                    arg
-                ):
+                if id(arg) in single_arguments or self._is_splattable_expression(arg):
                     splat_node = nodes.Starred(
                         ctx=Context.Load,
                         lineno=arg.lineno,

--- a/pylint/checkers/nested_min_max.py
+++ b/pylint/checkers/nested_min_max.py
@@ -91,6 +91,10 @@ class NestedMinMaxChecker(BaseChecker):
             return
 
         fixed_node = copy.copy(node)
+        # The argument of an inner call with a single argument, ``min(x)``, is
+        # necessarily an iterable, so it has to be splatted in the suggestion
+        # whether or not it can be inferred as one.
+        single_arguments: set[int] = set()
         while len(redundant_calls) > 0:
             for i, arg in enumerate(fixed_node.args):
                 # Exclude any calls with generator expressions as there is no
@@ -101,6 +105,8 @@ class NestedMinMaxChecker(BaseChecker):
                     return
 
                 if arg in redundant_calls:
+                    if len(arg.args) == 1:
+                        single_arguments.add(id(arg.args[0]))
                     fixed_node.args = (
                         fixed_node.args[:i] + arg.args + fixed_node.args[i + 1 :]
                     )
@@ -109,8 +115,10 @@ class NestedMinMaxChecker(BaseChecker):
             redundant_calls = self.get_redundant_calls(fixed_node, inferred)
 
         for idx, arg in enumerate(fixed_node.args):
-            if not isinstance(arg, nodes.Const):
-                if self._is_splattable_expression(arg):
+            if not isinstance(arg, (nodes.Const, nodes.Starred)):
+                if id(arg) in single_arguments or self._is_splattable_expression(
+                    arg
+                ):
                     splat_node = nodes.Starred(
                         ctx=Context.Load,
                         lineno=arg.lineno,

--- a/tests/functional/n/nested_min_max.py
+++ b/tests/functional/n/nested_min_max.py
@@ -75,3 +75,15 @@ max(1, max(5, 3), key=abs)  # [nested-min-max]
 LIST3 = [1, 2, 3]
 max(max(LIST3), 5, 7)  # [nested-min-max]
 max(4, max(LIST3), 7)  # [nested-min-max]
+
+# An inner call with a single argument only works on an iterable, so that
+# argument has to be splatted even when it cannot be inferred (see #9923).
+def bounds(lo, hi, elements):
+    """The suggested call must not compare ``lo`` with a list."""
+    return (
+        orig_min(lo, hi, orig_min(elements)),  # [nested-min-max]
+        max(lo, hi, max(elements)),  # [nested-min-max]
+    )
+
+
+max(1, max(*LIST3))  # [nested-min-max]

--- a/tests/functional/n/nested_min_max.txt
+++ b/tests/functional/n/nested_min_max.txt
@@ -16,8 +16,11 @@ nested-min-max:46:0:46:25::Do not use nested call of 'max'; it's possible to do 
 nested-min-max:49:0:49:45::Do not use nested call of 'max'; it's possible to do 'max(3, *[5] + [i for i in range(4) if i])' instead:INFERENCE
 nested-min-max:52:0:52:33::Do not use nested call of 'max'; it's possible to do 'max(3, *[5] + list(range(4)))' instead:INFERENCE
 nested-min-max:55:0:55:27::Do not use nested call of 'max'; it's possible to do 'max(3, *list(range(4)))' instead:INFERENCE
-nested-min-max:63:0:63:24::Do not use nested call of 'max'; it's possible to do 'max(3, max(MATRIX))' instead:INFERENCE
+nested-min-max:63:0:63:24::Do not use nested call of 'max'; it's possible to do 'max(3, *max(MATRIX))' instead:INFERENCE
 nested-min-max:64:4:64:23::Do not use nested call of 'max'; it's possible to do 'max(3, *MATRIX)' instead:INFERENCE
 nested-min-max:72:0:72:26::Do not use nested call of 'max'; it's possible to do 'max(1, 5, 3, key=abs)' instead:INFERENCE
 nested-min-max:76:0:76:21::Do not use nested call of 'max'; it's possible to do 'max(*LIST3, 5, 7)' instead:INFERENCE
 nested-min-max:77:0:77:21::Do not use nested call of 'max'; it's possible to do 'max(4, *LIST3, 7)' instead:INFERENCE
+nested-min-max:84:8:84:44:bounds:Do not use nested call of 'orig_min'; it's possible to do 'orig_min(lo, hi, *elements)' instead:INFERENCE
+nested-min-max:85:8:85:34:bounds:Do not use nested call of 'max'; it's possible to do 'max(lo, hi, *elements)' instead:INFERENCE
+nested-min-max:89:0:89:19::Do not use nested call of 'max'; it's possible to do 'max(1, *LIST3)' instead:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

```python
def bounds(lo, hi, elements):
    return min(lo, hi, min(elements))
```

was reported as `Do not use nested call of 'min'; it's possible to do 'min(lo, hi, elements)' instead`, and that suggestion raises `TypeError: '<' not supported between instances of 'list' and 'int'`. A single-argument `min()`/`max()` only accepts an iterable, so the flattened call has to unpack it: `min(lo, hi, *elements)`.

The checker already splats an inner argument when it infers to a list, tuple, set or dict; it just gave up on anything else, such as a parameter. Now the sole argument of an inner call is always splatted (unless it already is a `*` expression), whatever it infers to. This also corrects an existing expectation in the functional test: `max(3, max(max(MATRIX)))` was suggested as `max(3, max(MATRIX))`, which compares an `int` with a row, and is now `max(3, *max(MATRIX))`.

This follows the direction from the issue thread (keep the message, fix the suggestion); whether the message should be raised at all for a possibly huge generator is left as is.

Closes #9923
