### PR TITLE
Fix a false positive for `unpacking-non-sequence` with stubs

### DIFF
--- a/doc/whatsnew/fragments/9354.false_positive
+++ b/doc/whatsnew/fragments/9354.false_positive
@@ -1,0 +1,6 @@
+Fix a false positive for ``unpacking-non-sequence`` when unpacking the result
+of a function that is only declared in a stub (``.pyi``) file. A stub has no
+return statement, so its calls were inferred as returning ``None``; the return
+type declared by the stub is now used to check the unpacking instead.
+
+Closes #9354

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -108,6 +108,29 @@ def _wildcard_import_binds(stmt: nodes.ImportFrom, name: str) -> bool:
         return False
 
 
+def _inferred_return_of_stub(call: nodes.Call) -> InferenceResult | None:
+    """Infer the return type declared by the stub the call targets, if any.
+
+    A function whose body is only the ``...`` of a stub has no return statement,
+    so astroid infers its result as ``None``, even when it declares a return
+    type. The annotation describes the value at runtime, so use it instead.
+    """
+    called = utils.safe_infer(call.func)
+    if not isinstance(called, nodes.FunctionDef) or called.returns is None:
+        return None
+    if not utils.is_function_body_ellipsis(called):
+        return None
+    inferred = utils.safe_infer(called.returns)
+    if isinstance(inferred, nodes.Const) and isinstance(inferred.value, str):
+        # An unresolved string annotation: keep the previous behaviour rather
+        # than risking a false negative.
+        return None
+    if isinstance(inferred, nodes.ClassDef):
+        # The annotation names the class of the returned value.
+        return inferred.instantiate_class()
+    return inferred
+
+
 def _get_unpacking_extra_info(node: nodes.Assign, inferred: InferenceResult) -> str:
     """Return extra information to add to the message for unpacking-non-sequence
     and unbalanced-tuple/dict-unpacking errors.
@@ -3120,6 +3143,17 @@ class VariablesChecker(BaseChecker):
             return
         if isinstance(inferred, util.UninferableBase):
             return
+        if (
+            isinstance(inferred, nodes.Const)
+            and inferred.value is None
+            and isinstance(node.value, nodes.Call)
+        ):
+            # The call is inferred as returning ``None`` because the called
+            # function has no return statement; a stub, however, only declares
+            # its return type.
+            stub_return = _inferred_return_of_stub(node.value)
+            if stub_return is not None:
+                inferred = stub_return
         if (
             isinstance(inferred.parent, nodes.Arguments)
             and isinstance(node.value, nodes.Name)

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -1128,6 +1128,22 @@ def test_no_false_positive_from_pyi_stub() -> None:
     assert not run.linter.stats.by_msg
 
 
+def test_unpacking_from_pyi_stub() -> None:
+    """The return type declared by a stub is used to check the unpacking.
+
+    A stub has no return statement, so its calls used to be inferred as
+    returning ``None``, which made every unpacking of such a call look like
+    unpacking a non-sequence: https://github.com/pylint-dev/pylint/issues/9354
+    """
+    run = Run(
+        ["--recursive", "y", join(REGRTEST_DATA_DIR, "uses_pyi_stub_unpacking.py")],
+        exit=False,
+    )
+    # No message for the stub returning a tuple, and still one for the stub
+    # returning an int.
+    assert run.linter.stats.by_msg == {"unpacking-non-sequence": 1}
+
+
 @pytest.mark.parametrize(
     "ignore_parameter,ignore_parameter_value",
     [

--- a/tests/regrtest_data/pyi_stub_unpacking/__init__.pyi
+++ b/tests/regrtest_data/pyi_stub_unpacking/__init__.pyi
@@ -1,0 +1,8 @@
+# Only declared, the implementation is somewhere else (a C extension, or
+# another module): https://github.com/pylint-dev/pylint/issues/9354
+
+def declared_tuple() -> tuple[int, int, int]:
+    ...
+
+def declared_int() -> int:
+    ...

--- a/tests/regrtest_data/uses_pyi_stub_unpacking.py
+++ b/tests/regrtest_data/uses_pyi_stub_unpacking.py
@@ -1,0 +1,5 @@
+"""Unpack values returned by functions that are only declared in a stub."""
+from pyi_stub_unpacking import declared_int, declared_tuple
+
+FIRST, SECOND, THIRD = declared_tuple()
+VALUE, _REST = declared_int()


### PR DESCRIPTION
<!--
Thank you for submitting a PR to pylint!
-->
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Unpacking the result of a function that is only declared in a stub was reported as
unpacking a non-sequence (E0633):

```python
# module1/__init__.pyi
def func() -> tuple[int, int]: ...

# main.py
import module1

_, b = module1.func()  # E0633: Attempting to unpack a non-sequence
```

A function whose body is only the `...` of a stub has no return statement, so astroid
infers the call as returning `None`, and the return type that the stub declares was not
used by this check.

`_check_unpacking` now uses the declared return type when the body of the called
function is nothing but `...` — the same condition `utils.is_function_body_ellipsis()`
uses to recognise stubs elsewhere in pylint. A value of a declared class is
instantiated, so that it is checked for iterability like any other inferred value.

The change is deliberately narrow:

- a call to a function that is not a stub keeps the previous behaviour, so unpacking
  `def f(): return None` is still reported;
- a stub whose annotation is a non-iterable, e.g. `def f() -> int: ...`, is still
  reported;
- an unannotated stub is still reported, since nothing declares its return type;
- an annotation that is an unresolved string (`-> "tuple[int, int]"`) keeps the previous
  behaviour rather than risking a false negative.

## How was it tested

A stub package and a module using it were added under `tests/regrtest_data`, following the
existing `pyi` test data, and `test_unpacking_from_pyi_stub` checks that unpacking a stub
returning a tuple emits nothing while unpacking a stub returning an `int` still emits
exactly one `unpacking-non-sequence`.

```
$ pytest tests/lint/unittest_lint.py -q -k pyi
4 passed, 66 deselected
$ pytest tests/lint/unittest_lint.py tests/checkers/unittest_variables.py -q
80 passed
$ pytest tests/ --ignore=tests/test_functional.py -q
1260 passed, 271 skipped, 5 xfailed
$ pytest tests/test_functional.py -q
903 passed, 36 skipped, 1 failed   # test_functional[unbalanced_tuple_unpacking], pre-existing on main
$ pytest tests/test_self.py -q
158 passed, 1 xfailed
```

Without the change to `variables.py`, the new test fails with the E0633 message on line 5
of the test data. `black`, `isort` and `ruff check` are clean on the changed files.

Closes #9354
