### PR TITLE
Do not report assignment-from-no-return for stubs

### DIFF
--- a/doc/whatsnew/fragments/9080.false_positive
+++ b/doc/whatsnew/fragments/9080.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for :ref:`assignment-from-no-return` when the called function
+is a method of a ``Protocol`` or has a body consisting only of ``...``: such stubs
+declare a method to implement rather than returning nothing.
+
+Closes #9080

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1393,6 +1393,9 @@ accessed. Python regular expressions are accepted.",
             )
             or function_node.is_generator()
             or function_node.is_abstract(pass_is_abstract=False)
+            # a stub, declaring a method to implement rather than returning nothing
+            or utils.is_function_body_ellipsis(function_node)
+            or utils.is_protocol_class(function_node.parent)
         )
 
     @staticmethod

--- a/tests/functional/a/assignment/assignment_from_no_return.py
+++ b/tests/functional/a/assignment/assignment_from_no_return.py
@@ -1,5 +1,8 @@
 # pylint: disable=missing-docstring, invalid-name, too-few-public-methods
 
+from dataclasses import dataclass
+from typing import Protocol
+
 
 def some_func():
     pass
@@ -105,3 +108,39 @@ def early_return_then_raise(value):
 
 
 maybe = early_return_then_raise(None)  # [assignment-from-none]
+
+
+# Methods of a Protocol and functions whose body is only ``...`` are stubs
+# declaring what to implement, not functions returning nothing.
+# Regression test for https://github.com/pylint-dev/pylint/issues/9080
+class Blah(Protocol):
+    """A protocol"""
+
+    def do_thing(self) -> str:
+        """Declares the method without implementing it"""
+        ...
+
+
+class Overridable:
+    """A base class whose method is meant to be overridden"""
+
+    def do_thing(self): ...
+
+    def really_returns_nothing(self):
+        """A body that does something and returns None"""
+        print(self)
+
+
+@dataclass
+class BlahUser:
+    """Holds a protocol implementation and a base class instance"""
+
+    blah: Blah
+    overridable: Overridable
+
+    def do_thing_with_blah(self):
+        """No message for the stubs, one for the real method"""
+        value = self.blah.do_thing()
+        other = self.overridable.do_thing()
+        nothing = self.overridable.really_returns_nothing()  # [assignment-from-no-return]
+        return value, other, nothing

--- a/tests/functional/a/assignment/assignment_from_no_return.txt
+++ b/tests/functional/a/assignment/assignment_from_no_return.txt
@@ -1,4 +1,5 @@
-assignment-from-no-return:26:8:26:34:Class.some_other_method:Assigning result of a function call, but 'some_method' returns None:INFERENCE
-assignment-from-no-return:31:0:31:19::Assigning result of a function call, but 'some_func' returns None:INFERENCE
-assignment-from-no-return:33:0:33:37::Assigning result of a function call, but 'FUNCTIONS[0]' returns None:INFERENCE
-assignment-from-none:107:0:107:37::Assigning result of a function call, where the function returns None:UNDEFINED
+assignment-from-no-return:29:8:29:34:Class.some_other_method:Assigning result of a function call, but 'some_method' returns None:INFERENCE
+assignment-from-no-return:34:0:34:19::Assigning result of a function call, but 'some_func' returns None:INFERENCE
+assignment-from-no-return:36:0:36:37::Assigning result of a function call, but 'FUNCTIONS[0]' returns None:INFERENCE
+assignment-from-none:110:0:110:37::Assigning result of a function call, where the function returns None:UNDEFINED
+assignment-from-no-return:145:8:145:59:BlahUser.do_thing_with_blah:Assigning result of a function call, but 'really_returns_nothing' returns None:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

```python
class Blah(Protocol):
    def do_thing(self) -> str:
        ...

@dataclass
class BlahUser:
    blah: Blah
    def do_thing_with_blah(self):
        value = self.blah.do_thing()  # assignment-from-no-return
```

`Blah.do_thing` has no `return`, so `assignment-from-no-return` fires, but a `Protocol` method (like any function whose body is just `...`) declares what an implementation must provide rather than returning nothing. `_is_ignored_function` already skips abstract methods, generators and functions that always raise; it now also skips methods of a `Protocol` and functions whose body consists only of an ellipsis, the same stub idiom that `unnecessary-ellipsis` and the special-method return checks already recognise through `utils.is_function_body_ellipsis`.

The functional test covers the protocol method and an ellipsis-bodied method of a plain class (no message), and a method with a real body that returns nothing (still reported).

Closes #9080
