### PR TITLE
Emit missing-timeout for the request methods of requests.Session

### DIFF
--- a/doc/user_guide/configuration/all-options.rst
+++ b/doc/user_guide/configuration/all-options.rst
@@ -1574,9 +1574,9 @@ Standard Checkers
 
 --timeout-methods
 """""""""""""""""
-*List of qualified names (i.e., library.method) which require a timeout parameter e.g. 'requests.api.get,requests.api.post'*
+*List of qualified names (i.e., library.method) which require a timeout parameter e.g. 'requests.api.get,requests.sessions.Session.get'*
 
-**Default:**  ``('requests.api.delete', 'requests.api.get', 'requests.api.head', 'requests.api.options', 'requests.api.patch', 'requests.api.post', 'requests.api.put', 'requests.api.request')``
+**Default:**  ``('requests.api.delete', 'requests.api.get', 'requests.api.head', 'requests.api.options', 'requests.api.patch', 'requests.api.post', 'requests.api.put', 'requests.api.request', 'requests.sessions.Session.delete', 'requests.sessions.Session.get', 'requests.sessions.Session.head', 'requests.sessions.Session.options', 'requests.sessions.Session.patch', 'requests.sessions.Session.post', 'requests.sessions.Session.put', 'requests.sessions.Session.request', 'requests.sessions.Session.send')``
 
 
 
@@ -1590,7 +1590,7 @@ Standard Checkers
 .. code-block:: toml
 
    [tool.pylint.method_args]
-   timeout-methods = ["requests.api.delete", "requests.api.get", "requests.api.head", "requests.api.options", "requests.api.patch", "requests.api.post", "requests.api.put", "requests.api.request"]
+   timeout-methods = ["requests.api.delete", "requests.api.get", "requests.api.head", "requests.api.options", "requests.api.patch", "requests.api.post", "requests.api.put", "requests.api.request", "requests.sessions.Session.delete", "requests.sessions.Session.get", "requests.sessions.Session.head", "requests.sessions.Session.options", "requests.sessions.Session.patch", "requests.sessions.Session.post", "requests.sessions.Session.put", "requests.sessions.Session.request", "requests.sessions.Session.send"]
 
 
 

--- a/doc/whatsnew/fragments/9517.false_negative
+++ b/doc/whatsnew/fragments/9517.false_negative
@@ -1,0 +1,7 @@
+:ref:`missing-timeout` is now also emitted for the request methods of a
+``requests.Session`` (``session.get(url)``, ``session.post(url)``, ...), which
+default to no timeout like the module-level ``requests.get()`` and friends. The
+``timeout-methods`` option now lists them, and bound methods are matched against
+that option in general.
+
+Closes #9517

--- a/pylint/checkers/method_args.py
+++ b/pylint/checkers/method_args.py
@@ -56,11 +56,20 @@ class MethodArgsChecker(BaseChecker):
                     "requests.api.post",
                     "requests.api.put",
                     "requests.api.request",
+                    "requests.sessions.Session.delete",
+                    "requests.sessions.Session.get",
+                    "requests.sessions.Session.head",
+                    "requests.sessions.Session.options",
+                    "requests.sessions.Session.patch",
+                    "requests.sessions.Session.post",
+                    "requests.sessions.Session.put",
+                    "requests.sessions.Session.request",
+                    "requests.sessions.Session.send",
                 ),
                 "type": "csv",
                 "metavar": "<comma separated list>",
                 "help": "List of qualified names (i.e., library.method) which require a timeout parameter "
-                "e.g. 'requests.api.get,requests.api.post'",
+                "e.g. 'requests.api.get,requests.sessions.Session.get'",
             },
         ),
     )
@@ -84,7 +93,13 @@ class MethodArgsChecker(BaseChecker):
             inferred
             and not call_site.has_invalid_keywords()
             and isinstance(
-                inferred, (nodes.FunctionDef, nodes.ClassDef, bases.UnboundMethod)
+                inferred,
+                (
+                    nodes.FunctionDef,
+                    nodes.ClassDef,
+                    bases.UnboundMethod,
+                    bases.BoundMethod,
+                ),
             )
             and inferred.qname() in self.linter.config.timeout_methods
         ):

--- a/tests/functional/m/missing/missing_timeout.py
+++ b/tests/functional/m/missing/missing_timeout.py
@@ -81,5 +81,34 @@ post("http://localhost", timeout=10)
 put("http://localhost", timeout=10)
 request("call", "http://localhost", timeout=10)
 
-KWARGS_TIMEOUT = {'timeout': 10}
+KWARGS_TIMEOUT = {"timeout": 10}
 post("http://localhost", **KWARGS_TIMEOUT)
+
+# requests.Session methods
+SESSION = requests.Session()
+SESSION.delete("http://localhost")  # [missing-timeout]
+SESSION.get("http://localhost")  # [missing-timeout]
+SESSION.head("http://localhost")  # [missing-timeout]
+SESSION.options("http://localhost")  # [missing-timeout]
+SESSION.patch("http://localhost")  # [missing-timeout]
+SESSION.post("http://localhost")  # [missing-timeout]
+SESSION.put("http://localhost")  # [missing-timeout]
+SESSION.request("call", "http://localhost")  # [missing-timeout]
+SESSION.send(requests.Request("GET", "http://localhost").prepare())  # [missing-timeout]
+requests.Session().get("http://localhost")  # [missing-timeout]
+
+with requests.Session() as session:
+    session.get("http://localhost")  # [missing-timeout]
+    session.get("http://localhost", timeout=10)
+
+SESSION.delete("http://localhost", timeout=10)
+SESSION.get("http://localhost", timeout=10)
+SESSION.head("http://localhost", timeout=10)
+SESSION.options("http://localhost", timeout=10)
+SESSION.patch("http://localhost", timeout=10)
+SESSION.post("http://localhost", timeout=10)
+SESSION.put("http://localhost", timeout=10)
+SESSION.request("call", "http://localhost", timeout=10)
+SESSION.send(requests.Request("GET", "http://localhost").prepare(), timeout=10)
+KWARGS_WITH_TIMEOUT = {"timeout": 10}
+SESSION.get("http://localhost", **KWARGS_WITH_TIMEOUT)

--- a/tests/functional/m/missing/missing_timeout.txt
+++ b/tests/functional/m/missing/missing_timeout.txt
@@ -23,3 +23,14 @@ missing-timeout:49:0:49:24::Missing timeout argument for method 'post' can cause
 missing-timeout:50:0:50:23::Missing timeout argument for method 'put' can cause your program to hang indefinitely:INFERENCE
 missing-timeout:51:0:51:35::Missing timeout argument for method 'request' can cause your program to hang indefinitely:INFERENCE
 missing-timeout:54:0:54:45::Missing timeout argument for method 'post' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:89:0:89:34::Missing timeout argument for method 'SESSION.delete' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:90:0:90:31::Missing timeout argument for method 'SESSION.get' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:91:0:91:32::Missing timeout argument for method 'SESSION.head' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:92:0:92:35::Missing timeout argument for method 'SESSION.options' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:93:0:93:33::Missing timeout argument for method 'SESSION.patch' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:94:0:94:32::Missing timeout argument for method 'SESSION.post' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:95:0:95:31::Missing timeout argument for method 'SESSION.put' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:96:0:96:43::Missing timeout argument for method 'SESSION.request' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:97:0:97:67::Missing timeout argument for method 'SESSION.send' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:98:0:98:42::Missing timeout argument for method 'requests.Session().get' can cause your program to hang indefinitely:INFERENCE
+missing-timeout:101:4:101:35::Missing timeout argument for method 'session.get' can cause your program to hang indefinitely:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

```python
session = requests.Session()
session.get(url)  # nothing, while requests.get(url) is reported
```

`Session.get()` and the other request methods of a `requests.Session` default to no timeout exactly like the module-level functions (they all go through `Session.request()`, whose `timeout` defaults to `None`), so the reason for `missing-timeout` applies to them as much as to `requests.get()`.

Two things kept them out: the checker only accepted `FunctionDef`, `ClassDef` and `UnboundMethod` results for the called object, so the `BoundMethod` a session method infers to was skipped, and the default `timeout-methods` only listed the `requests.api` functions. Bound methods are now matched (against the configured names, so this also lets users list methods of their own classes), and the defaults include `requests.sessions.Session.{delete,get,head,options,patch,post,put,request,send}`.

The functional test covers each method through a stored session, a temporary `requests.Session().get(...)`, a session used as a context manager, and the `timeout=` and `**kwargs` forms that must stay silent. `all-options.rst` is regenerated for the new default.

Closes #9517
