### PR TITLE
Do not recurse forever in has_known_bases on a base-class cycle

### DIFF
--- a/doc/whatsnew/fragments/9190.bugfix
+++ b/doc/whatsnew/fragments/9190.bugfix
@@ -1,0 +1,5 @@
+Fix a crash (``RecursionError``) when a class has a base that infers to one of
+its own subclasses, typically a base bound under ``TYPE_CHECKING`` to the
+subclass and to something else otherwise.
+
+Closes #9190

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -1480,6 +1480,10 @@ def has_known_bases(
         return klass._all_bases_known  # type: ignore[no-any-return]
     except AttributeError:
         pass
+    # Mark the class before looking at its bases: when a base infers to a
+    # subclass of the class (typically a base chosen under ``TYPE_CHECKING``),
+    # the recursion below would otherwise come back to it indefinitely.
+    klass._all_bases_known = False
     for base in klass.bases:
         result = safe_infer(base, context=context)
         if (

--- a/tests/regrtest_data/type_checking_base_cycle/__init__.py
+++ b/tests/regrtest_data/type_checking_base_cycle/__init__.py
@@ -1,0 +1,1 @@
+"""A base class chosen under TYPE_CHECKING that is a subclass of the class."""

--- a/tests/regrtest_data/type_checking_base_cycle/models.py
+++ b/tests/regrtest_data/type_checking_base_cycle/models.py
@@ -1,0 +1,20 @@
+"""The mixin's base is the subclass itself when type checking (see #9190)."""
+
+# pylint: disable=too-few-public-methods
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from type_checking_base_cycle.pipe import Pipe
+
+    _PipeDataRelatedMixinBase = Pipe
+else:
+    _PipeDataRelatedMixinBase = object
+
+
+class PipeDataRelatedMixin(_PipeDataRelatedMixinBase):
+    """Mixin whose base infers to its own subclass."""
+
+    def get_statistic_aggregations(self: "Pipe", is_scrap):
+        """Method with an annotated ``self``."""
+        return is_scrap

--- a/tests/regrtest_data/type_checking_base_cycle/pipe.py
+++ b/tests/regrtest_data/type_checking_base_cycle/pipe.py
@@ -1,0 +1,9 @@
+"""The subclass that the mixin's base resolves to."""
+
+# pylint: disable=too-few-public-methods
+
+from type_checking_base_cycle.models import PipeDataRelatedMixin
+
+
+class Pipe(PipeDataRelatedMixin):
+    """Subclass of the mixin."""

--- a/tests/test_regr.py
+++ b/tests/test_regr.py
@@ -64,6 +64,7 @@ def Equals(expected: str) -> Callable[[str], bool]:
         ([join(REGR_DATA, "decimal_inference.py")], Equals("")),
         ([join(REGR_DATA, "absimp", "string.py")], Equals("")),
         ([join(REGR_DATA, "bad_package")], lambda x: "Unused import missing" in x),
+        ([join(REGR_DATA, "type_checking_base_cycle")], Equals("")),
     ],
 )
 def test_package(


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

The file from the issue has a mixin whose base is bound under `TYPE_CHECKING` to a subclass of the mixin:

```python
if TYPE_CHECKING:
    from pipe import Pipe
    _Base = Pipe
else:
    _Base = models.Model

class PipeDataRelatedMixin(_Base): ...
```

with `class Pipe(PipeDataRelatedMixin)` in the other module. `has_known_bases(PipeDataRelatedMixin)` infers the base as `Pipe`, recurses into `has_known_bases(Pipe)`, whose base is the mixin again, and so on until `RecursionError`, which escapes as an `astroid-error` crash from the docstring checker (and any other caller). The MRO side of this was made robust in astroid 4.1.2, but this helper has its own recursion.

The class is now marked before its bases are examined, so coming back to it through the cycle answers `False` (the bases are not "known" in any useful sense) and the walk terminates; the mark is set to `True` at the end as before. The regression test is a two-module package under `tests/regrtest_data`, checked through `test_package` with the expectation of no output: without the fix it reports the `astroid-error`.

Closes #9190
