### PR TITLE
Find nonlocal declarations nested in a block of the function

### DIFF
--- a/doc/whatsnew/fragments/9689.false_positive
+++ b/doc/whatsnew/fragments/9689.false_positive
@@ -1,0 +1,5 @@
+Fix a false positive for :ref:`used-before-assignment` when a ``nonlocal``
+declaration is nested in a block of the function, such as a ``try``, ``while`` or
+``with``, rather than at its top level.
+
+Closes #9689

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -332,15 +332,20 @@ def _is_before(node: nodes.NodeNG, reference_node: nodes.NodeNG) -> bool:
 
 
 def _is_nonlocal_name(node: nodes.Name, frame: nodes.LocalsDictNodeNG) -> bool:
-    """Checks if name node has a nonlocal declaration in the given frame."""
+    """Checks if name node has a nonlocal declaration in the given frame.
+
+    The declaration can be nested in a block of the frame, such as a ``try``,
+    ``while`` or ``with``, but not in another scope.
+    """
     if not isinstance(frame, nodes.FunctionDef):
         return False
 
     return any(
-        isinstance(stmt, nodes.Nonlocal)
-        and node.name in stmt.names
-        and _is_before(stmt, node)
-        for stmt in frame.body
+        node.name in stmt.names and _is_before(stmt, node)
+        for stmt in frame.nodes_of_class(
+            nodes.Nonlocal,
+            skip_klass=(nodes.FunctionDef, nodes.Lambda, nodes.ClassDef),
+        )
     )
 
 

--- a/tests/functional/u/used/used_before_assignment.py
+++ b/tests/functional/u/used/used_before_assignment.py
@@ -264,7 +264,7 @@ def outer_():
     def inner_try():
         try:
             nonlocal a
-            print(a)  # [used-before-assignment] FALSE POSITIVE
+            print(a)
             a = 2
             print(a)
         except:
@@ -275,7 +275,7 @@ def outer_():
         while i < 2:
             i += 1
             nonlocal a
-            print(a)  # [used-before-assignment] FALSE POSITIVE
+            print(a)
             a = 2
             print(a)
 

--- a/tests/functional/u/used/used_before_assignment.txt
+++ b/tests/functional/u/used/used_before_assignment.txt
@@ -15,6 +15,4 @@ used-before-assignment:192:10:192:18::Using variable 'ALL_DONE' before assignmen
 used-before-assignment:203:6:203:24::Using variable 'NOT_ALWAYS_DEFINED' before assignment:INFERENCE
 used-before-assignment:239:10:239:11::Using variable 'x' before assignment:CONTROL_FLOW
 possibly-used-before-assignment:253:10:253:15:__:Possibly using variable 'fail1' before assignment:CONTROL_FLOW
-used-before-assignment:267:18:267:19:outer_.inner_try:Using variable 'a' before assignment:HIGH
-used-before-assignment:278:18:278:19:outer_.inner_while:Using variable 'a' before assignment:HIGH
 possibly-used-before-assignment:315:10:315:11:conditional_wildcard_import_unresolvable:Possibly using variable 'x' before assignment:CONTROL_FLOW

--- a/tests/functional/u/used/used_before_assignment_nonlocal.py
+++ b/tests/functional/u/used/used_before_assignment_nonlocal.py
@@ -163,3 +163,43 @@ def nonlocal_after_bad_usage_fail():
         num = num + 1  # [used-before-assignment]
         nonlocal num
     inner()
+
+
+def nonlocal_in_nested_blocks():
+    """https://github.com/pylint-dev/pylint/issues/9689
+
+    The declaration can be nested in a block of the function.
+    """
+    num = 1
+
+    def inner_with():
+        with open("file.txt", encoding="utf-8") as handle:
+            nonlocal num
+            print(num, handle)
+            num = 2
+
+    def inner_try_in_if():
+        try:
+            if num:
+                nonlocal num
+                print(num)
+                num = 2
+        finally:
+            pass
+
+    inner_with()
+    inner_try_in_if()
+
+
+def nonlocal_only_in_nested_function_fail():
+    """A declaration in a nested function does not apply to its parent."""
+    num = 1
+
+    def inner():
+        def deeper():
+            nonlocal num
+            num = 3
+        deeper()
+        print(num)  # [used-before-assignment]
+        num = 2
+    inner()

--- a/tests/functional/u/used/used_before_assignment_nonlocal.txt
+++ b/tests/functional/u/used/used_before_assignment_nonlocal.txt
@@ -9,3 +9,4 @@ used-before-assignment:96:14:96:18:inner_function_lacks_access_to_outer_args.inn
 used-before-assignment:117:18:117:21:nonlocal_in_outer_frame_fail.outer.inner:Using variable 'num' before assignment:HIGH
 possibly-used-before-assignment:149:20:149:28:nonlocal_in_distant_outer_frame_fail.outer.intermediate.inner:Possibly using variable 'callback' before assignment:CONTROL_FLOW
 used-before-assignment:163:14:163:17:nonlocal_after_bad_usage_fail.inner:Using variable 'num' before assignment:HIGH
+used-before-assignment:203:14:203:17:nonlocal_only_in_nested_function_fail.inner:Using variable 'num' before assignment:HIGH


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

```python
def outer():
    a = 1
    def inner_try():
        try:
            nonlocal a
            print(a)  # used-before-assignment
            a = 2
        except ValueError:
            pass
```

`_is_nonlocal_name` only iterated over `frame.body`, so a `nonlocal` declared inside a `try`, `while` or `with` block (the three cases from the issue, plus the nested-`if` variant) was not seen. It now walks the whole frame with `nodes_of_class(nodes.Nonlocal, skip_klass=(FunctionDef, Lambda, ClassDef))`, so declarations in nested scopes still do not count, and the declaration still has to come before the use.

`used_before_assignment.py` already contained the `try` and `while` cases from the issue annotated as `FALSE POSITIVE`; those two expectations are removed. The `nonlocal` functional test gains the `with` and nested-block cases, and a case where the declaration is only in a nested function, which must still be reported.

Closes #9689
