### PR TITLE
Accept a name bound by a walrus in the condition of a comprehension

### DIFF
--- a/doc/whatsnew/fragments/9460.false_positive
+++ b/doc/whatsnew/fragments/9460.false_positive
@@ -1,0 +1,7 @@
+Fix a false positive for :ref:`used-before-assignment` when a name is bound by an
+assignment expression in the ``if`` of a comprehension and used in its element (or
+key and value) or in a later ``for`` or ``if`` clause, as in
+``[service for port in ports if (service := lookup(port))]``. The condition of a
+comprehension is evaluated before those parts.
+
+Closes #9460

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2450,7 +2450,8 @@ class VariablesChecker(BaseChecker):
         defnode: nodes.NamedExpr, node: nodes.Name
     ) -> bool:
         """Check that ``defnode`` is in an ``if`` of a comprehension and ``node``
-        in a part of that comprehension evaluated afterwards: its element (or key
+        in a part of that comprehension evaluated afterwards: its element (or key.
+
         and value), or a ``for`` or ``if`` clause that follows the condition.
         """
         comprehension = utils.get_node_first_ancestor_of_type(

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2424,6 +2424,18 @@ class VariablesChecker(BaseChecker):
                         a is defnode.value for a in node.node_ancestors()
                     )
                 elif (
+                    isinstance(defnode, nodes.NamedExpr)
+                    and frame is defframe
+                    and stmt is defstmt
+                    and VariablesChecker._is_defined_in_comprehension_condition(
+                        defnode, node
+                    )
+                ):
+                    # ``[b for x in it if (b := f(x))]``: the condition of a
+                    # comprehension is evaluated before its element, and before
+                    # the clauses that follow it
+                    maybe_before_assign = False
+                elif (
                     isinstance(defframe, nodes.ClassDef)
                     and defnode in defframe.type_params
                 ):
@@ -2432,6 +2444,45 @@ class VariablesChecker(BaseChecker):
                     maybe_before_assign = False
 
         return maybe_before_assign, annotation_return, use_outer_definition
+
+    @staticmethod
+    def _is_defined_in_comprehension_condition(
+        defnode: nodes.NamedExpr, node: nodes.Name
+    ) -> bool:
+        """Check that ``defnode`` is in an ``if`` of a comprehension and ``node``
+        in a part of that comprehension evaluated afterwards: its element (or key
+        and value), or a ``for`` or ``if`` clause that follows the condition.
+        """
+        comprehension = utils.get_node_first_ancestor_of_type(
+            defnode, nodes.Comprehension
+        )
+        if comprehension is None:
+            return False
+        defining_index = next(
+            (
+                index
+                for index, condition in enumerate(comprehension.ifs)
+                if condition is defnode or condition.parent_of(defnode)
+            ),
+            None,
+        )
+        if defining_index is None:
+            return False
+        scope = comprehension.parent
+        if not isinstance(scope, nodes.ComprehensionScope):
+            return False
+        generators = scope.generators
+        evaluated_afterwards: list[nodes.NodeNG] = [
+            *comprehension.ifs[defining_index + 1 :],
+            *generators[generators.index(comprehension) + 1 :],
+        ]
+        if isinstance(scope, nodes.DictComp):
+            evaluated_afterwards += [scope.key, scope.value]
+        else:
+            evaluated_afterwards.append(scope.elt)
+        return any(
+            part is node or part.parent_of(node) for part in evaluated_afterwards
+        )
 
     @staticmethod
     def _maybe_used_and_assigned_at_once(defstmt: _base_nodes.Statement) -> bool:

--- a/tests/functional/u/used/used_before_assignment_comprehension_walrus.py
+++ b/tests/functional/u/used/used_before_assignment_comprehension_walrus.py
@@ -1,0 +1,47 @@
+"""A name bound by a walrus in the ``if`` of a comprehension is usable in the parts
+evaluated afterwards. Regression test for https://github.com/pylint-dev/pylint/issues/9460
+"""
+
+
+def service_or_none(port: int) -> str | None:
+    """Return a service name for some ports."""
+    return f"service-{port}" if port % 2 else None
+
+
+KNOWN_SERVICES = [
+    service for port in range(1, 1024) if
+    (service := service_or_none(port))
+]
+KNOWN_PORTS = {
+    service: port for port in range(1, 1024) if (service := service_or_none(port))
+}
+LENGTHS = {len(service) for port in range(1, 1024) if (service := service_or_none(port))}
+UPPER = (service.upper() for port in range(1, 1024) if (service := service_or_none(port)))
+
+# A later clause of the same comprehension...
+CHARS = [
+    (service, char)
+    for port in range(1, 1024)
+    if (service := service_or_none(port))
+    for char in service
+]
+# ...or a later condition of the same clause can use the name too
+LONG = [
+    service
+    for port in range(1, 1024)
+    if (service := service_or_none(port))
+    if len(service) > 9
+]
+
+# A condition evaluated before the one binding the name cannot
+EARLY = [
+    port
+    for port in range(1, 1024)
+    if early  # [used-before-assignment]
+    if (early := service_or_none(port))
+]
+
+
+def in_function():
+    """The same, in a function scope."""
+    return [name for port in range(1, 1024) if (name := service_or_none(port))]

--- a/tests/functional/u/used/used_before_assignment_comprehension_walrus.txt
+++ b/tests/functional/u/used/used_before_assignment_comprehension_walrus.txt
@@ -1,0 +1,1 @@
+used-before-assignment:40:7:40:12::Using variable 'early' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

```python
known_services = [
    service for port in range(1, 49151) if
    (service := getservbyport_or_not(port))
]
```

was reported with `used-before-assignment` for `service`. The walrus comes after the use in the source, and the existing handling of assignment expressions only accepts a use that is textually after its walrus in the same statement; but the condition of a comprehension is evaluated before its element, so this is fine at runtime.

`_is_variable_violation` now accepts a name defined by a walrus in an `if` of a comprehension when the use is in a part of that comprehension evaluated afterwards: the element (or the key and value of a dict comprehension), a later `for` clause, or a later `if` of the same clause. A use in an earlier condition (`if early if (early := ...)`) is still reported, which the functional test checks along with list, dict, set and generator comprehensions at module and function level.

Closes #9460
