### PR TITLE
Fix unspecified-encoding for joined pathlib paths

### DIFF
--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -763,6 +763,12 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
     def visit_call(self, node: nodes.Call) -> None:
         """Visit a Call node."""
         self.check_deprecated_class_in_call(node)
+        if (
+            isinstance(node.func, nodes.Attribute)
+            and node.func.attrname in {"read_text", "write_text"}
+            and self._is_pathlib_expression(node.func.expr)
+        ):
+            self._check_open_call(node, "pathlib", node.func.attrname)
         for inferred in utils.infer_all(node.func):
             if isinstance(inferred, util.UninferableBase):
                 continue
@@ -928,6 +934,32 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             "datetime.time",
         }:
             self.add_message("boolean-datetime", node=node)
+
+    @staticmethod
+    def _is_pathlib_expression(node: nodes.NodeNG) -> bool:
+        if isinstance(node, nodes.BinOp) and node.op == "/":
+            return any(
+                inferred.qname() in {"pathlib.Path", "pathlib._local.Path"}
+                for inferred in utils.infer_all(node.left)
+                if not isinstance(inferred, util.UninferableBase)
+            )
+
+        if isinstance(node, nodes.Name):
+            try:
+                _, assignments = node.lookup(node.name)
+            except astroid.InferenceError:
+                return False
+            return any(
+                isinstance(assignment.parent, nodes.AnnAssign)
+                and any(
+                    inferred.qname() in {"pathlib.Path", "pathlib._local.Path"}
+                    for inferred in utils.infer_all(assignment.parent.annotation)
+                    if not isinstance(inferred, util.UninferableBase)
+                )
+                for assignment in assignments
+            )
+
+        return False
 
     def _check_open_call(
         self, node: nodes.Call, open_module: str, func_name: str

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -61,6 +61,9 @@ LOCALE_ENCODING = locale.getlocale()[1]
 Path(FILENAME).read_text(encoding=LOCALE_ENCODING)
 Path(FILENAME).read_text(encoding="utf8")
 Path(FILENAME).read_text("utf8")
+(Path("/") / "tmp").read_text()  # [unspecified-encoding]
+p: Path = Path("/") / "tmp"
+p.read_text()  # [unspecified-encoding]
 
 LOCALE_ENCODING = None
 Path(FILENAME).read_text()  # [unspecified-encoding]

--- a/tests/functional/u/unspecified_encoding_py38.txt
+++ b/tests/functional/u/unspecified_encoding_py38.txt
@@ -13,29 +13,31 @@ unspecified-encoding:41:0:41:37::Using open without explicitly specifying an enc
 unspecified-encoding:50:5:50:22::Using open without explicitly specifying an encoding:HIGH
 unspecified-encoding:53:5:53:37::Using open without explicitly specifying an encoding:HIGH
 unspecified-encoding:57:5:57:48::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:66:0:66:26::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:67:0:67:39::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:68:0:68:50::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:75:0:75:35::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:76:0:76:50::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:77:0:77:61::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:81:0:81:21::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:82:0:82:25::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:83:0:83:25::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:84:0:84:39::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:149:0:149:23::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:152:0:152:28::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:155:0:155:26::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:158:0:158:35::Using open without explicitly specifying an encoding:HIGH
-bad-open-mode:161:0:161:25::"""None"" is not a valid mode for open.":HIGH
-unspecified-encoding:161:0:161:25::Using open without explicitly specifying an encoding:HIGH
-bad-open-mode:164:0:164:19::"""2"" is not a valid mode for open.":HIGH
-unspecified-encoding:164:0:164:19::Using open without explicitly specifying an encoding:HIGH
-bad-open-mode:176:0:176:24::"""5"" is not a valid mode for open.":INFERENCE
-unspecified-encoding:176:0:176:24::Using open without explicitly specifying an encoding:HIGH
-bad-open-mode:177:0:177:27::"""5"" is not a valid mode for open.":INFERENCE
-unspecified-encoding:177:0:177:27::Using open without explicitly specifying an encoding:HIGH
-unspecified-encoding:180:5:180:29::Using open without explicitly specifying an encoding:INFERENCE
-unspecified-encoding:183:0:183:29::Using open without explicitly specifying an encoding:INFERENCE
-unspecified-encoding:186:0:186:44::Using open without explicitly specifying an encoding:INFERENCE
-unspecified-encoding:193:0:193:34::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:64:0:64:31::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:66:0:66:13::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:69:0:69:26::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:70:0:70:39::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:71:0:71:50::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:78:0:78:35::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:79:0:79:50::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:80:0:80:61::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:84:0:84:21::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:85:0:85:25::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:86:0:86:25::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:87:0:87:39::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:152:0:152:23::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:155:0:155:28::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:158:0:158:26::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:161:0:161:35::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:164:0:164:25::"""None"" is not a valid mode for open.":HIGH
+unspecified-encoding:164:0:164:25::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:167:0:167:19::"""2"" is not a valid mode for open.":HIGH
+unspecified-encoding:167:0:167:19::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:179:0:179:24::"""5"" is not a valid mode for open.":INFERENCE
+unspecified-encoding:179:0:179:24::Using open without explicitly specifying an encoding:HIGH
+bad-open-mode:180:0:180:27::"""5"" is not a valid mode for open.":INFERENCE
+unspecified-encoding:180:0:180:27::Using open without explicitly specifying an encoding:HIGH
+unspecified-encoding:183:5:183:29::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:186:0:186:29::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:189:0:189:44::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:196:0:196:34::Using open without explicitly specifying an encoding:INFERENCE


### PR DESCRIPTION
Closes #11202

## Description

The `unspecified-encoding` checker missed `Path(...) / "child"` expressions and variables annotated as `Path` because astroid cannot infer those receiver expressions. This reuses the existing pathlib encoding check when the receiver can be identified from the slash expression or annotation.

## Checks

- Functional `unspecified_encoding_py38` regression test
- `tests/checkers/unittest_stdlib.py`
- Ruff, Black, isort, mypy, Bandit, codespell, and `git diff --check`
- Full Requests-style local validation is not applicable; Pylint functional regression passes

The change was reviewed and tested by the submitting contributor; no bot co-author is included.