### PR TITLE
Document how pylint finds the imported modules

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -49,6 +49,13 @@ behavior. Likewise, since negative values are still technically supported,
 ``evaluation`` can be set to a version of the above expression that does not
 enforce a floor of zero.
 
+Pylint reports ``import-error`` for packages that are installed. Why?
+---------------------------------------------------------------------
+
+Pylint looks for imported modules with the interpreter it runs under, so it has to
+run from the environment where the dependencies of your project are installed, or be
+told where to look. See :ref:`finding_imported_modules`.
+
 How do I avoid getting unused argument warnings for API I do not control?
 -------------------------------------------------------------------------
 

--- a/doc/user_guide/usage/run.rst
+++ b/doc/user_guide/usage/run.rst
@@ -51,6 +51,41 @@ If the analyzed sources use implicit namespace packages (PEP 420), the source ro
 be specified using the ``--source-roots`` option. Otherwise, the package names are
 detected incorrectly, since implicit namespace packages don't contain an ``__init__.py``.
 
+.. _finding_imported_modules:
+
+Finding the imported modules
+----------------------------
+
+Pylint does not run the code it analyzes, but it needs to find the modules
+that the code imports in order to check them: ``import-error``,
+``no-name-in-module``, ``no-member`` and most inference-based checks depend on
+it. Modules are looked up the way the interpreter running pylint would look
+them up: in the current working directory, in the directories listed in
+``PYTHONPATH`` and in the ``site-packages`` of that interpreter.
+
+The simplest way to make the dependencies of a project available is therefore
+to install pylint in the same environment as the project, for example in its
+virtual environment, and to run it from there::
+
+    python -m pylint mypackage
+
+When pylint has to run with another interpreter, the directories to search can
+be added to ``sys.path`` before the analysis starts with the ``init-hook``
+option, which takes Python code::
+
+    pylint --init-hook='import sys; sys.path.append("/path/to/venv/lib/python3.12/site-packages")' mypackage
+
+or, in the configuration file:
+
+.. code-block:: toml
+
+    [tool.pylint.main]
+    init-hook = 'import sys; sys.path.append("/path/to/venv/lib/python3.12/site-packages")'
+
+Modules that still cannot be found are reported with ``import-error``. The
+``ignored-modules`` option silences that message, as well as the checks of the
+members of the module, for the modules it lists.
+
 Globbing support
 ----------------
 

--- a/doc/whatsnew/fragments/9974.other
+++ b/doc/whatsnew/fragments/9974.other
@@ -1,0 +1,5 @@
+Document how pylint finds the modules that the analyzed code imports, and how to
+point it at the dependencies of a project with ``init-hook`` when it cannot run
+from the project's environment.
+
+Closes #9974


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :scroll: Docs          |

## Description

The documentation did not say anywhere that pylint resolves imports with the interpreter it runs under, nor mention `init-hook`, so users who run pylint from outside their project's environment get `import-error` for installed dependencies and end up on Stack Overflow (the answer linked in the issue).

This adds a "Finding the imported modules" section to the *Running Pylint* page: what the lookup depends on, the recommended fix (install and run pylint in the project's environment), the `init-hook` alternative on the command line and in the configuration file, and `ignored-modules` for what still cannot be found. An FAQ entry points to it.

`tox -e docs` builds cleanly with `-W` and leaves the generated pages unchanged.

Closes #9974
