### PR TITLE
Use a parameter's default as the mode of an ``open`` call

### DIFF
--- a/doc/whatsnew/fragments/11415.false_negative
+++ b/doc/whatsnew/fragments/11415.false_negative
@@ -1,0 +1,6 @@
+Fix a false negative for ``unspecified-encoding`` and ``bad-open-mode`` when the
+mode of an ``open`` call is a parameter of the enclosing function that has a
+default value. The default is now used to check the call, as a literal mode
+would be. Calls with such a mode stopped being reported in pylint 4.0.8.
+
+Refs #11415

--- a/pylint/checkers/stdlib.py
+++ b/pylint/checkers/stdlib.py
@@ -554,6 +554,38 @@ def _check_mode_str(mode: Any) -> bool:
     return True
 
 
+def _infer_mode_arg(mode_arg: nodes.NodeNG) -> tuple[InferenceResult | None, bool]:
+    """Infer the mode argument of an ``open`` call.
+
+    Return the inferred node and whether it comes from a parameter default.
+    A mode that is a parameter of the enclosing function cannot be inferred from
+    the function body alone, but its default value is what the call uses unless
+    the caller overrides it, so fall back on that default before giving up.
+    """
+    inferred = utils.safe_infer(mode_arg)
+    if isinstance(inferred, util.UninferableBase):
+        # safe_infer hands back Uninferable itself when it is the only result.
+        inferred = None
+    if inferred is not None or not isinstance(mode_arg, nodes.Name):
+        return inferred, False
+    _, assignments = mode_arg.lookup(mode_arg.name)
+    if len(assignments) != 1:
+        return None, False
+    (parameter,) = assignments
+    if not isinstance(parameter, nodes.AssignName) or not isinstance(
+        parameter.parent, nodes.Arguments
+    ):
+        return None, False
+    try:
+        default = parameter.parent.default_value(mode_arg.name)
+    except astroid.NoDefault:
+        return None, False
+    inferred = utils.safe_infer(default)
+    if inferred is None or isinstance(inferred, util.UninferableBase):
+        return None, False
+    return inferred, True
+
+
 class StdlibChecker(DeprecatedMixin, BaseChecker):
     name = "stdlib"
 
@@ -949,8 +981,11 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
             if mode_arg:
                 confidence = INFERENCE
 
+        mode_from_default = False
         if mode_arg:
-            mode_arg = utils.safe_infer(mode_arg)
+            mode_arg, mode_from_default = _infer_mode_arg(mode_arg)
+            if mode_from_default:
+                confidence = INFERENCE
             if func_name in OPEN_FILES_MODE:
                 if not isinstance(mode_arg, nodes.Const):
                     return  # mode may be binary - don't guess
@@ -967,7 +1002,7 @@ class StdlibChecker(DeprecatedMixin, BaseChecker):
         if not mode_arg or (
             isinstance(mode_arg, nodes.Const) and "b" not in str(mode_arg.value)
         ):
-            confidence = HIGH
+            confidence = INFERENCE if mode_from_default else HIGH
             try:
                 if open_module in PATHLIB_MODULE:
                     match node.func.attrname:

--- a/tests/functional/b/bad_open_mode.py
+++ b/tests/functional/b/bad_open_mode.py
@@ -24,3 +24,8 @@ open(NAME, "Ut", encoding="utf-8")
 open(NAME, "Ubr")
 # Crashed with a TypeError on Python >= 3.14 (issue #11099)
 open(NAME, NotImplemented, encoding="utf-8")  # [bad-open-mode]
+
+
+def open_with_bad_default_mode(mode="rwx"):
+    """The default mode is what the call uses unless the caller overrides it."""
+    return open(NAME, mode, encoding="utf-8")  # [bad-open-mode]

--- a/tests/functional/b/bad_open_mode.txt
+++ b/tests/functional/b/bad_open_mode.txt
@@ -5,3 +5,4 @@ bad-open-mode:15:0:15:34::"""xw"" is not a valid mode for open.":HIGH
 bad-open-mode:21:0:21:34::"""Ua"" is not a valid mode for open.":HIGH
 bad-open-mode:22:0:22:36::"""Ur++"" is not a valid mode for open.":HIGH
 bad-open-mode:26:0:26:44::"""NotImplemented"" is not a valid mode for open.":HIGH
+bad-open-mode:31:11:31:45:open_with_bad_default_mode:"""rwx"" is not a valid mode for open.":INFERENCE

--- a/tests/functional/u/unspecified_encoding_py38.py
+++ b/tests/functional/u/unspecified_encoding_py38.py
@@ -203,3 +203,50 @@ def open_with_unknown_mode(mode):
     Path(FILENAME).open(mode)
     Path(FILENAME).open(mode=mode)
     open(FILENAME, mode, encoding=None)
+
+
+def open_with_text_default(mode="wt"):
+    """The default mode is text, so the call needs an encoding."""
+    return open(FILENAME, mode)  # [unspecified-encoding]
+
+
+def open_with_binary_default(mode="wb"):
+    """The default mode is binary, no encoding is involved."""
+    return open(FILENAME, mode)
+
+
+def open_with_keyword_only_default(*, mode="r"):
+    """Keyword-only parameters carry a default too."""
+    return open(FILENAME, mode=mode)  # [unspecified-encoding]
+
+
+def path_open_with_text_default(mode="w"):
+    """The same applies to the pathlib variant."""
+    return Path(FILENAME).open(mode)  # [unspecified-encoding]
+
+
+def open_with_text_default_and_encoding(mode="wt"):
+    """An explicit encoding satisfies the check."""
+    return open(FILENAME, mode, encoding="utf-8")
+
+
+def open_with_rebound_mode(mode="wt"):
+    """The parameter is rebound, its default no longer describes the mode."""
+    mode = mode.replace("t", "b")
+    return open(FILENAME, mode)
+
+
+def open_with_conditional_mode(binary, mode="wt"):
+    """The mode depends on a condition, so it stays unknown."""
+    if binary:
+        mode = "wb"
+    return open(FILENAME, mode)
+
+
+def make_opener(default_mode):
+    """A default that cannot be inferred tells nothing about the mode."""
+
+    def open_with_unknown_default(mode=default_mode):
+        return open(FILENAME, mode)
+
+    return open_with_unknown_default

--- a/tests/functional/u/unspecified_encoding_py38.txt
+++ b/tests/functional/u/unspecified_encoding_py38.txt
@@ -39,3 +39,6 @@ unspecified-encoding:180:5:180:29::Using open without explicitly specifying an e
 unspecified-encoding:183:0:183:29::Using open without explicitly specifying an encoding:INFERENCE
 unspecified-encoding:186:0:186:44::Using open without explicitly specifying an encoding:INFERENCE
 unspecified-encoding:193:0:193:34::Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:210:11:210:31:open_with_text_default:Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:220:11:220:36:open_with_keyword_only_default:Using open without explicitly specifying an encoding:INFERENCE
+unspecified-encoding:225:11:225:36:path_open_with_text_default:Using open without explicitly specifying an encoding:INFERENCE


### PR DESCRIPTION
## Type of Changes

|     | Type                   |
| --- | ---------------------- |
| ✓   | :bug: Bug fix          |

## Description

Since #11163 an `open` call whose mode cannot be inferred is no longer checked, so a wrapper taking the mode as a parameter is not reported when the mode might be binary. That also silenced the case where the parameter has a default:

```python
def save(path, mode="wt"):
    return open(path, mode)  # was reported before 4.0.8, silent since
```

Astroid does not infer a parameter from its default without a call context, so `safe_infer` returns nothing and the check gave up. The default is what the call uses unless the caller overrides it, so `_check_open_call` now falls back on it before giving up, with `INFERENCE` confidence. Both `unspecified-encoding` and `bad-open-mode` benefit. A parameter that is rebound in the body, that depends on a condition, or that has no default stays unknown and the call stays unreported, as #11163 intended.

Found while reviewing #11214, a duplicate of #11163 that has the same behavior.

The regression shipped in 4.0.8 (#11163 was backported), so this should be backported too.
